### PR TITLE
Change ubuntu-latest to ubuntu-22.04 for builds

### DIFF
--- a/.github/workflows/release_beta.yaml
+++ b/.github/workflows/release_beta.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   test_playwright:
     name: Test Playwright - regular
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
   create_release_tag:
     needs: [ test_playwright ]
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release_dev.yaml
+++ b/.github/workflows/release_dev.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   push_release_to_registry:
     name: Push release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release_stable.yaml
+++ b/.github/workflows/release_stable.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   test_playwright:
     name: Test Playwright
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
   create_release_tag:
     needs: [ test_playwright ]
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Build releases on an older environment to improve glibc compatibility of static binary releases.

**Description**
To fix #755. I'm not sure if this change should be extended to all workflows or just the releases workflows. I've only tested linux-amd64, not the other binaries.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.

**Additional Details**
I should mention that this would need to be updated when 22.04 gets EOL'd but hopefully by then, users would have moved to more current stable distros with newer glibc.

The only workflow failure I had was the Dockerhub uploads which I have not set up on my fork.