### PR TITLE
also show prompt when navigating away for prevent unsaved changes on editor

### DIFF
--- a/frontend/src/views/files/MarkdownViewer.vue
+++ b/frontend/src/views/files/MarkdownViewer.vue
@@ -16,6 +16,7 @@ export default {
   data() {
     return {
       content: "",
+      keyboardHandler: null,
     };
   },
   methods: {
@@ -207,7 +208,23 @@ export default {
       // Set initial content. The `watch` will trigger the first highlight.
       const fileContent = state.req.content == "empty-file-x6OlSil" ? "" : state.req.content || "";
       this.content = fileContent;
-    }
+    },
+    setupKeyboardShortcuts() {
+      this.keyboardHandler = (event) => {
+        const { key, ctrlKey, metaKey } = event;
+        // Ctrl+E for quick edit
+        if ((ctrlKey || metaKey) && key.toLowerCase() === 'e') {
+          event.preventDefault();
+          this.quickEdit();
+        }
+      };
+      window.addEventListener('keydown', this.keyboardHandler);
+    },
+    quickEdit() {
+      if (window.location.hash !== '#edit') {
+        window.location.hash = "#edit";
+      }
+    },
   },
   watch: {
     // We now watch the `content` property.
@@ -249,12 +266,16 @@ export default {
   },
   mounted() {
     this.reinit();
+    this.setupKeyboardShortcuts();
   },
   unmounted() {
     // Cleanup logic is correct and remains.
     const link = document.getElementById('highlight-theme-link');
     if (link) {
       document.head.removeChild(link);
+    }
+    if (this.keyboardHandler) {
+      window.removeEventListener('keydown', this.keyboardHandler);
     }
   }
 };


### PR DESCRIPTION
**Description**
Hi! I noticed that the prompt on the editor is not working at all, so I added a "Navigation Guard" that checks if the user try to navigate away with the browser itself, so for example if I click the back button of my mouse (or one of the browser) the prompt will appear instead of just leave the editor with unsaved changes.

If the user tries to close the browser or the tab with unsaved changes, will be prompted with the default prompt of the browser.

I also added a shortcut (CTRL + E) when on the markdown viewer for make edits more quickly.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**

https://github.com/user-attachments/assets/7f2b1a27-5a55-491a-b3c7-2ff338c5e0c7
