### PR TITLE
fix(settings): preserve anonymous download permission

### DIFF
--- a/backend/common/settings/apply_user_defaults_test.go
+++ b/backend/common/settings/apply_user_defaults_test.go
@@ -177,6 +177,37 @@ func TestApplyUserDefaults_copiesUserDefaultsOntoUser(t *testing.T) {
 	}
 }
 
+func TestApplyUserDefaults_anonymousKeepsDownloadOnly(t *testing.T) {
+	saved := Config
+	defer func() { Config = saved }()
+
+	Config = Settings{
+		Server: Server{},
+		UserDefaults: UserDefaults{
+			Account: UserDefaultsAccount{
+				Permissions: UserDefaultsAccountPermissions{
+					Api:      true,
+					Admin:    true,
+					Modify:   true,
+					Share:    true,
+					Realtime: true,
+					Delete:   true,
+					Create:   true,
+					Download: boolPtr(true),
+				},
+			},
+		},
+	}
+
+	u := &users.User{Username: "anonymous"}
+	ApplyUserDefaults(u)
+
+	want := users.Permissions{Download: true}
+	if diff := cmp.Diff(want, u.Permissions); diff != "" {
+		t.Fatalf("anonymous permissions mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestApplyUserDefaults_setsLoginMethodWhenEmpty(t *testing.T) {
 	saved := Config
 	defer func() { Config = saved }()

--- a/backend/common/settings/settings.go
+++ b/backend/common/settings/settings.go
@@ -134,6 +134,7 @@ func ApplyUserDefaults(u *users.User) {
 	u.FileLoading = d.FileLoading
 
 	if u.Username == "anonymous" {
+		u.Permissions.Download = boolValueOrDefault(d.Account.Permissions.Download, true)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Keep applying the configured download permission to the `anonymous` user used by public share links.
- Continue returning before elevated permissions are copied, so anonymous users do not inherit admin/modify/delete/create/share/api/realtime permissions.
- Add a regression test for anonymous defaults to cover the share-link permission case.

## Test plan
- `go test ./common/settings -run 'TestApplyUserDefaults_(anonymousKeepsDownloadOnly|copiesUserDefaultsOntoUser|setsLoginMethodWhenEmpty|preservesLoginMethodWhenAlreadySet)$' -count=1`
- `go test ./common/settings -count=1`
- `go test ./common/settings ./http -count=1`
- `go test -race ./common/settings -count=1`
- `go vet ./common/settings ./http`
- `git diff --check`

Full-suite note:
- `go test ./...` was also run; packages related to this change passed, but the existing timing-sensitive `backend/auth` test `TestJSONAuth_NoTimingAttack` failed because valid vs invalid user timing differed by 24.95% vs the 20% threshold.

Fixes #2433
