### PR TITLE
Fix brand text in login screen

### DIFF
--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -223,7 +223,7 @@ export default {
       return globalVars.darkMode;
     },
     loginName() {
-      return globalVars.name;
+      return this.name;
     },
   },
   data: function () {


### PR DESCRIPTION
**Description**
Fix the brand text in the login screen that wasn't working when setting `frontend.name` in `config.yaml`

<img height="250" alt="image" src="https://github.com/user-attachments/assets/e8d2e931-c34c-479e-bbc4-8dfc8c8253f1" />

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional details**
Fixes #1897 