### PR TITLE
fix share undefined url after editing

### DIFF
--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -835,7 +835,6 @@ export default {
         return true;
       } catch (err) {
         console.error(err);
-        notify.showError(err?.message || err);
         return false;
       } finally {
         this.linksLoading = false;

--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -798,24 +798,18 @@ export default {
           payload.enableOnlyOffice = false;
         }
 
-        const res = await shareApi.create(payload);
+        await shareApi.create(payload);
 
-        if (!this.isEditMode && !this.editingLink) {
-          this.links.push(res);
-          this.sort();
-        } else if (this.editingLink) {
-          // Update the link in the local list
-          const index = this.links.findIndex(l => l.hash === this.editingLink.hash);
-          if (index !== -1) {
-            this.links.splice(index, 1, res);
-          }
-          this.editingLink = null;
-          // emit event to reload shares in settings view
-          eventBus.emit('sharesChanged');
-        } else {
+        if (this.isEditMode) {
           // emit event to reload shares in settings view
           eventBus.emit('sharesChanged');
           mutations.closeTopPrompt();
+        } else {
+          // refrest the shares list when editing or creating from listing view
+          const refreshed = await this.refreshShares();
+          if (!refreshed) return;
+          this.editingLink = null;
+          eventBus.emit('sharesChanged');
         }
 
         this.time = "";
@@ -829,6 +823,22 @@ export default {
           // didn't come from api, show error to user
           notify.showError(err);
         }
+      }
+    },
+    async refreshShares() {
+      if (this.isEditMode) return true;
+      this.linksLoading = true;
+      try {
+        const links = await shareApi.get(this.item.path, this.item.source);
+        this.links = links;
+        this.sort();
+        return true;
+      } catch (err) {
+        console.error(err);
+        notify.showError(err?.message || err);
+        return false;
+      } finally {
+        this.linksLoading = false;
       }
     },
     /**


### PR DESCRIPTION
Fixes #2523 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes issue `#2523`, where copying a share link could copy the string `"undefined"` instead of the actual share URL when the user copies immediately after editing and saving a share’s settings.

## What changed

In `frontend/src/components/prompts/Share.vue`, the share creation success flow was reworked to avoid relying on the `shareApi.create()` response to update the component state.

### Updated `submit()` flow
- After `await shareApi.create(payload)` succeeds:
  - **Edit mode (`this.isEditMode`)**: emits `sharesChanged` and closes the top prompt (`mutations.closeTopPrompt()`).
  - **Non-edit mode**: calls a new `refreshShares()` helper to re-fetch the latest shares; if it fails, exits early. On success, clears `editingLink` and emits `sharesChanged`.

### New `refreshShares()` helper
- If **in edit mode**, returns `true` immediately.
- Otherwise:
  - Sets `linksLoading = true`
  - Fetches fresh share data via `shareApi.get(this.item.path, this.item.source)`
  - Replaces `this.links`, re-sorts via `this.sort()`, and returns `true`
  - On error: logs to console and returns `false`
  - Always clears `linksLoading` in a `finally` block

## Impact

By re-fetching and re-sorting shares from the backend after create/update (outside edit mode), the component state stays consistent, preventing the copy button from reading stale/undefined link values.

## Files Modified
- `frontend/src/components/prompts/Share.vue`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->