### PR TITLE
Feat: Enabled plyr video player to rotate when entering full screen

### DIFF
--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -175,6 +175,7 @@ export default {
     },
     mounted() {
         this.updateMedia();
+        this.hookEvents();
     },
     beforeUnmount() {
         if (this.toastTimeout) {
@@ -358,6 +359,31 @@ export default {
                 this.audioMetadata = null;
                 this.albumArtUrl = null;
             }
+        },
+        hookEvents() {
+            if (!this.useDefaultMediaPlayer && this.$refs.videoPlayer && this.$refs.videoPlayer.player) {
+                const player = this.$refs.videoPlayer.player;
+
+                // Attach handlers only if the screen.orientation API is available.
+                if (screen.orientation) {
+                    player.on('enterfullscreen', this.onFullscreenEnter);
+                    player.on('exitfullscreen', this.onFullscreenExit);
+                }
+            }
+        },
+        async onFullscreenEnter() {
+            // Allow free rotation when video enters full screen mode. This works even if the device's orientation is currently locked.
+            try {
+                await screen.orientation.lock('any');
+            } catch (error) {
+                // The NotSupportedError is thrown for non-mobile browsers and there seems to be no way to pre-check if it is supported.
+                // -> Swallow NotSupportedError but let other errors be thrown.
+                if (error.name !== 'NotSupportedError')
+                    throw error;
+            }
+        },
+        onFullscreenExit() {
+            screen.orientation.unlock();
         },
     },
     expose: ['toggleLoop'],


### PR DESCRIPTION
**Description**
Feat: Enabled plyr video player to rotate when entering full screen
- this makes it much more convenient to watch landscape videos when device is locked in portrait mode (or vice versa)
- it uses the device's rotation sensor
- it gets activated when the plyr video player enters full screen mode
- it works when the device's rotation is currently locked

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.

**Additional Details**
