### PR TITLE
oidc: Extract group from keys in the map

### DIFF
--- a/backend/http/oidc.go
+++ b/backend/http/oidc.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -44,6 +45,8 @@ func (u *userInfoUnmarshaller) UnmarshalJSON(data []byte) error {
 	if u.groupsClaim != "" {
 		if v, ok := raw[u.groupsClaim]; ok {
 			switch val := v.(type) {
+			case map[string]interface{}:
+				u.userInfo.Groups = slices.Collect(maps.Keys(val))
 			case []interface{}:
 				groups := make([]string, len(val))
 				for i, g := range val {


### PR DESCRIPTION
Zitadel (IAM) provides roles within a claim as a map of role names to organisations. This change enables the backend to extract these roles for the admin check.

Reference config:
```yaml
auth:
  methods:
    oidc:
      # ...
      groupsClaim: "urn:zitadel:iam:org:project:roles"
      adminGroup: "admin"
```
