### PR TITLE
Add swipe and visual timeout to notifications

### DIFF
--- a/frontend/src/notify/index.ts
+++ b/frontend/src/notify/index.ts
@@ -6,6 +6,9 @@ const notify = {
     closeNotification: messageFunctions.closeNotification,
     getNotifications: messageFunctions.getNotifications,
     setUpdateCallback: messageFunctions.setUpdateCallback,
+    pauseAutoClose: messageFunctions.pauseAutoClose,
+    resumeAutoClose: messageFunctions.resumeAutoClose,
+    getNotificationProgress: messageFunctions.getNotificationProgress,
     // Toast functions
     showToast: messageFunctions.showToast,
     showSuccessToast: messageFunctions.showSuccessToast,

--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -241,6 +241,7 @@ export default {
                     this.setupPlaybackQueue(forceReshuffle);
                     this.$nextTick(() => {
                         this.ensurePlaybackModeApplied();
+                        this.syncMediaLoopState();
                     });
                 }
             },
@@ -416,7 +417,7 @@ export default {
             // Handle 'P' and 'L' keys for loop and change playback
             if (event.key.toLowerCase() === 'p' || event.key.toLowerCase() === 'l') {
                 event.stopPropagation();
-
+                event.preventDefault();
                 // Use requestAnimationFrame to ensure UI updates
                 requestAnimationFrame(() => {
                     if (event.key.toLowerCase() === 'p') {
@@ -1191,6 +1192,10 @@ export default {
 /************
 *** AUDIO ***
 ************/
+
+.plyr.plyr--audio {
+    border-radius: 12px;
+}
 
 /* Hide some unnesary buttons on the audio player */
 .plyr--audio .plyr__control--overlaid,


### PR DESCRIPTION
**Description**
I tried to enhance a bit more the notifications, now you can drag for dismiss them and also they show a visual timeout which pauses the current notification that we are hovering.

Related to the changes in `plyrViewer` you were right about the videos with the border radius, so I only applied it to the audio player and fixed a tiny issue too.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**

https://github.com/user-attachments/assets/d0b9fdeb-a56c-4a31-8b1c-34c778c7ff79

