### PR TITLE
fix mouse back buttons not working while previewing images

### DIFF
--- a/frontend/src/components/StatusBar.vue
+++ b/frontend/src/components/StatusBar.vue
@@ -202,7 +202,7 @@ export default {
     },
     // Ctrl + Mouse Wheel to adjust the slider sizes
     handleWheel(event) {
-      if (!event.ctrlKey) return;
+      if (!(event.ctrlKey || event.metaKey)) return;
 
       const delta = event.deltaY > 0 ? 1 : -1; // Scroll down increases, up decreases
 

--- a/frontend/src/components/files/ExtendedImage.vue
+++ b/frontend/src/components/files/ExtendedImage.vue
@@ -547,6 +547,7 @@ export default {
       this.applyImgTransform();
     },
     mousedownStart(event) {
+      if (event.button !== 0) return;
       if (this.scale === 1) {
         this.teardownEdgeMouseListeners();
         this.edgeMouseActive = true;
@@ -567,12 +568,14 @@ export default {
       event.preventDefault();
     },
     mouseMove(event) {
+      if (event.button !== 0) return;
       if (this.scale > 1 && this.inDrag) {
         this.doMove(event.movementX, event.movementY);
         event.preventDefault();
       }
     },
     mouseUp(event) {
+      if (event.button !== 0) return;
       if (this.scale > 1) {
         this.inDrag = false;
         event.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/gtsteffaniak/filebrowser/issues/2227#issuecomment-4182097949, I added an early return if the button is a different one than the right click.