### PR TITLE
Fix "L" Loop key on plyr

### DIFF
--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -151,7 +151,7 @@ export default {
                     "settings",
                     "fullscreen",
                 ],
-                settings: ["quality", "speed", "loop", "playback"],
+                settings: ["quality", "speed", "playback"],
                 speed: {
                     selected: 1,
                     options: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2],
@@ -220,6 +220,16 @@ export default {
                 }
             });
         },
+        playbackMode: {
+            handler(newMode, oldMode) {
+                if (newMode !== oldMode) {
+                    this.$nextTick(() => {
+                        this.ensurePlaybackModeApplied();
+                    });
+                }
+            },
+            immediate: true
+        }
     },
     computed: {
         darkMode() {
@@ -237,6 +247,7 @@ export default {
 
         this.updateMedia();
         this.hookEvents();
+        document.addEventListener('keydown', this.handleKeydown);
     },
     beforeUnmount() {
         if (this.toastTimeout) {
@@ -248,38 +259,104 @@ export default {
             } catch (e) {Error;}
             this.albumArt = null;
         }
+        document.removeEventListener('keydown', this.handleKeydown);
     },
     methods: {
         handlePlay() {
             this.$emit('play');
         },
-        toggleLoop() {
-            if (this.useDefaultMediaPlayer) {
-                // Handle default HTML5 players
-                let playerRef =
-                    this.previewType === "video"
-                        ? this.$refs.defaultVideoPlayer
+        ensurePlaybackModeApplied() {
+            if (this.useDefaultMediaPlayer) return;
+            
+            const playerRef = this.previewType === 'video' 
+                ? this.$refs.videoPlayer 
+                : this.$refs.audioPlayer;
+                
+            if (!playerRef || !playerRef.player) return;
+            
+            const player = playerRef.player;
+            
+            // Try multiple times to apply the settings
+            const tryApplySettings = (attempt = 0) => {
+                if (attempt > 10) {
+                    console.log('Failed to apply playback mode after 10 attempts');
+                    return;
+                }
+                
+                try {
+                    const playbackBtn = player.elements.settings?.buttons?.playback;
+                    if (playbackBtn) {
+                        // Settings elements exist - apply the mode
+                        this.applyCustomPlaybackSettings(player);
+                        console.log('Playback mode applied to UI on attempt', attempt);
+                    } else {
+                        // Settings don't exist yet - try again
+                        setTimeout(() => tryApplySettings(attempt + 1), 100);
+                    }
+                } catch (error) {
+                    // Try again on error
+                    setTimeout(() => tryApplySettings(attempt + 1), 100);
+                }
+            };
+            
+            // Start trying
+            tryApplySettings();
+        },
+        focusPlayer() {
+            this.$nextTick(() => {
+                if (this.useDefaultMediaPlayer) {
+                    // Focus default HTML5 players
+                    const playerElement = this.previewType === 'video' 
+                        ? this.$refs.defaultVideoPlayer 
                         : this.$refs.defaultAudioPlayer;
-
-                if (playerRef) {
-                    this.loopEnabled = !this.loopEnabled;
-                    playerRef.loop = this.loopEnabled;
-                    this.showToast();
-                }
-            } else {
-                // Handle vue-plyr players
-                let playerRef =
-                    this.previewType === "video"
-                        ? this.$refs.videoPlayer
+                    
+                    if (playerElement) {
+                        playerElement.focus();
+                        console.log('Focused default media player');
+                    }
+                } else {
+                    // Focus Plyr players
+                    const playerRef = this.previewType === 'video' 
+                        ? this.$refs.videoPlayer 
                         : this.$refs.audioPlayer;
-
-                if (playerRef && playerRef.player) {
-                    // Toggle loop mode
-                    this.loopEnabled = !this.loopEnabled;
-                    playerRef.player.loop = this.loopEnabled;
-                    this.showToast();
+                        
+                    if (playerRef && playerRef.player && playerRef.player.elements.container) {
+                        const container = playerRef.player.elements.container;
+                        container.focus();
+                        console.log('Focused Plyr player container');
+                        
+                        // Also try to focus the progress bar specifically
+                        const progressContainer = container.querySelector('.plyr__progress__container');
+                        if (progressContainer) {
+                            progressContainer.focus();
+                            console.log('Focused progress bar');
+                        }
+                    }
                 }
+            });
+        },
+        toggleLoop() {
+            // Always use our custom loop instead of Plyr's default
+            this.loopEnabled = !this.loopEnabled;
+            
+            // Update playback mode based on custom loop state
+            if (this.loopEnabled) {
+                this.playbackMode = 'loop-single';
+                console.log('Custom Loop Single File enabled');
+            } else {
+                this.playbackMode = 'single';
+                console.log('Custom Loop Single File disabled');
             }
+            
+            // Update playback queue to reflect the new mode
+            this.setupPlaybackQueue();
+            this.showToast();
+            
+            // Ensure player is focused and UI is updated
+            this.focusPlayer();
+            this.$nextTick(() => {
+                this.ensurePlaybackModeApplied();
+            });
         },
         showToast() {
             if (this.toastTimeout) {
@@ -349,6 +426,11 @@ export default {
             if (this.previewType === "audio") {
                 this.loadAudioMetadata();
             }
+            this.$nextTick(() => {
+                setTimeout(() => {
+                    this.focusPlayer();
+                }, 300);
+            });
         },
         // Album art hover and scroll handlers
         onAlbumArtHover() {
@@ -442,6 +524,23 @@ export default {
 
                 // Set up custom playback settings
                 this.setupCustomPlaybackSettings(player);
+                player.on('controlsshown', () => {
+                    this.$nextTick(() => {
+                        this.ensurePlaybackModeApplied();
+                    });
+                });
+                player.on('play', () => {
+                    console.log('Video playing - focusing player');
+                    this.focusPlayer();
+                });
+
+                player.on('ready', () => {
+                    console.log('Video player ready - focusing player');
+                    this.focusPlayer();
+                });
+
+                // Set up custom playback settings
+                this.setupCustomPlaybackSettings(player);
             }
 
             // Also debug audio player
@@ -457,6 +556,23 @@ export default {
 
                 // Set up custom playback settings
                 this.setupCustomPlaybackSettings(player);
+                player.on('controlsshown', () => {
+                    this.$nextTick(() => {
+                        this.ensurePlaybackModeApplied();
+                    });
+                });
+                player.on('play', () => {
+                    console.log('Audio playing - focusing player');
+                    this.focusPlayer();
+                });
+
+                player.on('ready', () => {
+                    console.log('Audio player ready - focusing player');
+                    this.focusPlayer();
+                });
+
+                // Set up custom playback settings
+                this.setupCustomPlaybackSettings(player);
             }
 
             // Handle default HTML5 players
@@ -466,9 +582,15 @@ export default {
 
                 if (videoElement) {
                     videoElement.addEventListener('ended', this.handleMediaEnd);
+                    videoElement.addEventListener('play', () => {
+                        this.focusPlayer();
+                    });
                 }
                 if (audioElement) {
                     audioElement.addEventListener('ended', this.handleMediaEnd);
+                    audioElement.addEventListener('play', () => {
+                        this.focusPlayer();
+                    });
                 }
             }
         },
@@ -727,6 +849,9 @@ export default {
             // Separated so it can be called both on 'ready' event and after source changes
             console.log('Applying custom playback settings, current mode:', this.playbackMode);
 
+            // Sync loopEnabled with playbackMode
+            this.loopEnabled = (this.playbackMode === 'loop-single');
+            
             try {
                 // Access the playback button and panel
                 const playbackBtn = player.elements.settings.buttons.playback;


### PR DESCRIPTION
**Description**
Yeah, now is fine, sorry for the two closed PR of before.

I fixed the issue of the loop key (when pressing the letter "L").
Now when you click the the letter "L" instead of use the default loop of plyr, uses the custom loop from "Loop single" and syncs with the UI.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**
