### PR TITLE
settings: do not center settings title

### DIFF
--- a/frontend/src/components/sidebar/Settings.vue
+++ b/frontend/src/components/sidebar/Settings.vue
@@ -63,7 +63,6 @@ export default {
 .settings-card {
   display: flex;
   align-items: center;
-  justify-content: center;
   overflow: unset !important;
   padding: 1em;
 }


### PR DESCRIPTION
**Description**

Centering icon and text makes it quite difficult to read the actual text.
Also in some languages, the current way of centering is not working properly, example in french:

<img width="624" height="1238" alt="image" src="https://github.com/user-attachments/assets/672d6332-19d5-43a6-91bb-bf325c66a34a" />


This PR proposes to remove the centering altogether so the text of those buttons align properly and makes it easier for people to read.

<img width="624" height="1238" alt="image" src="https://github.com/user-attachments/assets/f297c515-79fb-47ac-b5f3-979277e8f896" />
