### PR TITLE
Startup better error handling for embed fs case

### DIFF
--- a/backend/http/httpRouter.go
+++ b/backend/http/httpRouter.go
@@ -50,7 +50,11 @@ func StartHttp(ctx context.Context, storage *bolt.BoltStore, shutdownComplete ch
 		// Embedded mode: Serve files from the embedded assets
 		assetFs, err = fs.Sub(assets, "embed")
 		if err != nil {
-			logger.Fatal("Could not embed frontend. Does dist exist?")
+			logger.Fatalf("fs.Sub failed: %v", err)
+		}
+		entries, err := fs.ReadDir(assetFs, ".")
+		if err != nil || len(entries) == 0 {
+			logger.Fatalf("Could not embed frontend. Does dist exist? %v", err)
 		}
 		assetPathPrefix = "public/img/icons/"
 		if config.Frontend.LoginIcon == "" {


### PR DESCRIPTION
This PR properly handles errors when you try to get non existing dir from embed.FS

Surprisingly, `fs.Sub` does not return error for non-existing paths. I could only make it fail for "", `..`, `/`. Any other dir-like values (including `*`, `|`) are “ok” for the function.

So additional `ReadDir` call is required to fail fast and not in http handler