### PR TITLE
fix light and dark mode on the player and editor nextPrevious

### DIFF
--- a/frontend/src/components/files/nextPrevious.vue
+++ b/frontend/src/components/files/nextPrevious.vue
@@ -327,6 +327,12 @@ export default {
        return;
      }
 
+    // Don't handle arrow keys when playing media or when editing a file on the editor
+    const blockedViews = ['audio', 'video', 'editor'];
+    if (blockedViews.includes(this.currentView)) {
+      return;
+    }
+
       const { key } = event;
 
       switch (key) {

--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -39,7 +39,7 @@
 
             </div>
 
-            <div class="audio-controls-container" :class="{ 'dark-mode': darkMode }">
+            <div class="audio-controls-container" :class="{ 'dark-mode': darkMode, 'light-mode': !darkMode }">
                 <vue-plyr ref="audioPlayer" :options="plyrOptions">
                     <audio :src="raw" :autoplay="autoPlayEnabled" @play="handlePlay"></audio>
                 </vue-plyr>
@@ -464,12 +464,17 @@ button:hover,
     flex-direction: row;
     gap: 8px;
     background-color: transparent;
-    color: black;
+    color: white;
 }
 
 .audio-controls-container.dark-mode .plyr .plyr__controls {
     color: white;
 }
+
+.audio-controls-container.light-mode .plyr .plyr__controls {
+    color: black;
+}
+
 .plyr .plyr__controls__items {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
**Description**
fix light and dark mode on the player and avoid change of preview with the arrow keys if editing on the editor
According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.
