### PR TITLE
fix rename shortcut

### DIFF
--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -846,7 +846,7 @@ export default {
           break;
 
         case "F2":
-          if (!!this.permissions?.modify || state.selected.length !== 1)  return;
+          if (!this.permissions?.modify || state.selected.length !== 1)  return;
           mutations.showHover({
             name: "rename",
             props: {


### PR DESCRIPTION
**Description**
This was my fault, I didn't noticed that I added a extra `!` in the condition, just noticed it right now 😅

Now should work.

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**
