### PR TITLE
Add .devcontainer and fix 'make dev' startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+  "name": "filebrowser",
+  "image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
+  
+
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+
+  "containerEnv": {
+    "CGO_ENABLED": "1",
+    "FILEBROWSER_DEVMODE": "true"
+  },
+
+  "forwardPorts": [80],
+  "portsAttributes": {
+    "80": {
+      "label": "filebrowser app",
+      "onAutoForward": "notify"
+    }
+  },
+
+  "postCreateCommand": "make setup",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "Vue.volar",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  }
+}

--- a/backend/http/middleware.go
+++ b/backend/http/middleware.go
@@ -827,17 +827,14 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		duration := time.Since(start)
 
 		// Use the StatusCode from wrappedWriter, which might have been set to 500 by the recover logic
-		// Skip logging for '/health' endpoint
-		if r.URL.Path != "/health" {
-			logger.Api(wrappedWriter.StatusCode,
-				fmt.Sprintf("%-7s | %3d | %-15s | %-12s | %-12s | \"%s\"",
-					r.Method,
-					wrappedWriter.StatusCode,
-					getRemoteIP(r),
-					truncUser,
-					fmt.Sprintf("%vms", duration.Milliseconds()),
-					fullURL))
-		}
+		logger.Api(wrappedWriter.StatusCode,
+			fmt.Sprintf("%-7s | %3d | %-15s | %-12s | %-12s | \"%s\"",
+				r.Method,
+				wrappedWriter.StatusCode,
+				getRemoteIP(r),
+				truncUser,
+				fmt.Sprintf("%vms", duration.Milliseconds()),
+				fullURL))
 	})
 }
 

--- a/backend/http/middleware.go
+++ b/backend/http/middleware.go
@@ -827,14 +827,17 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		duration := time.Since(start)
 
 		// Use the StatusCode from wrappedWriter, which might have been set to 500 by the recover logic
-		logger.Api(wrappedWriter.StatusCode,
-			fmt.Sprintf("%-7s | %3d | %-15s | %-12s | %-12s | \"%s\"",
-				r.Method,
-				wrappedWriter.StatusCode,
-				getRemoteIP(r),
-				truncUser,
-				fmt.Sprintf("%vms", duration.Milliseconds()),
-				fullURL))
+		// Skip logging for '/health' endpoint
+		if r.URL.Path != "/health" {
+			logger.Api(wrappedWriter.StatusCode,
+				fmt.Sprintf("%-7s | %3d | %-15s | %-12s | %-12s | \"%s\"",
+					r.Method,
+					wrappedWriter.StatusCode,
+					getRemoteIP(r),
+					truncUser,
+					fmt.Sprintf("%vms", duration.Milliseconds()),
+					fullURL))
+		}
 	})
 }
 

--- a/makefile
+++ b/makefile
@@ -48,8 +48,8 @@ build-backend:
 # New dev target with hot-reloading for frontend and backend
 dev: generate-docs
 	@echo "Starting dev servers... Press Ctrl+C to stop."
-	pkill -f 'test_config.yaml' || true
-	pkill -f 'go tool air' || true
+	pkill -f '[t]est_config.yaml' || true
+	pkill -f '[g]o tool air' || true
 	@cd frontend && DEV_BUILD=true npm run watch & \
 	FRONTEND_PID=$$!; \
 	cd backend && export FILEBROWSER_DEVMODE=true && go tool air $$([ "$(OS)" = "Windows_NT" ] && echo "-c .air.windows.toml" || echo "") & \


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.

**Additional Details**

This PR adds:
* A .devcontainer file to simplify dev environment
* Fixes: https://github.com/gtsteffaniak/filebrowser/issues/2280
* Removed logging for `/health` endpoint so it does not clutter logs