### PR TITLE
Fix/Improve some behaviors in nextPrevious

### DIFF
--- a/frontend/src/components/files/nextPrevious.vue
+++ b/frontend/src/components/files/nextPrevious.vue
@@ -905,27 +905,11 @@ export default {
     showFileList(type) {
       // Hide navigation buttons when showing file list
       mutations.setNavigationShow(false);
-      // Determine what list to show based on drag type
-      if (type === 'previous') {
-        // Show parent directories for navigating up
-        this.showParentDirectories();
-      } else if (type === 'next') {
+
+      if (type === 'previous' || type === 'next') {
         // Show current listing items for quick jumping
         this.showCurrentListing();
       }
-    },
-
-    showParentDirectories() {
-      // Show files in the current directory (same directory as the previewed file)
-      const currentItems = this.getCurrentListingItems();
-      mutations.showHover({
-        name: "file-list",
-        props: {
-          fileList: currentItems,
-          mode: "navigate-siblings",
-          title: this.$t("prompts.quickJump")
-        }
-      });
     },
 
     showCurrentListing() {
@@ -940,35 +924,6 @@ export default {
       });
     },
 
-    getParentDirectories() {
-      // Build array of parent directories from current path
-      const currentPath = state.req.path || "/";
-      const pathParts = currentPath.split("/").filter(part => part);
-      const parentDirs = [];
-
-      // Add root
-      parentDirs.push({
-        name: "/",
-        path: "/",
-        source: state.req.source,
-        isDirectory: true
-      });
-
-      // Add each level up to current
-      let buildPath = "";
-      for (let i = 0; i < pathParts.length; i++) {
-        buildPath += "/" + pathParts[i];
-        parentDirs.push({
-          name: pathParts[i],
-          path: buildPath,
-          source: state.req.source,
-          isDirectory: true
-        });
-      }
-
-      return parentDirs.reverse(); // Show deepest first
-    },
-
     getCurrentListingItems() {
       // Get items from the current navigation listing (files in same directory)
       const listing = state.navigation.listing || [];
@@ -981,6 +936,7 @@ export default {
         originalItem: item
       }));
     },
+
     handleGlobalMouseMove(event) {
       // Check if mouse is in the nav zone areas to show navigation buttons
       if (!this.enabled) return;


### PR DESCRIPTION
**Description**
I'm not sure if counts as improvement or fix, but this should accomplish 3 things:

- In mobile, when in media mode, the navigation was being triggered 2 times, skipping 1 file in the queue each time that you pressed the buttons.
- In mobile, long pressing the buttons was triggering navigation, making difficult to open the file list if you don't swipe fast. Now if you long press **and** if you don't move your finger, after release the tap will trigger navigation, but if you swipe a bit (but not enough to open the file list) will return the button to its position.

- In desktop, if you dragged the buttons with the mouse but the drag was not enough to open the file list, was triggering navigation. Now just returns to its original position instead.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**
Now fast-forward/rewind shortcuts in the media player should work fine, even if is paused :+1: 
Since before was checking if the media was playing to handle (or not) the arrow keys.