### PR TITLE
Fix pwa icons url in manifest

### DIFF
--- a/backend/icons/manifest.go
+++ b/backend/icons/manifest.go
@@ -87,9 +87,9 @@ func InitializePWAManifest() {
 		pwaIcon256 = favicon
 		pwaIcon512 = favicon
 	} else if settings.Env.FaviconIsCustom {
-		pwaIcon192 = staticURL + "/icons/pwa-icon-192.png"
-		pwaIcon256 = staticURL + "/icons/pwa-icon-256.png"
-		pwaIcon512 = staticURL + "/icons/pwa-icon-512.png"
+		pwaIcon192 = staticURL + "/pwa-icon-192.png"
+		pwaIcon256 = staticURL + "/pwa-icon-256.png"
+		pwaIcon512 = staticURL + "/pwa-icon-512.png"
 	}
 
 	CachedManifest = generatePWAManifest(title, description, config.Server.BaseURL, defaultThemeColor, pwaIcon192, pwaIcon256, pwaIcon512)


### PR DESCRIPTION
**Description**
This PR fixes a path mismatch for the PWA icons. Currently, the web application attempts to fetch icons from /public/static/icons/, which results in a 404 Not Found error because the assets are actually located in the root of the static folder.

**Additional Details**
During debugging on my local instance, I noticed that the browser console and Docker logs reported 404 errors for:
https://domain.com/public/static/icons/pwa-icon-192.png

However, the file is successfully served at:
https://domain.com/public/static/pwa-icon-192.png

I am quite confident that the URLs in the manifest.json are pointing to an extra /icons/ subfolder that doesn't exist in the current build structure. This PR adjusts the paths to match the actual file location.
