### PR TITLE
Fastfoward and rewind when playing media

### DIFF
--- a/frontend/src/components/files/nextPrevious.vue
+++ b/frontend/src/components/files/nextPrevious.vue
@@ -311,10 +311,6 @@ export default {
         return;
       }
 
-     if (!this.useDefaultMediaPlayer && this.$refs.videoPlayer && this.$refs.videoPlayer.player) {
-        return;
-      }
-
      // Check if any media element is currently playing
      const mediaElements = document.querySelectorAll('audio, video');
      let mediaActive = false;

--- a/frontend/src/components/files/nextPrevious.vue
+++ b/frontend/src/components/files/nextPrevious.vue
@@ -317,8 +317,7 @@ export default {
   
      mediaElements.forEach(media => {
        if (!media.paused || 
-           document.activeElement === media  || 
-           document.activeElement.closest('.plyr__controls')) {
+           document.activeElement === media) {
          mediaActive = true;
        }
      });

--- a/frontend/src/components/files/nextPrevious.vue
+++ b/frontend/src/components/files/nextPrevious.vue
@@ -311,6 +311,27 @@ export default {
         return;
       }
 
+     if (!this.useDefaultMediaPlayer && this.$refs.videoPlayer && this.$refs.videoPlayer.player) {
+        return;
+      }
+
+     // Check if any media element is currently playing
+     const mediaElements = document.querySelectorAll('audio, video');
+     let mediaActive = false;
+  
+     mediaElements.forEach(media => {
+       if (!media.paused || 
+           document.activeElement === media  || 
+           document.activeElement.closest('.plyr__controls')) {
+         mediaActive = true;
+       }
+     });
+  
+     // If media is playing don't handle arrow keys and let use fastfoward and rewind of the player
+     if (mediaActive) {
+       return;
+     }
+
       const { key } = event;
 
       switch (key) {


### PR DESCRIPTION
**Description**

Something similar happened before (#546), and well, with the recent implementation of the universal arrows for change preview between files, I lost the ability to use my arrow keys for navigate on media.

---

Now when you are **playing** media, you can use the arrows for fastfoward or rewind; if the media is **paused** and you click the arrows, the preview will change to the next/previous file.

This works on both, the native player of the browser, and plyr.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**
A video just in case


https://github.com/user-attachments/assets/d5186129-a38d-41e2-9931-67ee42963fcf


