### PR TITLE
fix webm mimetype and add more media mimetypes

### DIFF
--- a/backend/adapters/fs/files/mime.go
+++ b/backend/adapters/fs/files/mime.go
@@ -631,7 +631,6 @@ var types = map[string]string{
 	".jpgm":      "video/jpm",
 	".mj2":       "video/mj2",
 	".mjp2":      "video/mj2",
-	".ts":        "video/mp2t",
 	".m2t":       "video/mp2t",
 	".m2ts":      "video/mp2t",
 	".mts":       "video/mp2t",


### PR DESCRIPTION
**Description**
Not sure when the `.webm` file started to be detected with wrong mimetype, maybe a dependency update?
I noticed that wasn't in the mimetype list in backend. So, I added it and also added more mimetypes for media files there.

Those extra mimetypes maybe aren't useful now, but when the max media mode is implemented I think that will help :)

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [X] A clear description of why it was opened.
- [X] A short title that best describes the change.
- [X] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [X] Any additional details for functionality not covered by tests.

**Additional Details**

<img width="1043" height="523" alt="screenshot_2026-03-03_18-09-32" src="https://github.com/user-attachments/assets/ea370242-498a-4591-8cfa-71df83c10a25" />
