### PR TITLE
Add fbx models back

### DIFF
--- a/backend/indexing/iteminfo/conditions.go
+++ b/backend/indexing/iteminfo/conditions.go
@@ -282,6 +282,7 @@ var model3DMimeType = map[string]string{
 	".gltf":  "model/gltf+json",
 	".glb":   "model/gltf-binary",
 	".obj":   "model/obj",
+	".fbx":   "model/fbx",
 	".stl":   "model/stl",
 	".ply":   "model/ply",
 	".dae":   "model/vnd.collada+xml",

--- a/frontend/src/views/files/ThreeJs.vue
+++ b/frontend/src/views/files/ThreeJs.vue
@@ -35,6 +35,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
 import { MTLLoader } from 'three/addons/loaders/MTLLoader.js';
+import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
 import { STLLoader } from 'three/addons/loaders/STLLoader.js';
 import { PLYLoader } from 'three/addons/loaders/PLYLoader.js';
 import { ColladaLoader } from 'three/addons/loaders/ColladaLoader.js';
@@ -58,6 +59,7 @@ const LOADERS = {
   gltf: GLTFLoader,
   glb: GLTFLoader,
   obj: OBJLoader,
+  fbx: FBXLoader,
   stl: STLLoader,
   ply: PLYLoader,
   dae: ColladaLoader,
@@ -341,6 +343,9 @@ export default {
     },
 
     resolveTextureUrl(url) {
+      if (url.startsWith('blob:') || url.startsWith('data:')) {
+        return url;
+      }
       if (url.includes('/api/resources/download?')) {
         return url;
       }


### PR DESCRIPTION
**Description**
Adds `.fbx` models back. Also a fix for some models that were loading black before.

**Additional Details**

<img width="380" alt="image" src="https://github.com/user-attachments/assets/5e2a6e0f-e054-4541-8d1d-3b53311d937d" />

<img width="370" alt="image" src="https://github.com/user-attachments/assets/33a99cfb-f705-4ac0-9286-94895842f554" />
