### PR TITLE
Ensure directory paths end with a trailing slash in upload manager

### DIFF
--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -53,7 +53,7 @@ class UploadManager {
           const probeResults = await Promise.all(
             [...topLevelDirs].map(async (dirName) => {
               try {
-                const testPath = `${basePath}${dirName}`;
+                const testPath = `${basePath}${dirName}/`;
                 if (getters.isShare()) {
                   await publicApi.post(state.shareInfo?.hash, testPath, new Blob([]), false, undefined, {}, true);
                 } else {


### PR DESCRIPTION
This fixes users unable to upload folders, caused by a file being created, instead of a folder.
#1534 talks about this