### PR TITLE
fix logout and closing of profile settings in shares + other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. For commit guidelines, please refer to [Standard Version](https://github.com/conventional-changelog/standard-version).
 
+## v1.4.2
+
+ **BugFixes**:
+ - Logout from share page now redirects to the share instead of `/Login` again. (#2245)
+ - `This location cannot be reached` error when navigating with FileTree in shares. (#2245)
+ - Fix FileTree rename and move actions in previews. (#2245)
+ - Delete prompt not showing date and thumbnails in some previews. (#2245)
+
 ## v1.4.1
 
  **Security**:

--- a/frontend/src/components/Action.vue
+++ b/frontend/src/components/Action.vue
@@ -58,27 +58,7 @@ export default {
       return getters.currentView();
     }
   },
-  mounted() {
-    this.reEvalAction();
-  },
-  watch: {
-    $route() {
-      this.reEvalAction();
-    },
-    req() {
-      this.reEvalAction();
-    },
-    currentView() {
-      this.reEvalAction();
-    },
-  },
   methods: {
-    reEvalAction() {
-      const currentView = getters.currentView();
-      if (currentView == "settings") {
-        mutations.setActiveSettingsView(getters.currentHash());
-      }
-    },
     actionMultiIcon() {
       if (this.show) {
         mutations.closeHovers();

--- a/frontend/src/components/ContextMenu.vue
+++ b/frontend/src/components/ContextMenu.vue
@@ -506,7 +506,7 @@ export default {
     },
     goToItem() {
       const item = this.firstSelected;
-      url.goToItem(item.source, item.path, {}, true);
+      url.goToItem(item.source, item.path, {}, true, getters.isShare());
       mutations.closeHovers();
     },
     hideTooltip() {

--- a/frontend/src/components/files/Breadcrumbs.vue
+++ b/frontend/src/components/files/Breadcrumbs.vue
@@ -280,7 +280,7 @@ export default {
           }
 
           const buttonAction = () => {
-            url.goToItem(source, targetPath, {});
+            url.goToItem(source, targetPath, {}, false, getters.isShare());
           };
 
           notify.showSuccess(this.$t("prompts.moveSuccess"), {

--- a/frontend/src/components/files/FileList.vue
+++ b/frontend/src/components/files/FileList.vue
@@ -426,11 +426,6 @@ export default {
       event.preventDefault();
       event.stopPropagation();
 
-      // Double click: navigate (into folder or open file)
-      if (this.isDisplayMode) {
-        this.navigateToItem(item);
-        return;
-      }
       const syntheticEvent = {
         currentTarget: {
           dataset: {
@@ -523,7 +518,9 @@ export default {
     navigateToItem(item) {
       mutations.closeTopPrompt();
       mutations.setNavigationTransitioning(true);
-      url.goToItem(item.source || state.req.source, item.path, undefined, false, getters.isShare);
+      const isShare = !!(this.browseShare) || getters.isShare();
+      const source = isShare ? (state.shareInfo?.hash) : (item.source || state.req.source);
+      url.goToItem(source, item.path, undefined, false, isShare);
     },
   },
 };

--- a/frontend/src/components/files/FileList.vue
+++ b/frontend/src/components/files/FileList.vue
@@ -317,8 +317,8 @@ export default {
         });
       }
 
-      // If this folder is empty, finish here.
-      if (req.items === null) return;
+      // If this folder has no items or items is not an array, finish here.
+      if (!req.items || !Array.isArray(req.items)) return;
       for (let item of req.items) {
         if (!this.showFolders && item.type === "directory") continue;
         if (!this.showFiles && item.type !== "directory") continue;

--- a/frontend/src/components/files/FileList.vue
+++ b/frontend/src/components/files/FileList.vue
@@ -523,7 +523,7 @@ export default {
     navigateToItem(item) {
       mutations.closeTopPrompt();
       mutations.setNavigationTransitioning(true);
-      url.goToItem(item.source || state.req.source, item.path, undefined);
+      url.goToItem(item.source || state.req.source, item.path, undefined, false, getters.isShare);
     },
   },
 };

--- a/frontend/src/components/files/FileTree.vue
+++ b/frontend/src/components/files/FileTree.vue
@@ -345,7 +345,7 @@ export default {
     navigateTo(node) {
       if (this.isShare) {
         mutations.setNavigationTransitioning(true);
-        goToItem(this.shareHash, node.path, {});
+        goToItem(this.shareHash, node.path, {}, false, true);
       } else {
         mutations.setNavigationTransitioning(true);
         goToItem(this.currentSource, node.path, {});
@@ -589,7 +589,7 @@ export default {
           }
           const buttonAction = () => {
             if (this.isShare) {
-              goToItem(null, node.path, {}, false, this.shareHash);
+              goToItem(null, node.path, {}, false, true);
             } else {
               goToItem(this.currentSource, node.path, {});
             }

--- a/frontend/src/components/files/FileTree.vue
+++ b/frontend/src/components/files/FileTree.vue
@@ -214,6 +214,7 @@ export default {
   },
   methods: {
     async loadRoot() {
+      if (this.expanding) return;
       this.error = null;
       this.rootLoaded = false;
       if ((!this.currentSource && !this.shareHash) || !this.isRootInstance) {
@@ -303,7 +304,7 @@ export default {
     },
 
     async tryExpandNodes() {
-      if (!this.rootLoaded || !this.pendingExpandPath) return;
+      if (this.expanding || !this.rootLoaded || !this.pendingExpandPath) return;
       await this.expandToPath(this.pendingExpandPath);
       this.pendingExpandPath = null;
     },
@@ -349,11 +350,18 @@ export default {
       }
     },
 
+    normalizePath(p) {
+      if (!p || p === '/') return '/';
+      return p.replace(/\/+$/, '');
+    },
+
     isCurrentItem(node) {
+      const normalizedNodePath = this.normalizePath(node.path);
+      const normalizedCurrentPath = this.normalizePath(this.currentPath);
       if (this.isShare) {
-        return node.path === this.currentPath;
+        return normalizedNodePath === normalizedCurrentPath;
       } else {
-        return node.source === this.currentSource && node.path === this.currentPath;
+        return node.source === this.currentSource && normalizedNodePath === normalizedCurrentPath;
       }
     },
 
@@ -398,7 +406,7 @@ export default {
     },
 
     async refresh() {
-      if (!this.isRootInstance || this.isRefreshing) return;
+      if (!this.isRootInstance || this.isRefreshing || this.expanding) return;
       this.isRefreshing = true;
       this.expandTimeouts.clear();
       // Save expanded paths before reload to restore them
@@ -537,13 +545,8 @@ export default {
 
       if (items.length === 0) return;
 
-      // We'll use the same logic as Breadcrumbs
-      const normalizePath = (path) => {
-        if (!path || path === "/") return "/";
-        return path.replace(/\/$/, '');
-      };
-      const targetDir = normalizePath(node.path);
-      const sourceDir = normalizePath(state.req.path);
+      const targetDir = this.normalizePath(node.path);
+      const sourceDir = this.normalizePath(state.req.path);
       if (targetDir === sourceDir) {
         notify.showErrorToast(this.$t("files.sameFolder"));
         return;

--- a/frontend/src/components/files/FileTree.vue
+++ b/frontend/src/components/files/FileTree.vue
@@ -342,7 +342,7 @@ export default {
     navigateTo(node) {
       if (this.isShare) {
         mutations.setNavigationTransitioning(true);
-        goToItem(null, node.path, {}, false, this.shareHash);
+        goToItem(this.shareHash, node.path, {});
       } else {
         mutations.setNavigationTransitioning(true);
         goToItem(this.currentSource, node.path, {});

--- a/frontend/src/components/files/FileTree.vue
+++ b/frontend/src/components/files/FileTree.vue
@@ -589,7 +589,7 @@ export default {
           }
           const buttonAction = () => {
             if (this.isShare) {
-              goToItem(null, node.path, {}, false, true);
+              goToItem(this.shareHash, node.path, {}, false, true);
             } else {
               goToItem(this.currentSource, node.path, {});
             }

--- a/frontend/src/components/files/FileTree.vue
+++ b/frontend/src/components/files/FileTree.vue
@@ -199,6 +199,7 @@ export default {
     );
     eventBus.on('itemsDeleted', this.refresh);
     eventBus.on('itemsRenamed', this.refresh);
+    eventBus.on('itemsMoved', this.refresh);
     window.addEventListener('dragend', this.clearAllDragStates);
   },
   beforeUnmount() {
@@ -210,6 +211,7 @@ export default {
     }
     eventBus.off('itemsDeleted', this.refresh);
     eventBus.off('itemsRenamed', this.refresh);
+    eventBus.off('itemsMoved', this.refresh);
     window.removeEventListener('dragend', this.clearAllDragStates);
   },
   methods: {
@@ -406,7 +408,7 @@ export default {
     },
 
     async refresh() {
-      if (!this.isRootInstance || this.isRefreshing || this.expanding) return;
+      if (!this.isRootInstance || this.isRefreshing ) return;
       this.isRefreshing = true;
       this.expandTimeouts.clear();
       // Save expanded paths before reload to restore them

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -809,7 +809,7 @@ export default {
           path: state.req.path,
         };
       }
-      url.goToItem(this.source, this.path, previousHistoryItem || {});
+      url.goToItem(this.source, this.path, previousHistoryItem || {}, false, getters.isShare());
     },
   },
 };

--- a/frontend/src/components/files/nextPrevious.vue
+++ b/frontend/src/components/files/nextPrevious.vue
@@ -506,6 +506,8 @@ export default {
           state.previousHistoryItem.source,
           state.previousHistoryItem.path,
           state.previousHistoryItem,
+          false,
+          state.previousHistoryItem.isShare
         );
         return;
       }

--- a/frontend/src/components/prompts/Archive.vue
+++ b/frontend/src/components/prompts/Archive.vue
@@ -200,7 +200,7 @@ export default {
         const archivePath = dest;
         const buttonAction = () => {
           if (archivePath) {
-            goToItem(destSource || null, archivePath, {});
+            goToItem(destSource || null, archivePath, {}, false, getters.isShare());
           }
         };
         notify.showSuccess(this.$t("prompts.archiveSuccess"), {

--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -264,13 +264,13 @@ export default {
               mutations.setNavigationTransitioning(true);
               // Try next, then previous, then parent directory
               if (state.navigation.nextItem) {
-                url.goToItem(state.navigation.nextItem.source, state.navigation.nextItem.path, undefined);
+                url.goToItem(state.navigation.nextItem.source, state.navigation.nextItem.path, undefined, false, getters.isShare());
               } else if (state.navigation.previousItem) {
-                url.goToItem(state.navigation.previousItem.source, state.navigation.previousItem.path, undefined);
+                url.goToItem(state.navigation.previousItem.source, state.navigation.previousItem.path, undefined, false, getters.isShare());
               } else {
                 // Navigate to parent directory of deleted item
                 const parentPath = url.removeLastDir(deletedItem.path);
-                url.goToItem(deletedItem.source, parentPath, {});
+                url.goToItem(deletedItem.source, parentPath, {}, false, getters.isShare());
               }
             } else {
               mutations.setReload(true);
@@ -281,7 +281,7 @@ export default {
               const deletedItem = this.itemsToDelete[0];
               if (deletedItem.type === 'directory' && deletedItem.path === state.req.path) {
                 const parentPath = url.removeLastDir(deletedItem.path);
-                url.goToItem(deletedItem.source, parentPath, {});
+                url.goToItem(deletedItem.source, parentPath, {}, false, getters.isShare());
                 this.deleting = false;
                 return; // return early to avoid extra reload (and 404)
               }

--- a/frontend/src/components/prompts/MoveCopy.vue
+++ b/frontend/src/components/prompts/MoveCopy.vue
@@ -371,11 +371,11 @@ export default {
           const next = state.navigation.nextItem;
           const prev = state.navigation.previousItem;
           if (next) {
-            url.goToItem(next.source, next.path, undefined);
+            url.goToItem(next.source, next.path, undefined, false, getters.isShare());
           } else if (prev) {
-            url.goToItem(prev.source, prev.path, undefined);
+            url.goToItem(prev.source, prev.path, undefined, false, getters.isShare());
           } else {
-            url.goToItem(state.req.source, url.removeLastDir(state.req.path), {});
+            url.goToItem(state.req.source, url.removeLastDir(state.req.path), {}, false, getters.isShare());
           }
         } else {
 
@@ -395,9 +395,7 @@ export default {
             // For shares, destSource might be null, but goToItem handles shares via state.shareInfo.hash
             const buttonAction = () => {
               if (destPath) {
-                // For shares, goToItem will use state.shareInfo.hash, so source can be null
-                // For regular files, destSource should be set
-                goToItem(destSource || null, destPath, {});
+                goToItem(destSource || state.shareInfo?.hash, destPath, {}, false, getters.isShare());
               }
             };
             const buttonProps = {

--- a/frontend/src/components/prompts/MoveCopy.vue
+++ b/frontend/src/components/prompts/MoveCopy.vue
@@ -62,6 +62,7 @@ import { notify } from "@/notify";
 import { goToItem } from "@/utils/url";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import PathPickerButton from "@/components/files/PathPickerButton.vue";
+import { eventBus } from '@/store/eventBus';
 
 export default {
   name: "move-copy",
@@ -347,41 +348,73 @@ export default {
           );
         }
 
-        // Only close prompts and reload on success (or partial success)
-        mutations.setReload(true);
-        mutations.closeTopPrompt(); // close conflict prompt
-        mutations.closeTopPrompt(); // close moveCopy prompt after conflict is resolved and file copied/moved
-        mutations.setSearch(false); // close search if open
+        // Determine if we should navigate (we can move items with fileTree context menu in previews)
+        const shouldNavigate = getters.isPreviewView() && this.operation === 'move';
+        let currentItemMoved = false;
 
-        // Only show success notification if there were no failures (or partial success was already shown)
-        if (!hasFailures || hasSuccesses) {
-          // Store destination info for the button action
-          const destSource = this.destSource;
-          const destPath = this.destPath;
+        if (shouldNavigate) {
+          currentItemMoved = this.localItems.some(item =>
+            item.from === state.req?.path && item.fromSource === state.req?.source
+          );
+        }
 
-          // Show success notification with optional button to navigate to destination
-          // For shares, destSource might be null, but goToItem handles shares via state.shareInfo.hash
-          const buttonAction = () => {
-            if (destPath) {
-              // For shares, goToItem will use state.shareInfo.hash, so source can be null
-              // For regular files, destSource should be set
-              goToItem(destSource || null, destPath, {});
-            }
-          };
-          const buttonProps = {
-            icon: "folder",
-            buttons: destPath ? [
-              {
-                label: this.$t("buttons.goToItem"),
-                primary: true,
-                action: buttonAction
-              }
-            ] : undefined
-          };
-          if (this.operation === "move") {
-            notify.showSuccess(this.$t("prompts.moveSuccess"), buttonProps);
+        if (shouldNavigate && currentItemMoved) {
+          eventBus.emit('itemsMoved');
+          mutations.closeTopPrompt(); // close conflict prompt
+          mutations.closeTopPrompt(); // close moveCopy prompt
+
+          if (!hasFailures || hasSuccesses) {
+            notify.showSuccessToast(this.$t("prompts.moveSuccess"));
+          }
+
+          // Navigate next, previous or parent dir (like when deleting)
+          const next = state.navigation.nextItem;
+          const prev = state.navigation.previousItem;
+          if (next) {
+            url.goToItem(next.source, next.path, undefined);
+          } else if (prev) {
+            url.goToItem(prev.source, prev.path, undefined);
           } else {
-            notify.showSuccess(this.$t("prompts.copySuccess"), buttonProps);
+            url.goToItem(state.req.source, url.removeLastDir(state.req.path), {});
+          }
+        } else {
+
+          // Only close prompts and reload on success (or partial success)
+          mutations.setReload(true);
+          mutations.closeTopPrompt(); // close conflict prompt
+          mutations.closeTopPrompt(); // close moveCopy prompt after conflict is resolved and file copied/moved
+          mutations.setSearch(false); // close search if open
+
+          // Only show success notification if there were no failures (or partial success was already shown)
+          if (!hasFailures || hasSuccesses) {
+            // Store destination info for the button action
+            const destSource = this.destSource;
+            const destPath = this.destPath;
+
+            // Show success notification with optional button to navigate to destination
+            // For shares, destSource might be null, but goToItem handles shares via state.shareInfo.hash
+            const buttonAction = () => {
+              if (destPath) {
+                // For shares, goToItem will use state.shareInfo.hash, so source can be null
+                // For regular files, destSource should be set
+                goToItem(destSource || null, destPath, {});
+              }
+            };
+            const buttonProps = {
+              icon: "folder",
+              buttons: destPath ? [
+                {
+                  label: this.$t("buttons.goToItem"),
+                  primary: true,
+                  action: buttonAction
+                }
+              ] : undefined
+            };
+            if (this.operation === "move") {
+              notify.showSuccess(this.$t("prompts.moveSuccess"), buttonProps);
+            } else {
+              notify.showSuccess(this.$t("prompts.copySuccess"), buttonProps);
+            }
           }
         }
       } catch (error) {

--- a/frontend/src/components/prompts/NewDir.vue
+++ b/frontend/src/components/prompts/NewDir.vue
@@ -103,6 +103,21 @@ export default {
       }
     },
 
+    showNotification(source, newPath) {
+      const buttonAction = () => {
+        url.goToItem(source, newPath, {}, false, getters.isShare());
+      };
+      const buttonProps = {
+        icon: "folder",
+        buttons: [{
+          label: this.$t("buttons.goToItem"),
+          primary: true,
+          action: buttonAction
+        }]
+      };
+      notify.showSuccess(this.$t("prompts.newDirSuccess"), buttonProps);
+    },
+
     async createDirectory(overwrite = false) {
       this.creating = true;
       try {
@@ -115,25 +130,16 @@ export default {
           mutations.setReload(true);
           mutations.closeTopPrompt();
           this.creating = false;
+          // Show notification for shares
+          this.showNotification(state.shareInfo?.hash, newPath);
           return;
         }
         await resourcesApi.post(source, newPath, "", overwrite, undefined, {}, true);
         mutations.setReload(true);
         mutations.closeTopPrompt();
 
-        // Show success notification with "go to item" button
-        const buttonAction = () => {
-          url.goToItem(source, newPath, {});
-        };
-        const buttonProps = {
-          icon: "folder",
-          buttons: [{
-            label: this.$t("buttons.goToItem"),
-            primary: true,
-            action: buttonAction
-          }]
-        };
-        notify.showSuccess(this.$t("prompts.newDirSuccess"), buttonProps);
+        // Show notification
+        this.showNotification(source, newPath);
         this.creating = false;
       } catch (error) {
         if (error.message === "conflict") {
@@ -164,6 +170,8 @@ export default {
                         mutations.closeTopPrompt(); // close conflict prompt
                         mutations.closeTopPrompt(); // close new dir prompt
                         success = true;
+                        // Show notification for shares after rename
+                        this.showNotification(state.shareInfo?.hash, newPath);
                         return;
                       }
                       await resourcesApi.post(source, newPath, "", false, undefined, {}, true);
@@ -172,19 +180,8 @@ export default {
                       mutations.closeTopPrompt(); // close new dir prompt
                       success = true;
 
-                      // Show success notification with "go to item" button
-                      const buttonAction = () => {
-                        url.goToItem(source, newPath, {}, false, getters.isShare());
-                      };
-                      const buttonProps = {
-                        icon: "folder",
-                        buttons: [{
-                          label: this.$t("buttons.goToItem"),
-                          primary: true,
-                          action: buttonAction
-                        }]
-                      };
-                      notify.showSuccess(this.$t("prompts.newDirSuccess"), buttonProps);
+                      // Show notification
+                      this.showNotification(source, newPath);
                     } catch (renameError) {
                       if (renameError.message === "conflict") {
                         // Continue to next iteration

--- a/frontend/src/components/prompts/NewDir.vue
+++ b/frontend/src/components/prompts/NewDir.vue
@@ -174,7 +174,7 @@ export default {
 
                       // Show success notification with "go to item" button
                       const buttonAction = () => {
-                        url.goToItem(source, newPath, {});
+                        url.goToItem(source, newPath, {}, false, getters.isShare());
                       };
                       const buttonProps = {
                         icon: "folder",

--- a/frontend/src/components/prompts/NewFile.vue
+++ b/frontend/src/components/prompts/NewFile.vue
@@ -100,6 +100,21 @@ export default {
       }
     },
 
+    showNotification(source, newPath) {
+      const buttonAction = () => {
+        url.goToItem(source, newPath, {}, false, getters.isShare());
+      };
+      const buttonProps = {
+        icon: "insert_drive_file",
+        buttons: [{
+          label: this.$t("buttons.goToItem"),
+          primary: true,
+          action: buttonAction
+        }]
+      };
+      notify.showSuccess(this.$t("prompts.newFileSuccess"), buttonProps);
+    },
+
     async createFile(overwrite = false) {
       this.creating = true;
       try {
@@ -112,25 +127,16 @@ export default {
           mutations.setReload(true);
           mutations.closeTopPrompt();
           this.creating = false;
+          // Show notification for shares
+          this.showNotification(state.shareInfo?.hash, newPath);
           return;
         }
         await resourcesApi.post(source, newPath, "", overwrite);
         mutations.setReload(true);
         mutations.closeTopPrompt();
 
-        // Show success notification with "go to item" button
-        const buttonAction = () => {
-          url.goToItem(source, newPath, {}, false, getters.isShare());
-        };
-        const buttonProps = {
-          icon: "insert_drive_file",
-          buttons: [{
-            label: this.$t("buttons.goToItem"),
-            primary: true,
-            action: buttonAction
-          }]
-        };
-        notify.showSuccess(this.$t("prompts.newFileSuccess"), buttonProps);
+        // Show notification
+        this.showNotification(source, newPath);
         this.creating = false;
       } catch (error) {
         if (error.message === "conflict") {
@@ -161,6 +167,8 @@ export default {
                         mutations.closeTopPrompt(); // close conflict prompt
                         mutations.closeTopPrompt(); // close new file prompt
                         success = true;
+                        // Show notification for shares after rename
+                        this.showNotification(state.shareInfo?.hash, newPath);
                         return;
                       }
                       await resourcesApi.post(source, newPath, "", false);
@@ -169,19 +177,8 @@ export default {
                       mutations.closeTopPrompt(); // close new file prompt
                       success = true;
 
-                      // Show success notification with "go to item" button
-                      const buttonAction = () => {
-                        url.goToItem(source, newPath, {}, false, getters.isShare());
-                      };
-                      const buttonProps = {
-                        icon: "insert_drive_file",
-                        buttons: [{
-                          label: this.$t("buttons.goToItem"),
-                          primary: true,
-                          action: buttonAction
-                        }]
-                      };
-                      notify.showSuccess(this.$t("prompts.newFileSuccess"), buttonProps);
+                      // Show notification
+                      this.showNotification(source, newPath);
                     } catch (renameError) {
                       if (renameError.message === "conflict") {
                         // Continue to next iteration

--- a/frontend/src/components/prompts/NewFile.vue
+++ b/frontend/src/components/prompts/NewFile.vue
@@ -120,7 +120,7 @@ export default {
 
         // Show success notification with "go to item" button
         const buttonAction = () => {
-          url.goToItem(source, newPath, {});
+          url.goToItem(source, newPath, {}, false, getters.isShare());
         };
         const buttonProps = {
           icon: "insert_drive_file",
@@ -171,7 +171,7 @@ export default {
 
                       // Show success notification with "go to item" button
                       const buttonAction = () => {
-                        url.goToItem(source, newPath, {});
+                        url.goToItem(source, newPath, {}, false, getters.isShare());
                       };
                       const buttonProps = {
                         icon: "insert_drive_file",

--- a/frontend/src/components/prompts/PlaybackQueue.vue
+++ b/frontend/src/components/prompts/PlaybackQueue.vue
@@ -195,7 +195,7 @@ export default {
       }
     },
     triggerNavigation(item) {
-      url.goToItem( item.source || state.req.source, item.path, undefined );
+      url.goToItem(item.source || state.req.source, item.path, undefined, false, getters.isShare());
     },
     scrollToCurrentItem() {
       if (this.queueCount === 0) return;

--- a/frontend/src/components/prompts/PlaybackQueue.vue
+++ b/frontend/src/components/prompts/PlaybackQueue.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script>
-import { state, mutations } from "@/store";
+import { state, mutations, getters } from "@/store";
 import { url } from "@/utils";
 export default {
   name: "PlaybackQueue",

--- a/frontend/src/components/prompts/Rename.vue
+++ b/frontend/src/components/prompts/Rename.vue
@@ -218,7 +218,7 @@ export default {
         if (this.isPreviewView) {
           // Navigate only if we rename the file that we're currently previewing (eg: from fileTree)
           if (this.item.path === state.req?.path && this.item.source === state.req?.source) {
-            url.goToItem(this.item.source, newPath, undefined); // When undefined will not create browser history
+            url.goToItem(this.item.source, newPath, undefined, false, getters.isShare()); // When undefined will not create browser history
           } else {
             mutations.setReload(true);
           }

--- a/frontend/src/components/prompts/Rename.vue
+++ b/frontend/src/components/prompts/Rename.vue
@@ -217,8 +217,19 @@ export default {
 
         if (this.isPreviewView) {
           // Navigate only if we rename the file that we're currently previewing (eg: from fileTree)
-          if (this.item.path === state.req?.path && this.item.source === state.req?.source) {
-            url.goToItem(this.item.source, newPath, undefined, false, getters.isShare()); // When undefined will not create browser history
+          const normalizePath = (p) => (p || '').replace(/^\/+|\/+$/g, '');
+          const currentReqPath = normalizePath(state.req?.path);
+          const oldItemPath = normalizePath(this.item.path);
+          
+          // For shares compare path and for regulars compare both path and source
+          const isCurrentItem = getters.isShare()
+            ? currentReqPath === oldItemPath
+            : (currentReqPath === oldItemPath && this.item.source === state.req?.source);
+          
+          if (isCurrentItem) {
+            // Navigate to the renamed file
+            const source = getters.isShare() ? state.shareInfo.hash : this.item.source;
+            url.goToItem(source, newPath, undefined, false, getters.isShare()); // When undefined will not create browser history
           } else {
             mutations.setReload(true);
           }

--- a/frontend/src/components/prompts/Rename.vue
+++ b/frontend/src/components/prompts/Rename.vue
@@ -183,6 +183,9 @@ export default {
 
       return { valid: true };
     },
+    normalizePath(p) {
+      return (p || '').replace(/^\/+|\/+$/g, '');
+    },
     async submit() {
       // remove trailing slashes
       if (this.name.endsWith("/") || this.name.endsWith("\\")) {
@@ -217,9 +220,8 @@ export default {
 
         if (this.isPreviewView) {
           // Navigate only if we rename the file that we're currently previewing (eg: from fileTree)
-          const normalizePath = (p) => (p || '').replace(/^\/+|\/+$/g, '');
-          const currentReqPath = normalizePath(state.req?.path);
-          const oldItemPath = normalizePath(this.item.path);
+          const currentReqPath = this.normalizePath(state.req?.path);
+          const oldItemPath = this.normalizePath(this.item.path);
           
           // For shares compare path and for regulars compare both path and source
           const isCurrentItem = getters.isShare()

--- a/frontend/src/components/prompts/Rename.vue
+++ b/frontend/src/components/prompts/Rename.vue
@@ -216,7 +216,12 @@ export default {
         mutations.closeTopPrompt();
 
         if (this.isPreviewView) {
-          url.goToItem(this.item.source, newPath, undefined); // When undefined will not create browser history
+          // Navigate only if we rename the file that we're currently previewing (eg: from fileTree)
+          if (this.item.path === state.req?.path && this.item.source === state.req?.source) {
+            url.goToItem(this.item.source, newPath, undefined); // When undefined will not create browser history
+          } else {
+            mutations.setReload(true);
+          }
         } else {
           mutations.setReload(true);
         }

--- a/frontend/src/components/prompts/Unarchive.vue
+++ b/frontend/src/components/prompts/Unarchive.vue
@@ -158,7 +158,7 @@ export default {
 
         const destPath = this.destPath;
         const destSource = toSource;
-        const buttonAction = () => destPath && goToItem(destSource, destPath, {});
+        const buttonAction = () => destPath && goToItem(destSource || state.shareInfo?.hash, destPath, {}, false, getters.isShare());
         notify.showSuccess(this.$t("prompts.unarchiveSuccess"), {
           icon: "folder",
           buttons: destPath ? [{ label: this.$t("buttons.goToItem"), primary: true, action: buttonAction }] : undefined,

--- a/frontend/src/components/sidebar/General.vue
+++ b/frontend/src/components/sidebar/General.vue
@@ -76,7 +76,7 @@ import * as auth from "@/utils/auth";
 import { globalVars } from "@/utils/constants";
 import { state, getters, mutations } from "@/store";
 import SidebarLinks from "./Links.vue";
-import { url } from "@/utils"; 
+import { url } from "@/utils";
 
 export default {
   name: "SidebarGeneral",
@@ -172,6 +172,7 @@ export default {
         name: state.req.name,
         source: state.req.source,
         path: state.req.path,
+        isShare: getters.isShare()
       });
       this.$router.push({ path: path, hash: hash });
       mutations.closeTopPrompt();
@@ -194,7 +195,7 @@ export default {
         const subPath = state.req?.path && state.req.path !== '/'
           ? url.removeLeadingSlash(state.req.path)
           : '';
-        sharePath = subPath ? `${shareBase}/${subPath}` : shareBase;
+        sharePath = subPath ? `${shareBase}/${url.encodedPath(subPath)}` : shareBase;
       }
       await auth.logout();
       window.location.href = sharePath || '/login';

--- a/frontend/src/components/sidebar/General.vue
+++ b/frontend/src/components/sidebar/General.vue
@@ -76,6 +76,7 @@ import * as auth from "@/utils/auth";
 import { globalVars } from "@/utils/constants";
 import { state, getters, mutations } from "@/store";
 import SidebarLinks from "./Links.vue";
+import { url } from "@/utils"; 
 
 export default {
   name: "SidebarGeneral",
@@ -184,7 +185,20 @@ export default {
     },
 
     // Logout the user
-    logout: auth.logout,
+    async logout() {
+      const isShare = getters.isShare();
+      let sharePath;
+
+      if (isShare && state.shareInfo?.hash) {
+        const shareBase = `/public/share/${state.shareInfo.hash}`;
+        const subPath = state.req?.path && state.req.path !== '/'
+          ? url.removeLeadingSlash(state.req.path)
+          : '';
+        sharePath = subPath ? `${shareBase}/${subPath}` : shareBase;
+      }
+      await auth.logout();
+      window.location.href = sharePath || '/login';
+    },
     beforeEnter(el) {
       el.style.maxHeight = '0';
       el.style.opacity = '0';

--- a/frontend/src/components/sidebar/Links.vue
+++ b/frontend/src/components/sidebar/Links.vue
@@ -450,7 +450,7 @@ export default {
         // For source links, use sourceName and target (relative path)
         if (!link.sourceName) return;
         const path = link.target || "/";
-        goToItem(link.sourceName, path, {});
+        goToItem(link.sourceName, path, {}, false, false);
         return;
       }
 
@@ -609,7 +609,7 @@ export default {
       this.navigateToSource(sourceName);
     },
     navigateToSource(sourceName) {
-      goToItem(sourceName, '/', {});
+      goToItem(sourceName, '/', {}, false, false);
     },
     closeDropdown(event) {
       if (!this.showSourceDropdown) return;

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -18,6 +18,7 @@ export interface ReqObject {
   source?: string;
   content?: string;
   modified?: string;
+  hasPreview?: string;
   subtitles?: any[];
 
   // Directory listing properties

--- a/frontend/src/utils/url.js
+++ b/frontend/src/utils/url.js
@@ -215,8 +215,7 @@ export function goToItem(source, path, previousHistoryItem, newTab = false, isSh
   mutations.resetAll()
   let newPath = encodedPath(path);
   let fullPath;
-  const share = isShare || getters.isShare();
-  if (share) {
+  if (isShare) {
     fullPath = `/public/share/${encodeURIComponent(source)}${newPath}`;
   } else {
     fullPath = `/files/${encodeURIComponent(source)}${newPath}`;

--- a/frontend/src/utils/url.js
+++ b/frontend/src/utils/url.js
@@ -205,7 +205,7 @@ export function encodedPath(path) {
 }
 
 // assume non-encoded input path and source
-export function goToItem(source, path, previousHistoryItem, newTab = false) {
+export function goToItem(source, path, previousHistoryItem, newTab = false, isShare = false) {
   const cv = getters.currentView();
   if (source === state.sources.current && path === state.req.path && cv === "listingView") {
     return;
@@ -215,9 +215,12 @@ export function goToItem(source, path, previousHistoryItem, newTab = false) {
   }
   mutations.resetAll()
   let newPath = encodedPath(path);
-  let fullPath = `/files/${encodeURIComponent(source)}${newPath}`;
-  if (getters.isShare()) {
-    fullPath = `/public/share/${source}${newPath}`;
+  let fullPath;
+  const share = isShare || getters.isShare();
+  if (share) {
+    fullPath = `/public/share/${encodeURIComponent(source)}${newPath}`;
+  } else {
+    fullPath = `/files/${encodeURIComponent(source)}${newPath}`;
   }
   if (newTab) {
     // Use absolute URL for new tab to ensure proper navigation

--- a/frontend/src/utils/url.js
+++ b/frontend/src/utils/url.js
@@ -210,7 +210,7 @@ export function goToItem(source, path, previousHistoryItem, newTab = false) {
   if (source === state.sources.current && path === state.req.path && cv === "listingView") {
     return;
   }
-  if (previousHistoryItem && cv === "listingView`") {
+  if (previousHistoryItem && cv === "listingView") {
     mutations.setPreviousHistoryItem(previousHistoryItem);
   }
   mutations.resetAll()

--- a/frontend/src/utils/url.js
+++ b/frontend/src/utils/url.js
@@ -198,10 +198,7 @@ export function encodedPath(path) {
   if (path === undefined) {
     return "";
   }
-  // Normalize Windows backslashes to forward slashes
-  const normalized = path.replace(/\\/g, '/');
-  // break apart path into parts and url encode each part
-  const parts = normalized.split("/");
+  const parts = path.split("/");
   const encodedParts = parts.map(part => encodeURIComponent(part));
   return encodedParts.join("/").replace("//", "/");
 }

--- a/frontend/src/utils/url.js
+++ b/frontend/src/utils/url.js
@@ -198,8 +198,10 @@ export function encodedPath(path) {
   if (path === undefined) {
     return "";
   }
+  // Normalize Windows backslashes to forward slashes
+  const normalized = path.replace(/\\/g, '/');
   // break apart path into parts and url encode each part
-  const parts = path.split("/");
+  const parts = normalized.split("/");
   const encodedParts = parts.map(part => encodeURIComponent(part));
   return encodedParts.join("/").replace("//", "/");
 }

--- a/frontend/src/views/bars/Default.vue
+++ b/frontend/src/views/bars/Default.vue
@@ -270,15 +270,16 @@ export default {
             return;
           }
           if (state.shareInfo?.hash && state.req?.source === state.shareInfo.hash) {
-            url.goToItem(state.shareInfo.hash, state.req.path);
+            url.goToItem(state.shareInfo.hash, state.req.path, {}, false, true);
             return;
           }
+          // otherwise navigate to files
           router.push({ path: "/files" });
           return;
         }
         if (getters.isPreviewView()) {
           if (state.previousHistoryItem?.name) {
-            url.goToItem(state.previousHistoryItem.source, state.previousHistoryItem.path, state.previousHistoryItem);
+            url.goToItem(state.previousHistoryItem.source, state.previousHistoryItem.path, state.previousHistoryItem, false, state.previousHistoryItem.isShare);
             return;
           } else {
             // navigate to parent directory of current url

--- a/frontend/src/views/bars/Default.vue
+++ b/frontend/src/views/bars/Default.vue
@@ -261,7 +261,7 @@ export default {
         if (cv === "settings") {
           if (state.previousHistoryItem?.name) {
             if (state.previousHistoryItem.isShare) {
-              const sharePath = `/public/share/${state.previousHistoryItem.source}${state.previousHistoryItem.path}`;
+              const sharePath = `/public/share/${state.previousHistoryItem.source}${url.encodedPath(state.previousHistoryItem.path)}`;
               router.push({ path: sharePath });
             } else {
               url.goToItem(state.previousHistoryItem.source, state.previousHistoryItem.path, state.previousHistoryItem);
@@ -269,7 +269,7 @@ export default {
             return;
           }
           if (state.shareInfo?.hash && state.req?.source === state.shareInfo.hash) {
-            const sharePath = `/public/share/${state.shareInfo.hash}${state.req.path || ''}`;
+            const sharePath = `/public/share/${state.shareInfo.hash}${url.encodedPath(state.req.path || '')}`;
             router.push({ path: sharePath });
             return;
           }

--- a/frontend/src/views/bars/Default.vue
+++ b/frontend/src/views/bars/Default.vue
@@ -260,17 +260,17 @@ export default {
         mutations.closeHovers();
         if (cv === "settings") {
           if (state.previousHistoryItem?.name) {
-            if (state.previousHistoryItem.isShare) {
-              const sharePath = `/public/share/${state.previousHistoryItem.source}${url.encodedPath(state.previousHistoryItem.path)}`;
-              router.push({ path: sharePath });
-            } else {
-              url.goToItem(state.previousHistoryItem.source, state.previousHistoryItem.path, state.previousHistoryItem);
-            }
+            url.goToItem(
+              state.previousHistoryItem.source,
+              state.previousHistoryItem.path,
+              state.previousHistoryItem,
+              false,
+              state.previousHistoryItem.isShare
+            );
             return;
           }
           if (state.shareInfo?.hash && state.req?.source === state.shareInfo.hash) {
-            const sharePath = `/public/share/${state.shareInfo.hash}${url.encodedPath(state.req.path || '')}`;
-            router.push({ path: sharePath });
+            url.goToItem(state.shareInfo.hash, state.req.path);
             return;
           }
           router.push({ path: "/files" });

--- a/frontend/src/views/bars/Default.vue
+++ b/frontend/src/views/bars/Default.vue
@@ -260,7 +260,17 @@ export default {
         mutations.closeHovers();
         if (cv === "settings") {
           if (state.previousHistoryItem?.name) {
-            url.goToItem(state.previousHistoryItem.source, state.previousHistoryItem.path, state.previousHistoryItem);
+            if (state.previousHistoryItem.isShare) {
+              const sharePath = `/public/share/${state.previousHistoryItem.source}${state.previousHistoryItem.path}`;
+              router.push({ path: sharePath });
+            } else {
+              url.goToItem(state.previousHistoryItem.source, state.previousHistoryItem.path, state.previousHistoryItem);
+            }
+            return;
+          }
+          if (state.shareInfo?.hash && state.req?.source === state.shareInfo.hash) {
+            const sharePath = `/public/share/${state.shareInfo.hash}${state.req.path || ''}`;
+            router.push({ path: sharePath });
             return;
           }
           router.push({ path: "/files" });

--- a/frontend/src/views/files/DocViewer.vue
+++ b/frontend/src/views/files/DocViewer.vue
@@ -66,6 +66,8 @@ export default defineComponent({
             size: newReq.size,
             type: newReq.type,
             source: newReq.source,
+            modified: newReq.source,
+            hasPreview: newReq.source,
           });
         }
       },

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -252,6 +252,8 @@ export default {
         size: this.req.size,
         type: this.req.type,
         source: this.req.source,
+        modified: this.req.modified,
+        hasPreview: this.req.hasPreview,
       });
 
       this.updateNavigationForCurrentItem();

--- a/frontend/src/views/files/EpubViewer.vue
+++ b/frontend/src/views/files/EpubViewer.vue
@@ -70,6 +70,8 @@ export default defineComponent({
       size: state.req.size,
       type: state.req.type,
       source: state.req.source,
+      modified: state.req.modified,
+      hasPreview: state.req.hasPreview,
     });
     try {
       // 1. Fetch the download URL for the EPUB file

--- a/frontend/src/views/files/MarkdownViewer.vue
+++ b/frontend/src/views/files/MarkdownViewer.vue
@@ -247,6 +247,8 @@ export default {
         size: state.req.size,
         type: state.req.type,
         source: state.req.source,
+        modified: state.req.modified,
+        hasPreview: state.req.hasPreview,
       });
       this.setHighlightTheme(getters.isDarkMode());
       // Set initial content. The `watch` will trigger the first highlight.

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -590,6 +590,8 @@ export default {
           state.previousHistoryItem.source,
           state.previousHistoryItem.path,
           state.previousHistoryItem,
+          false,
+          state.previousHistoryItem.isShare
         );
         return;
       }

--- a/frontend/src/views/files/ThreeJs.vue
+++ b/frontend/src/views/files/ThreeJs.vue
@@ -209,6 +209,8 @@ export default {
         size: this.fbdata.size,
         type: this.fbdata.type,
         source: this.fbdata.source,
+        modified: this.fbdata.modified,
+        hasPreview: this.fbdata.hasPreview,
       });
     },
 

--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -1874,7 +1874,7 @@ export default {
         mode: this.playbackMode
       });
       mutations.setNavigationTransitioning(true);
-      url.goToItem(prevItem.source || this.req.source, prevItem.path, undefined);
+      url.goToItem(prevItem.source || this.req.source, prevItem.path, undefined, false, getters.isShare());
     },
     playNext() {
       if (this.playbackQueue.length === 0) return;
@@ -1902,7 +1902,7 @@ export default {
         });
 
         mutations.setNavigationTransitioning(true);
-        url.goToItem( nextItem.source || this.req.source, nextItem.path, undefined );
+        url.goToItem( nextItem.source || this.req.source, nextItem.path, undefined, false, getters.isShare());
 
       } catch (error) {
         console.error('Failed to navigate to next file:', error);

--- a/frontend/src/views/tools/DuplicateFinder.vue
+++ b/frontend/src/views/tools/DuplicateFinder.vue
@@ -112,7 +112,6 @@ import { getHumanReadableFilesize } from "@/utils/filesizes";
 import { eventBus } from "@/store/eventBus";
 import ListingItem from "@/components/files/ListingItem.vue";
 import PathPickerButton from "@/components/files/PathPickerButton.vue";
-import * as url from "@/utils/url";
 import { getTypeInfo } from "@/utils/mimetype";
 
 export default {
@@ -355,17 +354,6 @@ export default {
         return true;
       }
       return false;
-    },
-    navigateToFile(file) {
-      const previousHistoryItem = {
-        name: "Duplicate Finder",
-        source: this.selectedSource,
-        path: this.$route.path,
-      };
-
-      // Get the full path including search path context
-      const filePath = this.getFullPath(file.path);
-      url.goToItem(this.selectedSource, filePath, previousHistoryItem);
     },
     getFileKey(file) {
       // Create a unique key for the file based on source and path


### PR DESCRIPTION
When we log out from shares we are redirected to the login page automatically, then redirected to `/files` if we login from there.

To avoid this, now if we logout from a share we will be redirected to the share instead.

Other things:

- Fixed a typo in goToItem
- Close button of profile settings in share (#2442), it wasn't fully fixed in `v1.4.1`.
- Initial hash in settings when we open it (was being updated automatically with `reEval`, which was always setting the wrong hash in the URL), now should highlight `Profile settings` initially.
- And some issues with the **File Tree** in shares and with its context menu like rename and move while in a preview.