### PR TITLE
Fix directories empty issue when disableIndexing is true

### DIFF
--- a/backend/indexing/indexingFiles.go
+++ b/backend/indexing/indexingFiles.go
@@ -24,6 +24,7 @@ var RealPathCache = cache.NewCache(48*time.Hour, 72*time.Hour)
 type actionConfig struct {
 	Quick     bool // whether to perform a quick scan (skip unchanged directories)
 	Recursive bool // whether to recursively index subdirectories
+	CheckSkip bool // whether to check indexing skip rules.
 }
 
 // NewactionConfig creates a new actionConfig with common presets
@@ -231,6 +232,7 @@ func (idx *Index) GetFsDirInfo(adjustedPath string) (*iteminfo.FileInfo, error) 
 	response, err = idx.GetDirInfo(dir, dirInfo, realPath, adjustedPath, combinedPath, &actionConfig{
 		Quick:     false,
 		Recursive: false,
+		CheckSkip: false,
 	})
 	if err != nil {
 		return nil, err
@@ -286,7 +288,7 @@ func (idx *Index) GetDirInfo(dirInfo *os.File, stat os.FileInfo, realPath, adjus
 				continue
 			}
 		}
-		if idx.shouldSkip(isDir, hidden, fullCombined, baseName) {
+		if config.CheckSkip && idx.shouldSkip(isDir, hidden, fullCombined, baseName) {
 			continue
 		}
 		itemInfo := &iteminfo.ItemInfo{

--- a/backend/indexing/indexingFiles.go
+++ b/backend/indexing/indexingFiles.go
@@ -232,7 +232,7 @@ func (idx *Index) GetFsDirInfo(adjustedPath string) (*iteminfo.FileInfo, error) 
 	response, err = idx.GetDirInfo(dir, dirInfo, realPath, adjustedPath, combinedPath, &actionConfig{
 		Quick:     false,
 		Recursive: false,
-		ForceCheck: false,
+		ForceCheck: true,
 	})
 	if err != nil {
 		return nil, err

--- a/backend/indexing/indexingFiles.go
+++ b/backend/indexing/indexingFiles.go
@@ -24,7 +24,7 @@ var RealPathCache = cache.NewCache(48*time.Hour, 72*time.Hour)
 type actionConfig struct {
 	Quick     bool // whether to perform a quick scan (skip unchanged directories)
 	Recursive bool // whether to recursively index subdirectories
-	CheckSkip bool // whether to check indexing skip rules.
+	ForceCheck bool // whether to check indexing skip rules.
 }
 
 // NewactionConfig creates a new actionConfig with common presets
@@ -232,7 +232,7 @@ func (idx *Index) GetFsDirInfo(adjustedPath string) (*iteminfo.FileInfo, error) 
 	response, err = idx.GetDirInfo(dir, dirInfo, realPath, adjustedPath, combinedPath, &actionConfig{
 		Quick:     false,
 		Recursive: false,
-		CheckSkip: false,
+		ForceCheck: false,
 	})
 	if err != nil {
 		return nil, err
@@ -288,7 +288,7 @@ func (idx *Index) GetDirInfo(dirInfo *os.File, stat os.FileInfo, realPath, adjus
 				continue
 			}
 		}
-		if config.CheckSkip && idx.shouldSkip(isDir, hidden, fullCombined, baseName) {
+		if !config.ForceCheck && idx.shouldSkip(isDir, hidden, fullCombined, baseName) {
 			continue
 		}
 		itemInfo := &iteminfo.ItemInfo{


### PR DESCRIPTION
**Description**
fixes #1248, repro steps:

0) After upgrading to v0.8.6
1) Add a source with `disableIndexing: true`
2) Run file browser


**Cause**
1) As part of change #1222  file `indexingFiles.go`, `checkSkip` parameter of method `GetDirInfo` is removed.
2) `idx.shouldSkip` always return `true` when `idx.Config.DisableIndexing` is `true`
3) `index.GetFsDirInfo(opts.Path)` is called from `FileInfoFaster` when `index.Config.DisableIndexing` is `true`.

The issue raises:
*Previous:* `index.GetFsDirInfo(opts.Path)` calls `GetDirInfo` with `checkSkip` as `false` so `GetDirInfo` will NOT skip file listing even when `shouldSkip` is `true`
*Now:* `GetDirInfo` will ALWAYS skip file listing when `shouldSkip` is `true`


**Fixes:**
Add `checkSkip` as a parameter to `index.GetFsDirInfo(opts.Path)` so it bahaves as before.

**Tests:**
Tested locally with a few scenarios.
