### PR TITLE
Add marquee selection to listing view

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -19,6 +19,7 @@
     :data-dir="isDir"
     :data-type="type"
     :data-name="name"
+    :data-index="index"
     :aria-label="name"
     :aria-selected="isSelected"
     @contextmenu="onRightClick"

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -46,9 +46,15 @@
           'add-padding': isStickySidebar,
           [listingViewMode]: true,
           dropping: isDragging,
+          'rectangle-selecting': isRectangleSelecting
         }"
         class="file-icons"
       >
+        <!-- Rectangle selection overlay -->
+        <div class="selection-rectangle" 
+          :style="rectangleStyle"
+        ></div>
+        
         <div>
           <div class="header card" :class="{ 'dark-mode-item-header': isDarkMode }">
             <p
@@ -194,6 +200,10 @@ export default {
       contextTimeout: null, // added for safari context menu
       ctrKeyPressed: false,
       clipboard: { items: [] }, // Initialize clipboard to prevent errors
+      isRectangleSelecting: false,
+      rectangleStart: { x: 0, y: 0 },
+      rectangleEnd: { x: 0, y: 0 },
+      rectangleSelection: [],
     };
   },
   watch: {
@@ -361,6 +371,21 @@ export default {
     loading() {
       return getters.isLoading();
     },
+    rectangleStyle() {
+      if (!this.isRectangleSelecting) return { display: 'none' };
+      
+      const left = Math.min(this.rectangleStart.x, this.rectangleEnd.x);
+      const top = Math.min(this.rectangleStart.y, this.rectangleEnd.y);
+      const width = Math.abs(this.rectangleStart.x - this.rectangleEnd.x);
+      const height = Math.abs(this.rectangleStart.y - this.rectangleEnd.y);
+      
+      return {
+        left: left + 'px',
+        top: top + 'px',
+        width: width + 'px',
+        height: height + 'px',
+      };
+    },
   },
   mounted() {
     mutations.setSearch(false);
@@ -394,6 +419,9 @@ export default {
     this.$el.addEventListener("dragenter", this.dragEnter);
     this.$el.addEventListener("dragleave", this.dragLeave);
     this.$el.addEventListener("drop", this.drop);
+    this.$el.addEventListener('mousedown', this.startRectangleSelection);
+    document.addEventListener('mousemove', this.updateRectangleSelection);
+    document.addEventListener('mouseup', this.endRectangleSelection);
   },
   beforeUnmount() {
     // Remove event listeners before destroying this page.
@@ -419,6 +447,9 @@ export default {
       this.$el.removeEventListener("dragenter", this.dragEnter);
       this.$el.removeEventListener("dragleave", this.dragLeave);
       this.$el.removeEventListener("drop", this.drop);
+      this.$el.removeEventListener('mousedown', this.startRectangleSelection);
+      document.removeEventListener('mousemove', this.updateRectangleSelection);
+      document.removeEventListener('mouseup', this.endRectangleSelection);
     }
   },
   methods: {
@@ -1001,6 +1032,127 @@ export default {
         });
       }
     },
