### PR TITLE
fix replace-rename prompt that wasn't working in some cases

### DIFF
--- a/backend/http/resource.go
+++ b/backend/http/resource.go
@@ -521,6 +521,10 @@ func resourcePostHandler(w http.ResponseWriter, r *http.Request, d *requestConte
 		existingIsDir := stat.IsDir()
 		requestingDir := isDir
 
+		if r.URL.Query().Get("override") != "true" {
+			return http.StatusConflict, nil
+		}
+
 		// If type mismatch (file vs folder or folder vs file) and not overriding
 		if existingIsDir != requestingDir && r.URL.Query().Get("override") != "true" {
 			logger.Debugf("Type conflict detected in chunked: existing is dir=%v, requesting dir=%v at path=%v", existingIsDir, requestingDir, realPath)

--- a/frontend/src/components/files/Breadcrumbs.vue
+++ b/frontend/src/components/files/Breadcrumbs.vue
@@ -223,7 +223,8 @@ export default {
           fromSource: selectedItem.source,
           to: url.joinPath(targetPath, selectedItem.name),
           toSource: source,
-          itemType: selectedItem.type
+          itemType: selectedItem.type,
+          name: selectedItem.name
         });
       }
 

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -554,13 +554,11 @@ export default {
       let items = [];
       for (let i of state.selected) {
         items.push({
-          // @ts-ignore
           from: state.req.items[i].path,
-          // @ts-ignore
           fromSource: state.req.items[i].source,
-          // @ts-ignore
           to: url.joinPath(this.path, state.req.items[i].name),
           toSource: this.source,
+          name: state.req.items[i].name,
         });
       }
 

--- a/frontend/src/components/prompts/CopyPasteConfirm.vue
+++ b/frontend/src/components/prompts/CopyPasteConfirm.vue
@@ -81,9 +81,12 @@ export default {
     closeTopPrompt() {
       mutations.closeTopPrompt();
     },
-    confirm() {
-      this.onConfirm();
-      mutations.closeTopPrompt();
+    async confirm() {
+      try {
+        await this.onConfirm();
+      } finally {
+        mutations.closeTopPrompt();
+      }
     },
   },
 };

--- a/frontend/src/components/prompts/NewDir.vue
+++ b/frontend/src/components/prompts/NewDir.vue
@@ -161,13 +161,15 @@ export default {
                       if (getters.isShare()) {
                         await resourcesApi.postPublic(state.shareInfo?.hash, newPath, "", false, undefined, {}, true);
                         mutations.setReload(true);
-                        mutations.closeTopPrompt();
+                        mutations.closeTopPrompt(); // close conflict prompt
+                        mutations.closeTopPrompt(); // close new dir prompt
                         success = true;
                         return;
                       }
                       await resourcesApi.post(source, newPath, "", false, undefined, {}, true);
                       mutations.setReload(true);
-                      mutations.closeTopPrompt();
+                      mutations.closeTopPrompt(); // close conflict prompt
+                      mutations.closeTopPrompt(); // close new dir prompt
                       success = true;
 
                       // Show success notification with "go to item" button

--- a/frontend/src/components/prompts/NewDir.vue
+++ b/frontend/src/components/prompts/NewDir.vue
@@ -78,6 +78,16 @@ export default {
         source: state.req?.source || null,
       };
     },
+    currentPromptName() {
+      return getters.currentPromptName();
+    },
+  },
+  watch: {
+    currentPromptName(newName, oldName) {
+      if (this.creating && oldName === "replace-rename" && newName !== "new-dir") {
+        this.creating = false;
+      }
+    },
   },
   methods: {
     closeTopPrompt() {

--- a/frontend/src/components/prompts/NewFile.vue
+++ b/frontend/src/components/prompts/NewFile.vue
@@ -78,6 +78,16 @@ export default {
         source: state.req?.source || null,
       };
     },
+    currentPromptName() {
+      return getters.currentPromptName();
+    },
+  },
+  watch: {
+    currentPromptName(newName, oldName) {
+      if (this.creating && oldName === "replace-rename" && newName !== "new-file") {
+        this.creating = false;
+      }
+    },
   },
   methods: {
     async submit(event) {

--- a/frontend/src/components/prompts/NewFile.vue
+++ b/frontend/src/components/prompts/NewFile.vue
@@ -158,13 +158,15 @@ export default {
                       if (getters.isShare()) {
                         await resourcesApi.postPublic(state.shareInfo?.hash, newPath, "", false);
                         mutations.setReload(true);
-                        mutations.closeTopPrompt();
+                        mutations.closeTopPrompt(); // close conflict prompt
+                        mutations.closeTopPrompt(); // close new file prompt
                         success = true;
                         return;
                       }
                       await resourcesApi.post(source, newPath, "", false);
                       mutations.setReload(true);
-                      mutations.closeTopPrompt();
+                      mutations.closeTopPrompt(); // close conflict prompt
+                      mutations.closeTopPrompt(); // close new file prompt
                       success = true;
 
                       // Show success notification with "go to item" button

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -1000,7 +1000,8 @@ export default {
         from: item.from,
         fromSource: item.fromSource,
         to: destPath + item.name,
-        toSource: state.req.source
+        toSource: state.req.source,
+        name: item.name,
       }));
 
       const operation = this.clipboard.key === "x" ? "move" : "copy";
@@ -1011,51 +1012,51 @@ export default {
         props: {
           operation: operation,
           items: items,
-          onConfirm: async () => {
-            mutations.setLoading("listing", true);
+          onConfirm: () => {
+            return new Promise((resolve, reject) => {
 
-            let action = async (overwrite, rename) => {
-              try {
-                if (getters.isShare()) {
-                  await resourcesApi.moveCopyPublic(state.shareInfo.hash, items, operation, overwrite, rename);
-                } else {
-                  await resourcesApi.moveCopy(items, operation, overwrite, rename);
+              const action = async (overwrite, rename) => {
+                try {
+                  if (getters.isShare()) {
+                    await resourcesApi.moveCopyPublic(state.shareInfo.hash, items, operation, overwrite, rename);
+                  } else {
+                    await resourcesApi.moveCopy(items, operation, overwrite, rename);
+                  }
+                  if (operation === "move") {
+                    this.clipboard = { items: [] };
+                    this.internalClipboardTimestamp = 0;
+                  }
+                  mutations.setReload(true);
+                  resolve();
+                } catch (error) {
+                  console.error("Error moving/copying items:", error);
+                  reject(error);
                 }
-                if (operation === "move") {
-                  this.clipboard = { items: [] };
-                  this.internalClipboardTimestamp = 0;
-                }
-                mutations.setLoading("listing", false);
-              } catch (error) {
-                console.error("Error moving/copying items:", error);
-              } finally {
-                mutations.setLoading("listing", false);
-                mutations.setReload(true);
+              };
+
+              if (this.clipboard.path === state.route.path) {
+                action(false, true);
+                return;
               }
-            };
 
-            if (this.clipboard.path === state.route.path) {
-              action(false, true);
-              return;
-            }
+              const conflict = upload.checkConflict(items, state.req.items);
 
-            const conflict = upload.checkConflict(items, state.req.items);
-
-            if (conflict) {
-              mutations.showPrompt({
-                name: "replace-rename",
-                pinned: true,
-                confirm: (event, option) => {
-                  const overwrite = option === "overwrite";
-                  const rename = option === "rename";
-                  event.preventDefault();
-                  mutations.closeTopPrompt();
-                  action(overwrite, rename);
-                },
-              });
-              return;
-            }
-            action(false, false);
+              if (conflict) {
+                mutations.showPrompt({
+                  name: "replace-rename",
+                  pinned: true,
+                  confirm: (event, option) => {
+                    const overwrite = option === "overwrite";
+                    const rename = option === "rename";
+                    event.preventDefault();
+                    mutations.closeTopPrompt();
+                    action(overwrite, rename);
+                  },
+                });
+                return;
+              }
+              action(false, false);
+            });
           },
         },
       });


### PR DESCRIPTION
Should fix #2275.

Also when creating a folder if another file/folder with the same name exists, the backend wasn't returning the conflict error, so the conflict prompt wasn't working and was overwriting without ask. Fixed that too.