### PR TITLE
fix: Check user permission in delete handler

### DIFF
--- a/backend/http/resource.go
+++ b/backend/http/resource.go
@@ -143,6 +143,10 @@ func resourceGetHandler(w http.ResponseWriter, r *http.Request, d *requestContex
 // @Failure 500 {object} map[string]string "Internal server error"
 // @Router /api/resources [delete]
 func resourceDeleteHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
+	if !d.user.Permissions.Modify {
+		return http.StatusForbidden, fmt.Errorf("user is not allowed to delete")
+	}
+
 	// TODO source := r.URL.Query().Get("source")
 	encodedPath := r.URL.Query().Get("path")
 	source := r.URL.Query().Get("source")


### PR DESCRIPTION
**Description**

This PR updates the `resourceDeleteHandler` to ensure that a user must have the *Modify* permission before deleting a file.

I discovered an issue where a user without the required permission was still able to delete files under certain conditions.

Steps to Reproduce:
- Upload a file as a user with Modify permission.
- Remove the user's Modify permission while keeping the browser session open.
- From the previously opened browser session, delete the file.
- The file is deleted even though the user no longer has the Modify permission.

Checklist:

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.
