### PR TITLE
Fix/loop key

### DIFF
--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -189,8 +189,8 @@ func extractAudioMetadata(item *iteminfo.ExtendedFileInfo) error {
 
 	// Extract album art and encode as base64 with strict size limits
 	if picture := m.Picture(); picture != nil && picture.Data != nil {
-		// More aggressive size limit to prevent memory issues (max 2MB)
-		if len(picture.Data) <= 2*1024*1024 {
+		// More aggressive size limit to prevent memory issues (max 5MB)
+		if len(picture.Data) <= 5*1024*1024 {
 			item.AudioMeta.AlbumArt = base64.StdEncoding.EncodeToString(picture.Data)
 		} else {
 			logger.Debugf("Skipping album art for %s: too large (%d bytes)", item.RealPath, len(picture.Data))

--- a/backend/indexing/iteminfo/conditions.go
+++ b/backend/indexing/iteminfo/conditions.go
@@ -334,6 +334,7 @@ func (i *ItemInfo) DetectType(realPath string, saveContent bool) {
 
 // hasAlbumArtLowLevel efficiently checks for album art in audio files.
 // It handles ID3v2 tags (MP3) and Vorbis comments (FLAC, OGG) with low-level parsing.
+// Uses a hybrid approach: small initial read for fast exit, then targeted reads based on format.
 func hasAlbumArtLowLevel(filePath string, extension string) (bool, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -341,43 +342,163 @@ func hasAlbumArtLowLevel(filePath string, extension string) (bool, error) {
 	}
 	defer file.Close()
 
-	// Same buffer for all the audio formats, will read the first 64KB.
-    buffer := make([]byte, 65536) // 64KB
-    n, err := file.Read(buffer)
-    if err != nil && err != io.EOF {
-        return false, err
-    }
+	// Step 1: Perform a small initial read to identify file type signature (magic bytes)
+	initialBuffer := make([]byte, 10)
+	n, err := io.ReadFull(file, initialBuffer)
+	if err != nil {
+		// File is too small or can't be read - no metadata possible
+		return false, nil
+	}
 
-    data := buffer[:n]
-
-    hasAlbumArtM4A := hasAlbumArtM4A(data)
-
-	// Handle different audio formats
+	// Step 2: Fast Path Exit & Format-Specific Handling
 	switch extension {
 	case ".mp3":
-		return hasAlbumArtMP3(data)
-	case ".flac", ".ogg", ".opus":
-		return hasAlbumArtVorbis(data), nil
+		// Check for ID3 signature in first 3 bytes
+		if string(initialBuffer[0:3]) != "ID3" {
+			// No ID3 tag, fast exit without reading more
+			return false, nil
+		}
+		// ID3 tag found - calculate exact tag size and read only what's needed
+		return hasAlbumArtMP3Optimized(file, initialBuffer)
+
+	case ".flac":
+		// Check for FLAC signature
+		if n >= 4 && string(initialBuffer[0:4]) != "fLaC" {
+			// Not a valid FLAC file, fast exit
+			return false, nil
+		}
+		// Valid FLAC - read larger chunk for metadata blocks
+		return hasAlbumArtFLACOptimized(file, initialBuffer)
+
+	case ".ogg", ".opus":
+		// Check for OGG signature
+		if n >= 4 && string(initialBuffer[0:4]) != "OggS" {
+			// Not a valid OGG file, fast exit
+			return false, nil
+		}
+		// Valid OGG/Opus - read larger chunk for vorbis comments
+		return hasAlbumArtOGGOptimized(file, initialBuffer)
+
 	case ".m4a", ".mp4":
-		// For M4A check signature or covr atom
-		return hasAlbumArtM4A || bytes.Contains(data, []byte("covr")), nil
+		// M4A/MP4 files need larger read for atom structure
+		// Reset to beginning and read sufficient data
+		file.Seek(0, 0)
+		buffer := make([]byte, 65536) // 64KB
+		n, err := file.Read(buffer)
+		if err != nil && err != io.EOF {
+			return false, err
+		}
+		return hasAlbumArtM4A(buffer[:n]), nil
+
 	default:
-		// For other formats, return false (no album art detection)
+		// Unknown format
 		return false, nil
 	}
 }
 
+// hasAlbumArtMP3Optimized checks for APIC/PIC frames with minimal I/O
+// Takes the 10-byte header already read and reads only the necessary tag data
+func hasAlbumArtMP3Optimized(file *os.File, header []byte) (bool, error) {
+	// Header already checked for "ID3" signature in caller
+
+	// Determine ID3v2 version for proper frame ID detection
+	version := header[3]
+	var pictureFrameID string
+	var frameHeaderSize int
+
+	switch version {
+	case 2:
+		pictureFrameID = "PIC" // ID3v2.2 uses 3-byte frame IDs
+		frameHeaderSize = 6
+	case 3, 4:
+		pictureFrameID = "APIC" // ID3v2.3/2.4 use 4-byte frame IDs
+		frameHeaderSize = 10
+	default:
+		return false, nil // Unsupported version
+	}
+
+	// Decode synchsafe tag size from header
+	tagSize := (int(header[6]) << 21) | (int(header[7]) << 14) | (int(header[8]) << 7) | int(header[9])
+
+	// Limit reading to reasonable size for performance (32KB max)
+	maxReadSize := 32768
+	readSize := tagSize
+	if readSize > maxReadSize {
+		readSize = maxReadSize
+	}
+	if readSize <= 0 {
+		return false, nil
+	}
+
+	// Read only the tag data needed
+	tagData := make([]byte, readSize)
+	n, err := io.ReadFull(file, tagData)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return false, nil
+	}
+	tagData = tagData[:n]
+
+	position := 0
+	frameIDLen := len(pictureFrameID)
+
+	// Loop through frames looking for picture frame
+	for position+frameHeaderSize <= len(tagData) {
+		// Check if we've hit padding (null bytes)
+		if tagData[position] == 0 {
+			break
+		}
+
+		// Extract frame ID
+		if position+frameIDLen > len(tagData) {
+			break
+		}
+		frameID := string(tagData[position : position+frameIDLen])
+
+		// Found picture frame!
+		if frameID == pictureFrameID {
+			return true, nil
+		}
+
+		// Skip to next frame
+		var frameSize int
+		if version == 2 {
+			// ID3v2.2: 3-byte size
+			if position+6 > len(tagData) {
+				break
+			}
+			frameSize = int(tagData[position+3])<<16 | int(tagData[position+4])<<8 | int(tagData[position+5])
+			position += 6 + frameSize
+		} else {
+			// ID3v2.3/2.4: 4-byte size
+			if position+10 > len(tagData) {
+				break
+			}
+			frameSize = int(tagData[position+4])<<24 | int(tagData[position+5])<<16 |
+				int(tagData[position+6])<<8 | int(tagData[position+7])
+			position += 10 + frameSize
+		}
+
+		// Safety check to prevent infinite loops
+		if frameSize <= 0 || position >= len(tagData) {
+			break
+		}
+	}
+
+	return false, nil
+}
+
 // hasAlbumArtMP3 checks for APIC/PIC frames in ID3v2 tags with optimized parsing
+// Legacy function kept for compatibility - operates on pre-loaded byte slice
 func hasAlbumArtMP3(data []byte) (bool, error) {
 	// Read 10-byte ID3v2 header
 	if len(data) < 10 {
-        return false, nil
-    }
+		return false, nil
+	}
 
 	// Check for "ID3" identifier
 	if string(data[0:3]) != "ID3" {
-        return false, nil
-    }
+		return false, nil
+	}
 
 	// Determine ID3v2 version for proper frame ID detection
 	version := data[3]
@@ -456,39 +577,132 @@ func hasAlbumArtMP3(data []byte) (bool, error) {
 	return false, nil
 }
 
+// hasAlbumArtFLACOptimized checks for PICTURE metadata block (type 6) in FLAC files
+func hasAlbumArtFLACOptimized(file *os.File, initialBuffer []byte) (bool, error) {
+	// Read a reasonable amount for FLAC metadata (typically in first 64KB)
+	buffer := make([]byte, 65526) // 64KB - 10 bytes already read
+	n, err := file.Read(buffer)
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+
+	// Combine initial buffer with the rest
+	fullData := append(initialBuffer, buffer[:n]...)
+
+	pos := 4 // Skip "fLaC" header
+
+	for pos < len(fullData)-4 {
+		// Read metadata block header (4 bytes total)
+		blockHeader := fullData[pos]
+		blockType := blockHeader & 0x7F // bits 0-6
+		isLast := blockHeader&0x80 != 0 // bit 7
+
+		// Found picture block!
+		if blockType == 6 { // PICTURE block type
+			return true, nil
+		}
+
+		// Get block size (next 3 bytes, big-endian)
+		if pos+4 > len(fullData) {
+			break
+		}
+		blockSize := int(fullData[pos+1])<<16 | int(fullData[pos+2])<<8 | int(fullData[pos+3])
+
+		// Move to next block
+		pos += 4 + blockSize
+
+		// Stop if this was the last block or we've exceeded buffer
+		if isLast || pos >= len(fullData) {
+			break
+		}
+	}
+
+	return false, nil
+}
+
+// hasAlbumArtOGGOptimized checks for METADATA_BLOCK_PICTURE in OGG Vorbis comments
+func hasAlbumArtOGGOptimized(file *os.File, initialBuffer []byte) (bool, error) {
+	// Read a reasonable amount for OGG metadata
+	buffer := make([]byte, 65526) // 64KB - 10 bytes already read
+	n, err := file.Read(buffer)
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+
+	// Combine initial buffer with the rest
+	fullData := append(initialBuffer, buffer[:n]...)
+
+	// Look for Vorbis comment patterns
+	vorbisPrefix := []byte("\x03vorbis")
+	opusPrefix := []byte("OpusTags")
+
+	// Search for either Vorbis or Opus tags
+	for i := 0; i < len(fullData)-8; i++ {
+		if i+len(vorbisPrefix) < len(fullData) && bytes.Equal(fullData[i:i+len(vorbisPrefix)], vorbisPrefix) {
+			// Found Vorbis comment block, look for METADATA_BLOCK_PICTURE
+			return searchForPictureInVorbisComment(fullData[i+len(vorbisPrefix):])
+		}
+		if i+len(opusPrefix) < len(fullData) && bytes.Equal(fullData[i:i+len(opusPrefix)], opusPrefix) {
+			// Found Opus tags block, look for METADATA_BLOCK_PICTURE
+			return searchForPictureInVorbisComment(fullData[i+len(opusPrefix):])
+		}
+	}
+
+	return false, nil
+}
+
+// searchForPictureInVorbisComment looks for METADATA_BLOCK_PICTURE field in Vorbis comments
+func searchForPictureInVorbisComment(buffer []byte) (bool, error) {
+	// Convert to string and look for the METADATA_BLOCK_PICTURE field
+	content := string(buffer)
+
+	// Look for the exact field name used in Vorbis comments
+	if strings.Contains(content, "METADATA_BLOCK_PICTURE=") {
+		return true, nil
+	}
+
+	// Some files might use alternative field names
+	if strings.Contains(content, "COVERART=") || strings.Contains(content, "COVER_ART=") {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // hasAlbumArtVorbis checks for album art in FLAC, OGG, and OPUS files
+// Legacy function kept for compatibility - operates on pre-loaded byte slice
 func hasAlbumArtVorbis(data []byte) bool {
-    // Check for FLAC signature and picture block
-    if len(data) >= 4 && string(data[0:4]) == "fLaC" {
-        return bytes.Contains(data, []byte("\x06")) // Picture block type
-    }
+	// Check for FLAC signature and picture block
+	if len(data) >= 4 && string(data[0:4]) == "fLaC" {
+		return bytes.Contains(data, []byte("\x06")) // Picture block type
+	}
 
-    // Check for OGG signature and cover art (opus included)
-    if len(data) >= 4 && string(data[0:4]) == "OggS" {
-        return bytes.Contains(data, []byte("METADATA_BLOCK_PICTURE")) ||
-               bytes.Contains(data, []byte("COVERART")) ||
-               bytes.Contains(data, []byte("COVER_ART"))
-    }
+	// Check for OGG signature and cover art (opus included)
+	if len(data) >= 4 && string(data[0:4]) == "OggS" {
+		return bytes.Contains(data, []byte("METADATA_BLOCK_PICTURE")) ||
+			bytes.Contains(data, []byte("COVERART")) ||
+			bytes.Contains(data, []byte("COVER_ART"))
+	}
 
-    return false
+	return false
 }
 
 // hasAlbumArtM4A checks for embedded artwork in M4A/MP4 files
 func hasAlbumArtM4A(data []byte) bool {
-    signatures := [][]byte{
-        []byte("\xFF\xD8\xFF"),            // JPEG
-        []byte("\x89PNG\x0D\x0A\x1A\x0A"), // PNG
-        []byte("GIF8"),                    // GIF
-        []byte("BM"),                      // BMP
-        []byte("\x00\x00\x00\x1C\x66\x74\x79\x70"), // MP4/M4A start
-    }
+	signatures := [][]byte{
+		[]byte("\xFF\xD8\xFF"),                     // JPEG
+		[]byte("\x89PNG\x0D\x0A\x1A\x0A"),          // PNG
+		[]byte("GIF8"),                             // GIF
+		[]byte("BM"),                               // BMP
+		[]byte("\x00\x00\x00\x1C\x66\x74\x79\x70"), // MP4/M4A start
+	}
 
-    for _, sig := range signatures {
-        if bytes.Contains(data, sig) {
-            return true
-        }
-    }
-    return false
+	for _, sig := range signatures {
+		if bytes.Contains(data, sig) {
+			return true
+		}
+	}
+	return false
 }
 
 func HasAlbumArt(filePath string, extension string) bool {

--- a/backend/indexing/iteminfo/conditions.go
+++ b/backend/indexing/iteminfo/conditions.go
@@ -385,7 +385,7 @@ func hasAlbumArtLowLevel(filePath string, extension string) (bool, error) {
 		if _, err := file.Seek(0, 0); err != nil {
 			return false, err
 		}
-		buffer := make([]byte, 65536) // 64KB
+		buffer := make([]byte, 12288) // 12KB seems to be enought
 		n, err := file.Read(buffer)
 		if err != nil && err != io.EOF {
 			return false, err
@@ -492,7 +492,7 @@ func hasAlbumArtMP3Optimized(file *os.File, header []byte) (bool, error) {
 // hasAlbumArtFLACOptimized checks for PICTURE metadata block (type 6) in FLAC files
 func hasAlbumArtFLACOptimized(file *os.File, initialBuffer []byte) (bool, error) {
 	// Read a reasonable amount for FLAC metadata (typically in first 64KB)
-	buffer := make([]byte, 65526) // 64KB - 10 bytes already read
+	buffer := make([]byte, 32768) // 32KB - 10 bytes already read
 	n, err := file.Read(buffer)
 	if err != nil && err != io.EOF {
 		return false, err
@@ -535,7 +535,7 @@ func hasAlbumArtFLACOptimized(file *os.File, initialBuffer []byte) (bool, error)
 // hasAlbumArtOGGOptimized checks for METADATA_BLOCK_PICTURE in OGG Vorbis comments
 func hasAlbumArtOGGOptimized(file *os.File, initialBuffer []byte) (bool, error) {
 	// Read a reasonable amount for OGG metadata
-	buffer := make([]byte, 65526) // 64KB - 10 bytes already read
+	buffer := make([]byte, 32768) // 32KB - 10 bytes already read
 	n, err := file.Read(buffer)
 	if err != nil && err != io.EOF {
 		return false, err

--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -130,7 +130,7 @@ export default {
             albumArtSize: 25, // Default size in em
             isHovering: false, // Track hover state
             // Playback settings
-            playbackMode: 'loop-single', // 'single', 'sequential', 'shuffle', 'loop-single', 'loop-all'
+            playbackMode: 'single', // 'single', 'sequential', 'shuffle', 'loop-single', 'loop-all'
             playbackQueue: [],
             currentQueueIndex: 0,
             isNavigating: false,


### PR DESCRIPTION
**Description**
I fixed the issue of the loop key (the letter "L").
Now when you click the the letter "L" instead of use the default loop of plyr, uses the custom loop from "Loop single" and syncs with the UI.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**