+    startRectangleSelection(event) {
+      // Start rectangle selection when clicking on empty space
+      if (event.target.closest('.item') || event.target.closest('.header')) {
+        return;
+      }
+      
+      // Don't start if it's a right click, this for avoid some weird issue with the context menu.
+      if (event.button !== 0) return;
+      
+      this.isRectangleSelecting = true;
+      
+      // Get the position to the listing view container
+      const listingRect = this.$refs.listingView.getBoundingClientRect();
+      this.rectangleStart = {
+        x: event.clientX - listingRect.left,
+        y: event.clientY - listingRect.top
+      };
+      this.rectangleEnd = {
+        x: event.clientX - listingRect.left,
+        y: event.clientY - listingRect.top
+      };
+      
+      // Store the current selection state when starting rectangle
+      this.initialSelectionState = [...state.selected];
+      
+      // Only clear selection when CTRL is not holded
+      const hasModifier = event.ctrlKey || event.metaKey;
+      if (!hasModifier) {
+        mutations.resetSelected();
+      }
+      
+      event.preventDefault();
+    },
+    
+    updateRectangleSelection(event) {
+      if (!this.isRectangleSelecting) return;
+      
+      // Get the position to the listing view container
+      const listingRect = this.$refs.listingView.getBoundingClientRect();
+      this.rectangleEnd = {
+        x: event.clientX - listingRect.left,
+        y: event.clientY - listingRect.top
+      };
+      
+      this.updateSelectedItemsInRectangle(event.ctrlKey || event.metaKey);
+    },
+    
+    endRectangleSelection(event) {
+      if (!this.isRectangleSelecting) return;
+      
+      this.isRectangleSelecting = false;
+      this.updateSelectedItemsInRectangle(event.ctrlKey || event.metaKey);
+      
+      // Clear rectangle after a short delay
+      setTimeout(() => {
+        this.rectangleStart = { x: 0, y: 0 };
+        this.rectangleEnd = { x: 0, y: 0 };
+        this.initialSelectionState = [];
+      }, 100);
+    },
+    
+    updateSelectedItemsInRectangle(isAdditive) {
+      if (!this.isRectangleSelecting) return;
+      
+      const listingRect = this.$refs.listingView.getBoundingClientRect();
+      const rect = {
+        left: Math.min(this.rectangleStart.x, this.rectangleEnd.x),
+        top: Math.min(this.rectangleStart.y, this.rectangleEnd.y),
+        right: Math.max(this.rectangleStart.x, this.rectangleEnd.x),
+        bottom: Math.max(this.rectangleStart.y, this.rectangleEnd.y)
+      };
+      
+      const rectangleSelectedIndexes = [];
+      
+      // Get all item elements
+      const itemElements = this.$el.querySelectorAll('.item');
+      
+      itemElements.forEach((element) => {
+        const elementRect = element.getBoundingClientRect();
+        
+        // Convert element position to be relative to listing view, this allows selection while scrolling
+        const elementRelativeRect = {
+          left: elementRect.left - listingRect.left,
+          top: elementRect.top - listingRect.top,
+          right: elementRect.right - listingRect.left,
+          bottom: elementRect.bottom - listingRect.top
+        };
+        
+        // Check if the item intersects with the rectangle
+        if (
+          elementRelativeRect.left < rect.right &&
+          elementRelativeRect.right > rect.left &&
+          elementRelativeRect.top < rect.bottom &&
+          elementRelativeRect.bottom > rect.top
+        ) {
+          const index = parseInt(element.getAttribute('data-index'));
+          if (!isNaN(index)) {
+            rectangleSelectedIndexes.push(index);
+          }
+        }
+      });
+      
+      // Update selection based on modifier keys (ctrl/meta)
+      if (isAdditive) {
+        // only add more items to the current selection without reset selection
+        const newSelection = [...state.selected];
+        rectangleSelectedIndexes.forEach(index => {
+          if (!newSelection.includes(index)) {
+            newSelection.push(index);
+          }
+        });
+        
+        mutations.resetSelected();
+        newSelection.forEach(index => mutations.addSelected(index));
+      } else {
+        // Select only the items in the rectangle and reset initial selection
+        // PS: If you don't want that just hold ctrl, the selection will not be reset, allowing multi select.
+        mutations.resetSelected();
+        rectangleSelectedIndexes.forEach(index => mutations.addSelected(index));
+      }
+    },
   },
 };
 </script>
@@ -1032,6 +1184,7 @@ export default {
 
 #listingView {
   min-height: 90vh !important;
+  position: relative;
 }
 
 .folder-items a {
@@ -1044,6 +1197,25 @@ export default {
   padding: 2em;
   max-width: 800px;
   margin: 0 auto;
+}
+
+.selection-rectangle {
+  position: absolute;
+  border: 2px solid var(--primaryColor);
+  background-color: color-mix(in srgb, var(--primaryColor) 25%, transparent);
+  border-radius: 8px;
+  pointer-events: none;
+  z-index: 10;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+#listingView.rectangle-selecting {
+  cursor: crosshair;
+  user-select: none;
+}
+
+#listingView.rectangle-selecting .item {
+  pointer-events: none;
 }
 
 </style>


### PR DESCRIPTION
**Description**
This adds rectangle selection, I don't have much to describe but:

- When holding ctrl key you can multiple select various files with the rectangle, clicking on a empty space meanwhile you are holding that key will not reset the active selection.


Closes #1077 

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**

https://github.com/user-attachments/assets/c47f0590-1833-4562-a956-e960bfc9a86d

---

And that random logout.. 