### PR TITLE
Respect playback queue when navigating media files

### DIFF
--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -14,6 +14,7 @@
 
       <!-- Media Player Component -->
       <plyrViewer v-else-if="previewType == 'audio' || previewType == 'video'" ref="plyrViewer"
+        :key="previewType"
         :previewType="previewType" :raw="raw" :subtitlesList="subtitlesList" :req="req" :listing="listing"
         :useDefaultMediaPlayer="useDefaultMediaPlayer" :autoPlayEnabled="autoPlay" @play="autoPlay = true"
         :class="{ 'plyr-background': previewType == 'audio' && !useDefaultMediaPlayer }"
@@ -451,11 +452,57 @@ export default {
       downloadFiles(items);
     },
     navigatePrevious() {
+      const mode = state.playbackQueue?.mode || 'single';
+      const queue = state.playbackQueue?.queue || [];
+      const isMediaQueueMode = (this.previewType === 'audio' || this.previewType === 'video') &&
+        mode !== 'single' && mode !== 'loop-single' && queue.length > 1;
+      if (isMediaQueueMode) {
+        const currentIndex = state.playbackQueue?.currentIndex ?? -1;
+        if (queue.length === 0 || currentIndex < 0) return;
+        let prevIndex = currentIndex - 1;
+        if (prevIndex < 0) {
+          if (mode === 'loop-all' || mode === 'shuffle') {
+            prevIndex = queue.length - 1;
+          } else {
+            return;
+          }
+        }
+        const prevItem = queue[prevIndex];
+        if (!prevItem) return;
+        mutations.setPlaybackQueue({ queue, currentIndex: prevIndex, mode });
+        const prevItemUrl = url.buildItemUrl(prevItem.source || state.req.source, prevItem.path);
+        mutations.replaceRequest(prevItem);
+        this.$router.replace({ path: prevItemUrl }).catch(() => {});
+        return;
+      }
       if (state.navigation.previousLink) {
         this.$router.replace({ path: state.navigation.previousLink });
       }
     },
     navigateNext() {
+      const mode = state.playbackQueue?.mode || 'single';
+      const queue = state.playbackQueue?.queue || [];
+      const isMediaQueueMode = (this.previewType === 'audio' || this.previewType === 'video') &&
+        mode !== 'single' && mode !== 'loop-single' && queue.length > 1;
+      if (isMediaQueueMode) {
+        const currentIndex = state.playbackQueue?.currentIndex ?? -1;
+        if (queue.length === 0 || currentIndex < 0) return;
+        let nextIndex = currentIndex + 1;
+        if (nextIndex >= queue.length) {
+          if (mode === 'loop-all' || mode === 'shuffle') {
+            nextIndex = 0;
+          } else {
+            return;
+          }
+        }
+        const nextItem = queue[nextIndex];
+        if (!nextItem) return;
+        mutations.setPlaybackQueue({ queue, currentIndex: nextIndex, mode });
+        const nextItemUrl = url.buildItemUrl(nextItem.source || state.req.source, nextItem.path);
+        mutations.replaceRequest(nextItem);
+        this.$router.replace({ path: nextItemUrl }).catch(() => {});
+        return;
+      }
       if (state.navigation.nextLink) {
         this.$router.replace({ path: state.navigation.nextLink });
       }

--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -356,10 +356,32 @@ export default {
       return state.navigation.enabled && getters.currentPrompt() === null;
     },
     hasVideoPreviousNav() {
-      return this.videoNavigationGestureAllowed && state.navigation.previousLink !== '';
+      if (!this.videoNavigationGestureAllowed) return false;
+      const mode = state.playbackQueue?.mode || 'single';
+      const queue = state.playbackQueue?.queue || [];
+      const isQueueMode = (this.previewType === 'audio' || this.previewType === 'video') &&
+        mode !== 'single' && mode !== 'loop-single' && queue.length > 1;
+      if (isQueueMode) {
+        const currentIndex = state.playbackQueue?.currentIndex ?? -1;
+        if (queue.length <= 1 || currentIndex < 0) return false;
+        if (mode === 'sequential' && currentIndex === 0) return false;
+        return true;
+      }
+      return state.navigation.previousLink !== '';
     },
     hasVideoNextNav() {
-      return this.videoNavigationGestureAllowed && state.navigation.nextLink !== '';
+      if (!this.videoNavigationGestureAllowed) return false;
+      const mode = state.playbackQueue?.mode || 'single';
+      const queue = state.playbackQueue?.queue || [];
+      const isQueueMode = (this.previewType === 'audio' || this.previewType === 'video') &&
+        mode !== 'single' && mode !== 'loop-single' && queue.length > 1;
+      if (isQueueMode) {
+        const currentIndex = state.playbackQueue?.currentIndex ?? -1;
+        if (queue.length <= 1 || currentIndex < 0) return false;
+        if (mode === 'sequential' && currentIndex >= queue.length - 1) return false;
+        return true;
+      }
+      return state.navigation.nextLink !== '';
     },
     /** Tracks `mutations.setMobile()` / window resize so watchers can react. */
     storeIsMobile() {


### PR DESCRIPTION
**Description**

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.

Closes #2243

The issue was that when swiping through media files, the player was ignoring the playback queue mode and just using the basic previous/next navigation. If you had the queue set to loop all or shuffle, you'd still hit the end and get stuck instead of wrapping around or jumping to the next queued item.

I updated the `navigatePrevious()` and `navigateNext()` functions to check if there's an active playback queue with a real mode set (not single). If so, they now navigate through the queue with proper handling for loop and shuffle modes. Falls back to the old navigation behavior for single file mode.

Also added a `:key` binding on the plyrViewer component to make sure it reinitializes when the media type changes.

**Additional Details**

Tested locally with audio and video files in different queue modes. Swiping now respects loop-all and shuffle correctly, and playback updates to the right file in the queue.