### PR TITLE
Improve rename prompt

### DIFF
--- a/frontend/src/components/prompts/Rename.vue
+++ b/frontend/src/components/prompts/Rename.vue
@@ -7,7 +7,7 @@
     <p>{{ $t("prompts.renameMessage") }}</p>
 
     <div v-if="item.type !== 'directory'" class="filename-inputs">
-      <input class="input" :class="{ 'form-invalid': !validation.valid }" v-focus type="text" @keyup.enter="submit"
+      <input class="input filename-input" :class="{ 'form-invalid': !validation.valid }" v-focus type="text" @keyup.enter="submit"
         v-model.trim="fileName" @input="updateFullName" />
       <span class="extension-separator">.</span> <!--eslint-disable-line @intlify/vue-i18n/no-raw-text-->
       <input class="input extension-input" type="text" @keyup.enter="submit" v-model.trim="fileExtension"
@@ -126,9 +126,7 @@ export default {
       for (const item of state.req.items) {
         if (item.path === this.item.path) continue;
         if (item.name.toLowerCase() === value.toLowerCase()) {
-          if (isFolder === (item.type === "directory")) {
-            return { valid: false, reason: 'conflict' };
-          }
+          return { valid: false, reason: 'conflict' };
         }
       }
 


### PR DESCRIPTION
**Description**
This should fix #1556 

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**
I also tried to improve it a bit more, one field is for the filename, and the other for the extension.
This for avoid rename the extension by mistake too.

<img width="780" height="298" alt="image" src="https://github.com/user-attachments/assets/da9b158d-8658-40e5-99f9-1808417464cf" />
