### PR TITLE
Allow secrets to be read from environment variables

### DIFF
--- a/backend/settings/config.go
+++ b/backend/settings/config.go
@@ -190,6 +190,25 @@ func loadConfigWithDefaults(configFile string) error {
 	if err != nil {
 		return fmt.Errorf("error unmarshaling YAML data: %v", err)
 	}
+
+	adminPassword, adminPassPresent := os.LookupEnv("FILEBROWSER_ADMIN_PASSWORD")
+	if adminPassPresent {
+		logger.Info("Using admin password from FILEBROWSER_ADMIN_PASSWORD environment variable")
+		Config.Auth.AdminPassword = adminPassword
+	}
+
+	recaptchaSecret, recaptchaSecretPresent := os.LookupEnv("FILEBROWSER_RECAPTCHA_SECRET")
+	if recaptchaSecretPresent {
+		logger.Info("Using recaptcha secret from FILEBROWSER_RECAPTCHA_SECRET environment variable")
+		Config.Auth.Recaptcha.Secret = recaptchaSecret
+	}
+
+	officeSecret, officeSecretPresent := os.LookupEnv("FILEBROWSER_ONLYOFFICE_SECRET")
+	if officeSecretPresent {
+		logger.Info("Using OnlyOffice secret from FILEBROWSER_ONLYOFFICE_SECRET environment variable")
+		Config.Integrations.OnlyOffice.Secret = officeSecret
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Description**

This adds a small amount of functionality to read secrets from environment vars if present for the admin password, recaptcha secret, and OnlyOffice secret. This makes it easier to provide secrets to the app in a more secure way when running using Kubernetes or similar tools.

**Additional Details**
I wasn't sure whether or not to add tests for this as there don't appear to be any other tests for configuration/settings. Do forgive me if I've made any silly mistakes; I have very little experience writing Go. I pushed a [package](https://github.com/aaronkyriesenbach/filebrowser/pkgs/container/filebrowser) to test this on my [fork](https://github.com/aaronkyriesenbach/filebrowser) and it seems to work as expected. Please let me know if other changes are desired/required. Thanks!