### PR TITLE
allow searching from first character by default

### DIFF
--- a/backend/common/settings/config.go
+++ b/backend/common/settings/config.go
@@ -220,7 +220,7 @@ func setupFrontend(generate bool) {
 	// Load login icon configuration at startup
 	loadLoginIcon()
 	if Config.Server.MinSearchLength == 0 {
-		Config.Server.MinSearchLength = 3
+		Config.Server.MinSearchLength = 1 // allow for single character searches
 	}
 	if !Config.Frontend.DisableDefaultLinks {
 		Config.Frontend.ExternalLinks = append(Config.Frontend.ExternalLinks, ExternalLink{


### PR DESCRIPTION
This PR changes the backend default for server.minSearchLength from 3 to 1, so search can start from the first character typed when users don’t explicitly set minSearchLength in their config.
Why
Improves UX by showing results/suggestions immediately after the first keystroke.
Keeps server.minSearchLength configurable—users can still set it to 3+ if they prefer fewer/noisier results.
Changes
Update backend default: Config.Server.MinSearchLength 3 → 1 when unset/0.
Testing
[checked ] make test-backend
[ checked] Manual: verified /api/search accepts 1-character queries and UI starts searching at 1 character.
Notes
This only changes the default behavior; existing configs that set server.minSearchLength are unaffected.
