### PR TITLE
Fix button disabled on move/copy prompt

### DIFF
--- a/frontend/src/components/prompts/MoveCopy.vue
+++ b/frontend/src/components/prompts/MoveCopy.vue
@@ -42,7 +42,7 @@ import buttons from "@/utils/buttons";
 import * as upload from "@/utils/upload";
 import { url } from "@/utils";
 import { notify } from "@/notify";
-import { removeLastDir, goToItem } from "@/utils/url";
+import { goToItem } from "@/utils/url";
 
 export default {
   name: "move-copy",
@@ -83,9 +83,16 @@ export default {
       if (!itemPath) {
         return false; // If itemPath is undefined, we can't check containment
       }
-      
-      const parentDir = (this.operation === "copy" ? url.removeLastDir(itemPath) : removeLastDir(itemPath)) + "/";
-      return this.destPath == parentDir || this.destPath.startsWith(itemPath);
+      // For move, prevent moving to the same directory, but for copy allow it.
+      if (this.operation === "move") {
+        const parentDir = url.removeLastDir(itemPath) + "/";
+        // Only disable if moving to the exact same directory
+        if (this.destPath === parentDir) {
+          return true;
+        }
+      }
+      // Prevent move/copy into itself or subdirectories (into itself too)
+      return this.destPath.startsWith(itemPath + "/") || this.destPath === itemPath;
     },
     user() {
       return state.user;


### PR DESCRIPTION
**Description**
Fix button disabled on move/copy prompt.
This enables the button of copy when you are copying a file into itself (which will throws the warning for replace or rename as before).

This will fix #1328 

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.