### PR TITLE
Revise WebDAV support and add information on CarlDAV/CardDAV integrat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Mac                           | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 Self hostable                 | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
 Has Stable Release?           | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 S3 support                    | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
-webdav support                | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ |
+webdav support                | ⚠️*¹ | ❌ | ✅ | ✅ | ❌ | ✅ |
 FTP support                   | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ |
 Dedicated docs site?          | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
 Multiple sources at once      | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
@@ -146,3 +146,7 @@ Can browse archive files      | :construction: | ❌ | ❌ | ❌ | ❌ | ✅ |
 Can convert documents         | :construction: | ❌ | ❌ | ❌ | ❌ | ✅ |
 Can convert videos            | :construction: | ❌ | ❌ | ❌ | ❌ | ❌ |
 Can convert photos            | :construction: | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+
+> *¹ Using the built-in API, a reverse proxy (e.g., Nginx Proxy Manager), and Radicale (properly configured), you can provide reliable CalDAV and CardDAV services. With the correct headers (X-Remote-User and X-Script-Name), all endpoints are recognized, allowing clients such as iOS, macOS, Android, Gnome Online Accounts, Thunderbird, Evolution, and other WebDAV-compatible apps to sync calendars and contacts automatically. Unlimited uploads and stable WebDAV support ensure even large files are handled efficiently.
+> A detailed guide is available here: [FileBrowser Quantum with Radicale Support!](https://github.com/cryinkfly/podman-rootless-quadlets/tree/main/quadlets/filebrowser-quantum/radicale) – thanks to [@cryinkfly](https://github.com/cryinkfly)


### PR DESCRIPTION
## Updated WebDAV support information and added details about CalDAV and CardDAV services using Radicale.

**Description:**

This PR updates the documentation to clarify the current status of WebDAV support and provides additional details on CalDAV and CardDAV integration via Radicale.

### According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), a PR should include:

✔️ A clear description of why it was opened.
✔️ A short, descriptive title for the change.
✔️ Confirmation that all unit and integration tests pass (can be run locally).
✔️ Any additional details for functionality not covered by tests.

### Additional Details

- Clarifies that WebDAV support is still in progress.
- Explains how Radicale enables CalDAV and CardDAV services.
- Notes relevant configuration tips for reverse proxies and headers.
