### PR TITLE
Move custom CSS and user-selected theme styles to the end of the body…

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -160,8 +160,6 @@
         transform: scale(1.0);
       }
     }
-    {{ .htmlVars.customCSS }}
-    {{ .htmlVars.userSelectedTheme }}
   </style>
 </head>
 
@@ -187,6 +185,10 @@
   {{end}}
   <script type="module" src="/src/main.ts"></script>
 
+  <style>
+    {{ .htmlVars.customCSS }}
+    {{ .htmlVars.userSelectedTheme }}
+  </style>
 </body>
 
 </html>


### PR DESCRIPTION
### Move Custom CSS to End of `<body>` for Correct Load Order

**Problem**
Custom CSS variables (`{{ .htmlVars.customCSS }}` and `{{ .htmlVars.userSelectedTheme }}`) were loaded in the `<head>`. As a result, they could be overridden by bundled CSS loaded later via Vite’s module script.

**Solution**
The custom CSS `<style>` block was moved to the end of the `<body>`, after the Vite script tag. This guarantees that custom styles load last and take precedence without relying on `!important`.

**Changes**

* Removed custom CSS variables from the `<head>` style block
* Added a new `<style>` block at the end of `<body>` containing the custom CSS variables

**Benefits**

* Custom user styles reliably override bundled styles
* Eliminates the need for `!important` in custom CSS
* Results in a cleaner and more predictable CSS cascade

Thanks for taking the time to review the PR !
