### PR TITLE
fix lyrics regex parsing

### DIFF
--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gtsteffaniak/go-logger/logger"
 )
 
-var reDuration = regexp.MustCompile(`\[(\d+):(\d+):(\d+)\.(\d+)\]`)
+var reDuration = regexp.MustCompile(`^\[(?:(\d{1,2}):)?(\d{1,2}):(\d{1,2})\.(\d+)\](.*)`)
 
 // CheckPermissionsFunc allows tests to override CheckPermissions behavior
 var CheckPermissionsFunc = checkPermissionsImpl


### PR DESCRIPTION
Noticed this issue with the lyrics:

(before/after)

<img width="350" alt="image" src="https://github.com/user-attachments/assets/81ea09a5-a949-47fd-ae83-648360ed59a6" />

<img width="350" alt="1779931620186225763" src="https://github.com/user-attachments/assets/d0a679dd-2d51-4209-ab8e-dc2183a65273" />

The regex got changed and wasn't working well.

