### PR TITLE
Fix audio metadata and album art extraction

### DIFF
--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -297,22 +297,20 @@ func processContent(info *iteminfo.ExtendedFileInfo, idx *indexing.Index, opts u
 
 			return
 		}
+	}
 
-		if isAudio {
-			// Create an ExtendedItemInfo to hold the metadata
-			extItem := &iteminfo.ExtendedItemInfo{
-				ItemInfo: info.ItemInfo,
-			}
-			err := extractAudioMetadata(context.Background(), extItem, info.RealPath, opts.AlbumArt || opts.Content, opts.Metadata || opts.Content, nil)
-			if err != nil {
-				logger.Debugf("failed to extract audio metadata for file: "+info.RealPath, info.Name, err)
-			} else {
-				// Copy metadata to ExtendedFileInfo
-				info.Metadata = extItem.Metadata
-				info.HasPreview = extItem.Metadata != nil && len(extItem.Metadata.AlbumArt) > 0
-			}
-			return
+	if isAudio && (opts.Metadata || opts.AlbumArt || opts.Content) {
+		extItem := &iteminfo.ExtendedItemInfo{
+			ItemInfo: info.ItemInfo,
 		}
+		err := extractAudioMetadata(context.Background(), extItem, info.RealPath, opts.AlbumArt || opts.Content, opts.Metadata || opts.Content, nil)
+		if err != nil {
+			logger.Debugf("failed to extract audio metadata for file: "+info.RealPath, info.Name, err)
+		} else {
+			info.Metadata = extItem.Metadata
+			info.HasPreview = extItem.Metadata != nil && len(extItem.Metadata.AlbumArt) > 0
+		}
+		return
 	}
 
 	// Process text content for non-video, non-audio files

--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -48,6 +48,8 @@ func addMetadataToChildren(response *iteminfo.ExtendedFileInfo, opts utils.FileO
 			if isAudio {
 				if err := extractAudioMetadata(context.Background(), fileItem, fullPath, opts.AlbumArt, opts.Metadata, sharedFFmpegService); err != nil {
 					logger.Debugf("failed to extract metadata for file: %s, error: %v", fileItem.Name, err)
+				} else {
+					fileItem.HasPreview = fileItem.Metadata != nil && len(fileItem.Metadata.AlbumArt) > 0
 				}
 			} else {
 				if err := extractVideoMetadata(context.Background(), fileItem, fullPath, sharedFFmpegService); err != nil {


### PR DESCRIPTION
Fixes #2236

The audio metadata extraction wasn't triggering properly because the condition was at the wrong scope and wasn't checking whether the relevant options were actually enabled. Pulled the check out to the right level and added a condition to only process audio metadata when Metadata, AlbumArt, or Content options are requested.

Tested with local mp3 files and album art is now showing up correctly.