### PR TITLE
fix linting error

### DIFF
--- a/frontend/src/api/resources.js
+++ b/frontend/src/api/resources.js
@@ -264,11 +264,17 @@ async function resolveDownloadContentLength(url) {
     headers: { Range: 'bytes=0-0' },
     credentials: 'same-origin',
   })
+  const cancelBody = () => {
+    if (res.body && typeof res.body.cancel === 'function') {
+      res.body.cancel().catch(() => {})
+    }
+  }
   try {
     token = res.headers.get('X-Archive-Token') || token
     if (res.status === 206) {
       const total = totalFromContentRange(res.headers.get('Content-Range'))
       if (total > 0) {
+        cancelBody()
         return { size: total, token }
       }
     }
@@ -277,20 +283,17 @@ async function resolveDownloadContentLength(url) {
       if (cl) {
         const n = parseInt(cl, 10)
         if (Number.isFinite(n) && n > 0) {
+          cancelBody()
           return { size: n, token }
         }
       }
     }
-  } finally {
-    if (res.body && typeof res.body.cancel === 'function') {
-      try {
-        await res.body.cancel()
-      } catch {
-        // ignore
-      }
-    }
+    cancelBody()
+    return { size: 0, token }
+  } catch (e) {
+    cancelBody()
+    throw e
   }
-  return { size: 0, token: null }
 }
 
 function archiveDisplayFileName(format, files) {


### PR DESCRIPTION
Just a test PR, codacy reviewer is crashing while trying to lint. Will try a few things to see if the reviewer works again, otherwise I'll close. Since I can't see anything else than those logs.

<details>
<summary>logs from codacy</summary>

```
KubernetesDockerRunner: Container for codacy/codacy-eslint:9.18.7 exited with non-zero code 1
TypeError: Cannot read properties of null (reading 'type')
Occurred while linting /src/frontend/src/api/resources.js:249
Rule: "security-node/detect-unhandled-async-errors"
    at isTryCatchStatement (/node_modules/eslint-plugin-security-node/lib/rules/detect-unhandled-async-errors.js:41:21)
    at FunctionDeclaration (/node_modules/eslint-plugin-security-node/lib/rules/detect-unhandled-async-errors.js:113:19)
    at ruleErrorHandler (/node_modules/eslint/lib/linter/linter.js:1076:28)
    at /node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (/node_modules/eslint/lib/linter/node-event-generator.js:340:14)
    at CodePathAnalyzer.enterNode (/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:803:23) {
  ruleId: 'security-node/detect-unhandled-async-errors',
  currentNode: <ref *1> {
    type: 'FunctionDeclaration',
    async: true,
    body: {
      type: 'BlockStatement',
      body: [Array],
      range: [Array],
      loc: [Object],
      parent: [Circular *1]
    },
    declare: false,
    expression: false,
    generator: false,
    id: {
      type: 'Identifier',
      decorators: [],
      name: 'resolveDownloadContentLength',
      optional: false,
      typeAnnotation: undefined,
      range: [Array],
      loc: [Object],
      parent: [Circular *1]
    },
    params: [ [Object] ],
    returnType: undefined,
    typeParameters: undefined,
    range: [ 7389, 8582 ],
    loc: { start: [Object], end: [Object] },
    parent: {
      type: 'Program',
      body: [Array],
      comments: [Array],
      range: [Array],
      sourceType: 'script',
      tokens: [Array],
      loc: [Object],
      parent: null
    }
  }
}
```

</details>

