### PR TITLE
Bug fix: file permissions not working

### DIFF
--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -586,7 +586,7 @@ func WriteDirectory(opts utils.FileOptions) error {
 	err = os.Chmod(realPath, fileutils.PermDir)
 	if err != nil {
 		// Handle chmod error gracefully
-		logger.Debugf("Could not set file permissions for %s (this may be expected in restricted environments): %v", dest, err)
+		logger.Debugf("Could not set file permissions for %s (this may be expected in restricted environments): %v", realPath, err)
 	}
 
 	return RefreshIndex(idx.Name, opts.Path, true, true)
@@ -638,7 +638,7 @@ func WriteFile(source, path string, in io.Reader) error {
 	err = os.Chmod(realPath, fileutils.PermDir)
 	if err != nil {
 		// Handle chmod error gracefully
-		logger.Debugf("Could not set file permissions for %s (this may be expected in restricted environments): %v", dest, err)
+		logger.Debugf("Could not set file permissions for %s (this may be expected in restricted environments): %v", realPath, err)
 	}
 
 	return RefreshIndex(source, path, false, false)


### PR DESCRIPTION
**Description**
This PR aims to fix a bug where the file and directory permissions set in the config don't get applied when creating a new file/directory (see the video for a clear example).

**Context**
I think that the previous chmod was removed because it wasn't compatible with rootless containers. But I saw that in the file [file.go](https://github.com/gtsteffaniak/filebrowser/blob/main/backend/adapters/fs/fileutils/file.go) this was solved with the following code:
```
// Preserve source file permissions
// Handle chmod errors gracefully (e.g., in rootless containers where chmod may be restricted)
err = os.Chmod(dest, sourcePerms)
if err != nil {
      // Log but don't fail - chmod may be restricted in some environments
      // The file was copied successfully, so we continue
      logger.Debugf("Could not set file permissions for %s (this may be expected in restricted environments): %v", dest, err)
}
```
So I think that the same approach should be applied with all file permissions, solving this bug.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.

**Additional Details**

https://github.com/user-attachments/assets/9e24837d-185a-464b-97ab-fc4e2bd5b8d0