### PR TITLE
feat: postMessage navigation sync for iframe embedding

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -181,4 +181,17 @@ router.beforeResolve(async (to, from, next) => {
   next();
 });
 
+router.afterEach((to) => {
+  // Only postMessage if running in an iframe
+  if (window.self !== window.top) {
+    window.parent.postMessage(
+      {
+        type: "filebrowser:navigation",
+        url: to.fullPath,
+      },
+      "*"
+    );
+  }
+});
+
 export { router, router as default };


### PR DESCRIPTION
This PR adds a router.afterEach() hook that posts
{ type: "filebrowser:navigation", url }
to the parent window when embedded in an iframe, enabling parent applications to synchronize navigation state.

All tests seem to pass.
