### PR TITLE
added pinned files to shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. For commit 
 
  **New Features**:
  - Added basic html viewer with relative reference support (#2522)
+ - Shares can have pinned files, requires a user to have edit access to share (#2522)
 
  **Notes**:
  - [docker] upgraded ffmpeg version 8.1 > 8.1.1

--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -282,7 +282,7 @@ func fileInfoFasterImpl(opts utils.FileOptions, access *access.Storage, user *us
 	if info.Type == "directory" && opts.ShowPinnedItems {
 		if opts.ShareHash != "" && shareStore != nil {
 			if link, err := shareStore.GetByHash(opts.ShareHash); err == nil {
-				if shareRelDir, err := link.ShareRelativeDir(user, opts.Source, response.Path); err == nil {
+				if shareRelDir, err := link.ShareRelativeDir(response.Path); err == nil {
 					response.PinnedItems = link.PinnedItems.NamesForDirectory(shareRelDir)
 				}
 			}

--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -223,12 +223,12 @@ func GetDirItems(opts utils.FileOptions, access *access.Storage, user *users.Use
 // FileInfoFasterFunc is a variable that can be mocked in tests
 var FileInfoFasterFunc = fileInfoFasterImpl
 
-func FileInfoFaster(opts utils.FileOptions, access *access.Storage, user *users.User, share *share.Storage) (*iteminfo.ExtendedFileInfo, error) {
-	return FileInfoFasterFunc(opts, access, user, share)
+func FileInfoFaster(opts utils.FileOptions, access *access.Storage, user *users.User, shareStore *share.Storage) (*iteminfo.ExtendedFileInfo, error) {
+	return FileInfoFasterFunc(opts, access, user, shareStore)
 }
 
 // fileInfoFasterImpl is the actual implementation of FileInfoFaster
-func fileInfoFasterImpl(opts utils.FileOptions, access *access.Storage, user *users.User, share *share.Storage) (*iteminfo.ExtendedFileInfo, error) {
+func fileInfoFasterImpl(opts utils.FileOptions, access *access.Storage, user *users.User, shareStore *share.Storage) (*iteminfo.ExtendedFileInfo, error) {
 	response := &iteminfo.ExtendedFileInfo{}
 	indexPath, userScope, topLevelErr := CheckPermissions(opts, access, user)
 	accessRulesErr := topLevelErr != nil && topLevelErr == errors.ErrAccessDenied && indexPath != ""
@@ -268,19 +268,25 @@ func fileInfoFasterImpl(opts utils.FileOptions, access *access.Storage, user *us
 	response.FileInfo = *info
 	response.RealPath = filepath.Join(idx.Path, indexPath)
 	response.Source = opts.Source
-	if share != nil && user.Permissions.Share && opts.ShowSharedAttr {
+	if shareStore != nil && user.Permissions.Share && opts.ShowSharedAttr {
 		for i := range response.Files {
 			file := &response.Files[i]
-			file.IsShared = share.IsShared(response.Path+file.Name, idx.Path, user.ID)
+			file.IsShared = shareStore.IsShared(response.Path+file.Name, idx.Path, user.ID)
 		}
 		for i := range response.Folders {
 			folder := &response.Folders[i]
-			folder.IsShared = share.IsShared(response.Path+folder.Name, idx.Path, user.ID)
+			folder.IsShared = shareStore.IsShared(response.Path+folder.Name, idx.Path, user.ID)
 		}
-		response.IsShared = share.IsShared(response.Path, idx.Path, user.ID)
+		response.IsShared = shareStore.IsShared(response.Path, idx.Path, user.ID)
 	}
 	if info.Type == "directory" && opts.ShowPinnedItems {
-		if source, ok := users.ResolveSourceKey(response.Source); ok {
+		if opts.ShareHash != "" && shareStore != nil {
+			if link, err := shareStore.GetByHash(opts.ShareHash); err == nil {
+				if shareRelDir, err := link.ShareRelativeDir(user, opts.Source, response.Path); err == nil {
+					response.PinnedItems = link.PinnedItems.NamesForDirectory(shareRelDir)
+				}
+			}
+		} else if source, ok := users.ResolveSourceKey(response.Source); ok {
 			response.PinnedItems = user.PinnedNamesForDirectory(source.Path, response.Path)
 		}
 	}

--- a/backend/common/utils/file.go
+++ b/backend/common/utils/file.go
@@ -57,7 +57,8 @@ type FileOptions struct {
 	ExtractEmbeddedSubtitles bool   // whether to extract embedded subtitles from media files
 	AlbumArt                 bool   // whether to get album art from media files
 	ShowHidden               bool   // whether to show hidden files (true = show, false = hide)
-	ShowPinnedItems          bool   // whether to show pinned items
+	ShowPinnedItems bool   // whether to show pinned items
+	ShareHash       string // when set, pinned items are loaded from this share link
 	HideFileExt              string // Hide files based on extensions (eg: '.lrc' or '.srt')
 	FollowSymlinks           bool   // whether to follow symlinks
 	Only                     string // whether to only get files or folders

--- a/backend/database/share/pinned_items.go
+++ b/backend/database/share/pinned_items.go
@@ -1,0 +1,81 @@
+package share
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
+	"github.com/gtsteffaniak/filebrowser/backend/database/users"
+)
+
+// PinnedItems maps share-relative directory paths to pinned item names.
+type PinnedItems map[string][]string
+
+// Add records a pinned item name under shareRelDir.
+func (p PinnedItems) Add(shareRelDir, name string) {
+	if p == nil {
+		return
+	}
+	items := p[shareRelDir]
+	if slices.Contains(items, name) {
+		return
+	}
+	p[shareRelDir] = append(items, name)
+}
+
+// Remove deletes a pinned item name and prunes empty map entries.
+func (p PinnedItems) Remove(shareRelDir, name string) {
+	if p == nil {
+		return
+	}
+	items := p[shareRelDir]
+	idx := slices.Index(items, name)
+	if idx < 0 {
+		return
+	}
+	items = append(items[:idx], items[idx+1:]...)
+	if len(items) == 0 {
+		delete(p, shareRelDir)
+	} else {
+		p[shareRelDir] = items
+	}
+}
+
+// NamesForDirectory returns pinned item names for a share-relative directory path.
+func (p PinnedItems) NamesForDirectory(shareRelDir string) []string {
+	if len(p) == 0 {
+		return nil
+	}
+	names := p[shareRelDir]
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]string, len(names))
+	copy(out, names)
+	return out
+}
+
+// EnsurePinnedItems returns a non-nil map for mutation.
+func (l *Link) EnsurePinnedItems() PinnedItems {
+	if l.PinnedItems == nil {
+		l.PinnedItems = make(PinnedItems)
+	}
+	return l.PinnedItems
+}
+
+// ShareRelativeDir maps a source index directory path to a share-relative directory path.
+// link.Path is the index path of the share root (e.g. "/share/").
+func (l *Link) ShareRelativeDir(_ *users.User, _ string, indexDirPath string) (string, error) {
+	shareRootIndex := utils.AddTrailingSlashIfNotExists(l.Path)
+	indexDirPath = utils.AddTrailingSlashIfNotExists(indexDirPath)
+	if !strings.HasPrefix(indexDirPath, shareRootIndex) {
+		return "", fmt.Errorf("path is outside share scope")
+	}
+
+	rel := strings.TrimPrefix(indexDirPath, shareRootIndex)
+	if rel == "" {
+		return "/", nil
+	}
+	return utils.AddTrailingSlashIfNotExists("/" + strings.TrimPrefix(rel, "/")), nil
+}

--- a/backend/database/share/pinned_items.go
+++ b/backend/database/share/pinned_items.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
-	"github.com/gtsteffaniak/filebrowser/backend/database/users"
 )
 
 // PinnedItems maps share-relative directory paths to pinned item names.
@@ -66,7 +65,7 @@ func (l *Link) EnsurePinnedItems() PinnedItems {
 
 // ShareRelativeDir maps a source index directory path to a share-relative directory path.
 // link.Path is the index path of the share root (e.g. "/share/").
-func (l *Link) ShareRelativeDir(_ *users.User, _ string, indexDirPath string) (string, error) {
+func (l *Link) ShareRelativeDir(indexDirPath string) (string, error) {
 	shareRootIndex := utils.AddTrailingSlashIfNotExists(l.Path)
 	indexDirPath = utils.AddTrailingSlashIfNotExists(indexDirPath)
 	if !strings.HasPrefix(indexDirPath, shareRootIndex) {

--- a/backend/database/share/pinned_items_test.go
+++ b/backend/database/share/pinned_items_test.go
@@ -1,0 +1,58 @@
+package share
+
+import "testing"
+
+func TestSharePinnedItemsAddRemove(t *testing.T) {
+	p := make(PinnedItems)
+	const dir = "/"
+	const name = "vacation.jpg"
+
+	p.Add(dir, name)
+	if len(p[dir]) != 1 || p[dir][0] != name {
+		t.Fatalf("add failed: %#v", p)
+	}
+
+	p.Add(dir, name)
+	if len(p[dir]) != 1 {
+		t.Fatalf("duplicate add should be ignored: %#v", p)
+	}
+
+	p.Remove(dir, name)
+	if len(p) != 0 {
+		t.Fatalf("remove should prune empty entries: %#v", p)
+	}
+}
+
+func TestSharePinnedNamesForDirectory(t *testing.T) {
+	p := PinnedItems{
+		"/photos/": {"vacation.jpg", "notes.txt"},
+	}
+
+	names := p.NamesForDirectory("/photos/")
+	if len(names) != 2 || names[0] != "vacation.jpg" || names[1] != "notes.txt" {
+		t.Fatalf("unexpected names: %#v", names)
+	}
+	if got := p.NamesForDirectory("/missing/"); got != nil {
+		t.Fatalf("expected nil for missing directory, got %#v", got)
+	}
+}
+
+func TestShareRelativeDir(t *testing.T) {
+	link := &Link{CommonShare: CommonShare{Path: "/share/"}}
+
+	got, err := link.ShareRelativeDir(nil, "", "/share/")
+	if err != nil {
+		t.Fatalf("ShareRelativeDir root: %v", err)
+	}
+	if got != "/" {
+		t.Fatalf("got %q, want /", got)
+	}
+
+	got, err = link.ShareRelativeDir(nil, "", "/share/test [file2]/")
+	if err != nil {
+		t.Fatalf("ShareRelativeDir subdir: %v", err)
+	}
+	if got != "/test [file2]/" {
+		t.Fatalf("got %q, want /test [file2]/", got)
+	}
+}

--- a/backend/database/share/pinned_items_test.go
+++ b/backend/database/share/pinned_items_test.go
@@ -40,7 +40,7 @@ func TestSharePinnedNamesForDirectory(t *testing.T) {
 func TestShareRelativeDir(t *testing.T) {
 	link := &Link{CommonShare: CommonShare{Path: "/share/"}}
 
-	got, err := link.ShareRelativeDir(nil, "", "/share/")
+	got, err := link.ShareRelativeDir("/share/")
 	if err != nil {
 		t.Fatalf("ShareRelativeDir root: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestShareRelativeDir(t *testing.T) {
 		t.Fatalf("got %q, want /", got)
 	}
 
-	got, err = link.ShareRelativeDir(nil, "", "/share/test [file2]/")
+	got, err = link.ShareRelativeDir("/share/test [file2]/")
 	if err != nil {
 		t.Fatalf("ShareRelativeDir subdir: %v", err)
 	}

--- a/backend/database/share/share.go
+++ b/backend/database/share/share.go
@@ -60,11 +60,12 @@ type CreateBody struct {
 // Link is the information needed to build a shareable link.
 type Link struct {
 	CommonShare
-	Downloads    int    `json:"downloads"`
-	Hash         string `json:"hash" storm:"id,index"`
-	UserID       uint   `json:"userID"`
-	Expire       int64  `json:"expire"`
-	PasswordHash string `json:"password_hash,omitempty"`
+	Downloads    int      `json:"downloads"`
+	Hash         string   `json:"hash" storm:"id,index"`
+	UserID       uint     `json:"userID"`
+	Expire       int64    `json:"expire"`
+	PasswordHash string   `json:"password_hash,omitempty"`
+	PinnedItems  PinnedItems `json:"pinnedItems,omitempty"`
 	// Token is a random value that will only be set when PasswordHash is set. It is
 	// URL-Safe and is used to download links in password-protected shares via a
 	// query arg.

--- a/backend/http/httpRouter.go
+++ b/backend/http/httpRouter.go
@@ -166,6 +166,7 @@ func StartHttp(ctx context.Context, storage *bolt.BoltStore, shutdownComplete ch
 	api.HandleFunc("PATCH /share", withPermShare(sharePatchHandler))
 	api.HandleFunc("DELETE /share", withPermShare(shareDeleteHandler))
 	publicApi.HandleFunc("GET /share/info", withOrWithoutUser(shareInfoHandler))
+	publicApi.HandleFunc("PATCH /share/pinnedItems", withPermShare(sharePatchPinnedItemsHandler))
 	publicApi.HandleFunc("GET /share/image", withHashFile(getShareImage))
 
 	// ========================================

--- a/backend/http/middleware.go
+++ b/backend/http/middleware.go
@@ -137,6 +137,8 @@ func withHashFileHelper(fn handleFunc) handleFunc {
 			ShowHidden:               link.ShowHidden,
 			HideFileExt:              link.HideFileExt,
 			FollowSymlinks:           true,
+			ShowPinnedItems:          true,
+			ShareHash:                hash,
 		}, store.Access, data.shareUser, store.Share)
 		if err != nil {
 			logger.Errorf("error fetching file info for share. hash=%v path=%v error=%v", hash, path, err)

--- a/backend/http/pinnedItems.go
+++ b/backend/http/pinnedItems.go
@@ -15,7 +15,13 @@ import (
 type pinnedItemPatchRequest struct {
 	Source string `json:"source" validate:"required"`
 	Path   string `json:"path" validate:"required"` // scope-relative parent directory
-	Name   string `json:"name" validate:"required"`   // item basename within path
+	Name   string `json:"name" validate:"required"` // item basename within path
+}
+
+// sharePinnedItemPatchRequest is the JSON body for PATCH /public/api/share/pinnedItems.
+type sharePinnedItemPatchRequest struct {
+	Path string `json:"path" validate:"required"` // share-relative parent directory
+	Name string `json:"name" validate:"required"` // item basename within path
 }
 
 // scopeRelativeDirToIndexPath maps a scope-relative directory to source and index paths.
@@ -37,6 +43,18 @@ func scopeRelativeDirToIndexPath(sourceName, userScope, directoryPath string) (s
 
 	fullDirPath := utils.JoinPathAsUnix(userScope, cleanDir)
 	return source.Path, idx.MakeIndexPath(fullDirPath, true), nil
+}
+
+// normalizeShareRelativeDir returns a normalized share-relative directory path key.
+func normalizeShareRelativeDir(shareRelDir string) (string, error) {
+	if shareRelDir == "" || shareRelDir == "/" {
+		return "/", nil
+	}
+	cleanDir, err := utils.SanitizeUserPath(shareRelDir)
+	if err != nil {
+		return "", fmt.Errorf("invalid path: %w", err)
+	}
+	return utils.AddTrailingSlashIfNotExists(cleanDir), nil
 }
 
 // pinnedItemAction returns the patch action query param, defaulting to "add".

--- a/backend/http/share.go
+++ b/backend/http/share.go
@@ -700,3 +700,78 @@ func redirectToShare(w http.ResponseWriter, r *http.Request, d *requestContext) 
 	http.Redirect(w, r, newURL, http.StatusMovedPermanently)
 	return http.StatusMovedPermanently, nil
 }
+
+// publicSharePatchPinnedItemsHandler adds or removes a pinned item on a share link.
+// @Summary Add or remove a pinned item on a share
+// @Description Patches one pinned item at a time for share owners. Defaults to add; pass ?action=remove to unpin.
+// @Tags Shares
+// @Accept json
+// @Produce json
+// @Param hash query string true "Share hash"
+// @Param action query string false "add (default) or remove"
+// @Param body body sharePinnedItemPatchRequest true "Pinned item"
+// @Success 204 "No Content"
+// @Failure 400 {object} map[string]string "Bad Request"
+// @Failure 403 {object} map[string]string "Forbidden"
+// @Failure 404 {object} map[string]string "Share not found"
+// @Failure 500 {object} map[string]string "Internal Server Error"
+// @Router /public/api/share/pinnedItems [patch]
+func sharePatchPinnedItemsHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
+	hash := r.URL.Query().Get("hash")
+	if hash == "" {
+		return http.StatusBadRequest, fmt.Errorf("hash is required")
+	}
+
+	link, err := store.Share.GetByHash(hash)
+	if err != nil {
+		return http.StatusNotFound, fmt.Errorf("share hash not found")
+	}
+
+	if d.user.Username == "anonymous" || !link.UserCanEdit(d.user) {
+		return http.StatusForbidden, fmt.Errorf("share pin editing is not allowed for this user")
+	}
+
+	if link.ShareType == "upload" {
+		return http.StatusForbidden, fmt.Errorf("pinning is disabled for upload shares")
+	}
+
+	var body sharePinnedItemPatchRequest
+	if err = json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("failed to decode body: %w", err)
+	}
+	defer r.Body.Close()
+
+	action := pinnedItemAction(r)
+	if action != "add" && action != "remove" {
+		return http.StatusBadRequest, fmt.Errorf("action must be add or remove")
+	}
+
+	if body.Path == "" || body.Name == "" {
+		return http.StatusBadRequest, fmt.Errorf("path and name are required")
+	}
+
+	shareRelDir, err := normalizeShareRelativeDir(body.Path)
+	if err != nil {
+		return http.StatusBadRequest, fmt.Errorf("invalid path: %s", body.Path)
+	}
+
+	cleanName, err := utils.SanitizeUserPath(body.Name)
+	if err != nil {
+		return http.StatusBadRequest, fmt.Errorf("invalid name: %s", body.Name)
+	}
+	body.Name = cleanName
+
+	pinned := link.EnsurePinnedItems()
+	switch action {
+	case "add":
+		pinned.Add(shareRelDir, body.Name)
+	case "remove":
+		pinned.Remove(shareRelDir, body.Name)
+	}
+
+	if err := store.Share.Save(link); err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to save share: %w", err)
+	}
+
+	return http.StatusNoContent, nil
+}

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -4630,6 +4630,86 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/public/api/share/pinnedItems": {
+            "patch": {
+                "description": "Patches one pinned item at a time for share owners. Defaults to add; pass ?action=remove to unpin.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Shares"
+                ],
+                "summary": "Add or remove a pinned item on a share",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share hash",
+                        "name": "hash",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "add (default) or remove",
+                        "name": "action",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Pinned item",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/http.sharePinnedItemPatchRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Share not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -4923,6 +5003,9 @@ const docTemplate = `{
                 "perUserDownloadLimit": {
                     "type": "boolean"
                 },
+                "pinnedItems": {
+                    "$ref": "#/definitions/share.PinnedItems"
+                },
                 "quickDownload": {
                     "type": "boolean"
                 },
@@ -5115,6 +5198,23 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.sharePinnedItemPatchRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "path"
+            ],
+            "properties": {
+                "name": {
+                    "description": "item basename within path",
+                    "type": "string"
+                },
+                "path": {
+                    "description": "share-relative parent directory",
                     "type": "string"
                 }
             }
@@ -7283,6 +7383,9 @@ const docTemplate = `{
                 "perUserDownloadLimit": {
                     "type": "boolean"
                 },
+                "pinnedItems": {
+                    "$ref": "#/definitions/share.PinnedItems"
+                },
                 "quickDownload": {
                     "type": "boolean"
                 },
@@ -7339,6 +7442,15 @@ const docTemplate = `{
                 },
                 "viewMode": {
                     "description": "default view mode for anonymous users: \"list\", \"compact\", \"normal\", \"gallery\"",
+                    "type": "string"
+                }
+            }
+        },
+        "share.PinnedItems": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
                     "type": "string"
                 }
             }

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -4619,6 +4619,86 @@
                     }
                 }
             }
+        },
+        "/public/api/share/pinnedItems": {
+            "patch": {
+                "description": "Patches one pinned item at a time for share owners. Defaults to add; pass ?action=remove to unpin.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Shares"
+                ],
+                "summary": "Add or remove a pinned item on a share",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share hash",
+                        "name": "hash",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "add (default) or remove",
+                        "name": "action",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Pinned item",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/http.sharePinnedItemPatchRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Share not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -4912,6 +4992,9 @@
                 "perUserDownloadLimit": {
                     "type": "boolean"
                 },
+                "pinnedItems": {
+                    "$ref": "#/definitions/share.PinnedItems"
+                },
                 "quickDownload": {
                     "type": "boolean"
                 },
@@ -5104,6 +5187,23 @@
                     "type": "string"
                 },
                 "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.sharePinnedItemPatchRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "path"
+            ],
+            "properties": {
+                "name": {
+                    "description": "item basename within path",
+                    "type": "string"
+                },
+                "path": {
+                    "description": "share-relative parent directory",
                     "type": "string"
                 }
             }
@@ -7272,6 +7372,9 @@
                 "perUserDownloadLimit": {
                     "type": "boolean"
                 },
+                "pinnedItems": {
+                    "$ref": "#/definitions/share.PinnedItems"
+                },
                 "quickDownload": {
                     "type": "boolean"
                 },
@@ -7328,6 +7431,15 @@
                 },
                 "viewMode": {
                     "description": "default view mode for anonymous users: \"list\", \"compact\", \"normal\", \"gallery\"",
+                    "type": "string"
+                }
+            }
+        },
+        "share.PinnedItems": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
                     "type": "string"
                 }
             }

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -193,6 +193,8 @@ definitions:
         type: boolean
       perUserDownloadLimit:
         type: boolean
+      pinnedItems:
+        $ref: '#/definitions/share.PinnedItems'
       quickDownload:
         type: boolean
       shareTheme:
@@ -338,6 +340,18 @@ definitions:
     - name
     - path
     - source
+    type: object
+  http.sharePinnedItemPatchRequest:
+    properties:
+      name:
+        description: item basename within path
+        type: string
+      path:
+        description: share-relative parent directory
+        type: string
+    required:
+    - name
+    - path
     type: object
   http.unarchiveRequest:
     properties:
@@ -1967,6 +1981,8 @@ definitions:
         type: string
       perUserDownloadLimit:
         type: boolean
+      pinnedItems:
+        $ref: '#/definitions/share.PinnedItems'
       quickDownload:
         type: boolean
       shareTheme:
@@ -2012,6 +2028,12 @@ definitions:
         description: 'default view mode for anonymous users: "list", "compact", "normal",
           "gallery"'
         type: string
+    type: object
+  share.PinnedItems:
+    additionalProperties:
+      items:
+        type: string
+      type: array
     type: object
   users.AuthToken:
     properties:
@@ -5585,6 +5607,60 @@ paths:
               type: string
             type: object
       summary: Get share information by hash
+      tags:
+      - Shares
+  /public/api/share/pinnedItems:
+    patch:
+      consumes:
+      - application/json
+      description: Patches one pinned item at a time for share owners. Defaults to
+        add; pass ?action=remove to unpin.
+      parameters:
+      - description: Share hash
+        in: query
+        name: hash
+        required: true
+        type: string
+      - description: add (default) or remove
+        in: query
+        name: action
+        type: string
+      - description: Pinned item
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/http.sharePinnedItemPatchRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Share not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Add or remove a pinned item on a share
       tags:
       - Shares
 swagger: "2.0"

--- a/frontend/src/api/share.js
+++ b/frontend/src/api/share.js
@@ -132,5 +132,6 @@ export async function patchPinnedItem({ hash, path, name, action = 'add' }) {
   await fetchURL(apiPath, {
     method: 'PATCH',
     body: JSON.stringify({ path, name }),
+    headers: { 'Content-Type': 'application/json' },
   })
 }

--- a/frontend/src/api/share.js
+++ b/frontend/src/api/share.js
@@ -124,3 +124,13 @@ export async function getShareInfoPublic(hash) {
     throw err
   }
 }
+
+// PATCH /public/api/share/pinnedItems (add by default; ?action=remove to unpin)
+export async function patchPinnedItem({ hash, path, name, action = 'add' }) {
+  const params = { hash, action }
+  const apiPath = getPublicApiPath('share/pinnedItems', params)
+  await fetchURL(apiPath, {
+    method: 'PATCH',
+    body: JSON.stringify({ path, name }),
+  })
+}

--- a/frontend/src/components/ContextMenu.vue
+++ b/frontend/src/components/ContextMenu.vue
@@ -195,7 +195,7 @@
 </template>
 
 <script>
-import { resourcesApi, usersApi } from "@/api";
+import { resourcesApi, shareApi, usersApi } from "@/api";
 import Action from "@/components/Action.vue";
 import { notify } from "@/notify";
 import { getters, mutations, state } from "@/store";
@@ -335,7 +335,8 @@ export default {
     },
     showPinAction() {
       if (this.showLimitedOptions) return false;
-      if (getters.isShare() || !getters.isLoggedIn()) return false;
+      if (!getters.isLoggedIn()) return false;
+      if (getters.isShare() && !state.shareInfo?.canEditShare) return false;
       if (this.showCreate || this.isSearchActive) return false;
       if (this.selectedCount !== 1) return false;
       return getters.currentView() === "listingView";
@@ -724,25 +725,37 @@ export default {
     },
     async togglePin() {
       const item = this.firstSelected;
-      if (!item?.name || getters.isShare() || !getters.isLoggedIn()) {
+      if (!item?.name || !getters.isLoggedIn()) {
+        return;
+      }
+      if (getters.isShare() && !state.shareInfo?.canEditShare) {
         return;
       }
       mutations.closeHovers();
-      const source = item.source || state.req?.source || state.sources.current;
-      if (!source) {
-        return;
-      }
       const directoryPath = state.req?.type === "directory"
         ? state.req.path
         : url.getParentDir(item.path);
       const action = item.pinned ? "remove" : "add";
       try {
-        await usersApi.patchPinnedItem({
-          source,
-          path: directoryPath,
-          name: item.name,
-          action,
-        });
+        if (getters.isShare()) {
+          await shareApi.patchPinnedItem({
+            hash: state.shareInfo.hash,
+            path: directoryPath,
+            name: item.name,
+            action,
+          });
+        } else {
+          const source = item.source || state.req?.source || state.sources.current;
+          if (!source) {
+            return;
+          }
+          await usersApi.patchPinnedItem({
+            source,
+            path: directoryPath,
+            name: item.name,
+            action,
+          });
+        }
         mutations.setReload(true);
       } catch (e) {
         notify.showError(e);

--- a/frontend/src/utils/htmlPreview.ts
+++ b/frontend/src/utils/htmlPreview.ts
@@ -208,9 +208,9 @@ export function rewriteDocumentStyles(
   });
 }
 
-export type HtmlPreview = {
+export interface HtmlPreview {
   srcdoc: string;
-};
+}
 
 export function buildHtmlPreview(
   content: string,

--- a/frontend/tests/playwright/global-setup.ts
+++ b/frontend/tests/playwright/global-setup.ts
@@ -3,8 +3,8 @@ import type { Browser, Page } from "@playwright/test";
 import { expect, firefox } from "@playwright/test";
 import {
   closeSharePromptIfOpen,
+  createShareViaApi,
   openShareAndExpectPath,
-  openShareFromFileActions,
 } from "./test-setup";
 
 // Perform authentication and store auth state
@@ -68,24 +68,13 @@ async function globalSetup() {
   }, shareHashFile);
   await closeSharePromptIfOpen(page);
 
-  // Create a share of root folder "/"
-  await page.goto("http://127.0.0.1/files/playwright%20%2B%20files/", { timeout: 1000 });
-  await page.locator('a[aria-label="share"]').waitFor({ state: 'visible' });
-  await openShareAndExpectPath(page, 'Path: /', () => openShareFromFileActions(page));
-  // Toggle "Allow creating and uploading files and folders" setting
-  await page.locator('input[aria-label="allow creating and uploading files and folders toggle"]').waitFor({ state: 'attached' });
-  await page.locator('input[aria-label="allow creating and uploading files and folders toggle"] + .slider').click();
-
-  // Toggle "Allow creating and uploading files and folders" setting
-  await page.locator('input[aria-label="allow editing files toggle"]').waitFor({ state: 'attached' });
-  await page.locator('input[aria-label="allow editing files toggle"] + .slider').click();
-
-  await page.locator('button[aria-label="Share-Confirm"]').click();
-  await expect(page.locator("div[aria-label='share-prompt'] .card-content table tbody tr:not(:has(th))")).toHaveCount(1);
-  const rootShareHash = await page.locator("div[aria-label='share-prompt'] .card-content table tbody tr:not(:has(th)) td").first().textContent();
-  if (!rootShareHash) {
-    throw new Error("Failed to retrieve rootShareHash");
-  }
+  // Create a share of root folder "/" (API — avoids flaky File-Actions UI in Docker global setup)
+  const rootShareHash = await createShareViaApi(page, {
+    path: "/",
+    source: "playwright + files",
+    allowCreate: true,
+    allowModify: true,
+  });
   // Store shareHash in localStorage
   await page.evaluate((hash) => {
     localStorage.setItem('rootShareHash', hash);

--- a/frontend/tests/playwright/global-setup.ts
+++ b/frontend/tests/playwright/global-setup.ts
@@ -1,7 +1,11 @@
 import { writeFile } from "node:fs/promises";
 import type { Browser, Page } from "@playwright/test";
 import { expect, firefox } from "@playwright/test";
-import { openContextMenuHelper, openShareAndExpectPath } from "./test-setup";
+import {
+  closeSharePromptIfOpen,
+  openShareAndExpectPath,
+  openShareFromFileActions,
+} from "./test-setup";
 
 // Perform authentication and store auth state
 async function globalSetup() {
@@ -41,6 +45,7 @@ async function globalSetup() {
   await page.evaluate((hash) => {
     localStorage.setItem('shareHash', hash);
   }, shareHash);
+  await closeSharePromptIfOpen(page);
 
   await page.goto("http://127.0.0.1/files/playwright%20%2B%20files/", { timeout: 1000 });
   // Create a share of file
@@ -61,14 +66,12 @@ async function globalSetup() {
   await page.evaluate((hash) => {
     localStorage.setItem('shareHashFile', hash);
   }, shareHashFile);
+  await closeSharePromptIfOpen(page);
 
   // Create a share of root folder "/"
   await page.goto("http://127.0.0.1/files/playwright%20%2B%20files/", { timeout: 1000 });
   await page.locator('a[aria-label="share"]').waitFor({ state: 'visible' });
-  await openShareAndExpectPath(page, 'Path: /', async () => {
-    await openContextMenuHelper(page);
-    await page.locator('button[aria-label="Share"]').click();
-  });
+  await openShareAndExpectPath(page, 'Path: /', () => openShareFromFileActions(page));
   // Toggle "Allow creating and uploading files and folders" setting
   await page.locator('input[aria-label="allow creating and uploading files and folders toggle"]').waitFor({ state: 'attached' });
   await page.locator('input[aria-label="allow creating and uploading files and folders toggle"] + .slider').click();

--- a/frontend/tests/playwright/sharing/share.spec.ts
+++ b/frontend/tests/playwright/sharing/share.spec.ts
@@ -1,10 +1,9 @@
-import { checkForNotification, expect, test } from "../test-setup";
+import { checkForNotification, expect, openShareFromFileActions, test } from "../test-setup";
 
-test("root share path is valid", async ({ page, checkForErrors, openContextMenu }) => {
+test("root share path is valid", async ({ page, checkForErrors }) => {
   await page.goto("/files/");
   await expect(page).toHaveTitle("Graham's Filebrowser - Files - playwright-files");
-  await openContextMenu();
-  await page.locator('button[aria-label="Share"]').click();
+  await openShareFromFileActions(page);
   await expect(page.locator('div[aria-label="share-path"]')).toHaveText('Path: /');
   checkForErrors();
 });
@@ -40,12 +39,11 @@ test("share download single file", async ({ page, checkForErrors }) => {
   checkForErrors(0,1);
 });
 
-test("share private source", async ({ page, checkForErrors, openContextMenu }) => {
+test("share private source", async ({ page, checkForErrors }) => {
   await page.goto("/files/docker");
   await expect(page).toHaveTitle("Graham's Filebrowser - Files - backend");
    // Create a share of folder
-   await openContextMenu();
-   await page.locator('button[aria-label="Share"]').click();
+   await openShareFromFileActions(page);
    await expect(page.locator('div[aria-label="share-path"]')).toHaveText('Path: /');
    await page.locator('button[aria-label="Share-Confirm"]').click();
   await expect(page.locator("div[aria-label='share-prompt'] .card-content table tbody tr:not(:has(th))")).toHaveCount(0);

--- a/frontend/tests/playwright/test-setup.ts
+++ b/frontend/tests/playwright/test-setup.ts
@@ -4,10 +4,30 @@ import { test as base, expect } from "@playwright/test";
 const PLAYWRIGHT_RETRY_INTERVALS = [500, 1000, 1500, 2000];
 
 async function dismissSharePrompt(page: Page, sharePrompt: Locator): Promise<void> {
-  if (await sharePrompt.isVisible()) {
+  if (!(await sharePrompt.isVisible())) {
+    return;
+  }
+
+  for (let attempt = 0; attempt < 3; attempt++) {
     await page.keyboard.press("Escape");
+    try {
+      await sharePrompt.waitFor({ state: "hidden", timeout: 2000 });
+      return;
+    } catch {
+      // Retry Escape or fall through to the close button.
+    }
+  }
+
+  const closeButton = sharePrompt.locator(".prompt-close");
+  if (await closeButton.isVisible()) {
+    await closeButton.click();
     await sharePrompt.waitFor({ state: "hidden", timeout: 3000 }).catch(() => {});
   }
+}
+
+/** Closes the share dialog when it is still open after creating or viewing a share. */
+export async function closeSharePromptIfOpen(page: Page): Promise<void> {
+  await dismissSharePrompt(page, page.locator("div[aria-label='share-prompt']"));
 }
 
 /**
@@ -43,6 +63,18 @@ export async function openContextMenuHelper(
     await fileActionsButton.waitFor({ state: "visible", timeout: 5000 });
     await fileActionsButton.click();
   }).toPass({ timeout, intervals: PLAYWRIGHT_RETRY_INTERVALS });
+}
+
+/**
+ * Opens the sidebar File-Actions menu and clicks Share once the context menu is ready.
+ */
+export async function openShareFromFileActions(page: Page): Promise<void> {
+  await openContextMenuHelper(page);
+  const contextMenu = page.locator("#context-menu");
+  await contextMenu.waitFor({ state: "visible", timeout: 5000 });
+  const shareButton = contextMenu.locator('button[aria-label="Share"]');
+  await shareButton.waitFor({ state: "visible", timeout: 5000 });
+  await shareButton.click();
 }
 
 /**

--- a/frontend/tests/playwright/test-setup.ts
+++ b/frontend/tests/playwright/test-setup.ts
@@ -30,6 +30,31 @@ export async function closeSharePromptIfOpen(page: Page): Promise<void> {
   await dismissSharePrompt(page, page.locator("div[aria-label='share-prompt']"));
 }
 
+/** Closes the file-actions / listing context menu if it is still open. */
+export async function closeContextMenuIfOpen(page: Page): Promise<void> {
+  const contextMenu = page.locator("#context-menu");
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (!(await contextMenu.isVisible())) {
+      return;
+    }
+    await page.keyboard.press("Escape");
+    await contextMenu.waitFor({ state: "hidden", timeout: 2000 }).catch(() => {});
+  }
+}
+
+async function waitForContextMenuReady(page: Page, contextMenu: Locator): Promise<void> {
+  await contextMenu.waitFor({ state: "visible", timeout: 5000 });
+  await page.waitForFunction(() => {
+    const menus = document.querySelectorAll("#context-menu");
+    const menu = menus[menus.length - 1];
+    if (!(menu instanceof HTMLElement)) {
+      return false;
+    }
+    const rect = menu.getBoundingClientRect();
+    return rect.height > 40 && rect.width > 40 && menu.style.opacity !== "0";
+  }, { timeout: 5000 });
+}
+
 /**
  * Standalone helper function to open the context menu (File-Actions button)
  * Can be used in both test fixtures and global setup
@@ -41,6 +66,9 @@ export async function openContextMenuHelper(
   const timeout = options?.timeout ?? 30000;
 
   await expect(async () => {
+    await closeContextMenuIfOpen(page);
+    await closeSharePromptIfOpen(page);
+
     const readyMarker = page.locator('[data-testid="file-actions-ready"]');
 
     try {
@@ -69,12 +97,81 @@ export async function openContextMenuHelper(
  * Opens the sidebar File-Actions menu and clicks Share once the context menu is ready.
  */
 export async function openShareFromFileActions(page: Page): Promise<void> {
+  await closeSharePromptIfOpen(page);
+  await closeContextMenuIfOpen(page);
   await openContextMenuHelper(page);
-  const contextMenu = page.locator("#context-menu");
-  await contextMenu.waitFor({ state: "visible", timeout: 5000 });
+
+  const contextMenu = page.locator("#context-menu").last();
+  await waitForContextMenuReady(page, contextMenu);
+
   const shareButton = contextMenu.locator('button[aria-label="Share"]');
   await shareButton.waitFor({ state: "visible", timeout: 5000 });
+  await shareButton.scrollIntoViewIfNeeded();
+
+  const sharePrompt = page.locator("div[aria-label='share-prompt']");
+  const shareListRequest = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/share") &&
+      response.request().method() === "GET" &&
+      response.ok(),
+    { timeout: 10000 },
+  );
+
   await shareButton.click();
+  await shareListRequest;
+  await sharePrompt.waitFor({ state: "visible", timeout: 8000 });
+}
+
+/**
+ * Creates a share via the authenticated API (for global setup data prep).
+ */
+export async function createShareViaApi(
+  page: Page,
+  options: {
+    path: string;
+    source: string;
+    allowCreate?: boolean;
+    allowModify?: boolean;
+  },
+): Promise<string> {
+  const response = await page.request.post("http://127.0.0.1/api/share", {
+    headers: { "Content-Type": "application/json" },
+    data: {
+      path: options.path,
+      source: options.source,
+      allowCreate: options.allowCreate ?? false,
+      allowModify: options.allowModify ?? false,
+      allowDelete: false,
+      shareType: "normal",
+      expires: "",
+      unit: "hours",
+      hash: "",
+      sidebarLinks: [
+        {
+          name: "Share QR Code and Info",
+          category: "shareInfo",
+          target: "#",
+          icon: "qr_code",
+        },
+        {
+          name: "Download",
+          category: "download",
+          target: "#",
+          icon: "download",
+        },
+      ],
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to create share: ${response.status()} ${await response.text()}`);
+  }
+
+  const body = await response.json() as { hash?: string };
+  if (!body.hash) {
+    throw new Error("Share API response missing hash");
+  }
+  return body.hash;
 }
 
 /**
@@ -87,10 +184,12 @@ export async function openShareAndExpectPath(
   options?: { timeout?: number },
 ): Promise<void> {
   const timeout = options?.timeout ?? 30000;
-  const sharePath = page.locator('div[aria-label="share-path"]');
   const sharePrompt = page.locator("div[aria-label='share-prompt']");
+  const sharePath = sharePrompt.locator('[aria-label="share-path"]');
 
   await expect(async () => {
+    await closeContextMenuIfOpen(page);
+
     if (await sharePrompt.isVisible()) {
       try {
         await sharePath.waitFor({ state: "visible", timeout: 1000 });
@@ -105,6 +204,7 @@ export async function openShareAndExpectPath(
     }
 
     await openShare();
+    await sharePrompt.waitFor({ state: "visible", timeout: 8000 });
     await sharePath.waitFor({ state: "visible", timeout: 8000 });
     await expect(sharePath).toHaveText(expectedPathText, { timeout: 5000 });
   }).toPass({ timeout, intervals: PLAYWRIGHT_RETRY_INTERVALS });


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shares can have pinned files; share owners with edit access can pin/unpin via context menus and a new public PATCH endpoint.
* **Documentation**
  * API docs updated to document the pinned-items endpoint and expose pinnedItems in share responses.
* **Tests**
  * Unit tests and Playwright E2E updates added to cover pinned-items operations and share-relative path normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->