### PR TITLE
Add metadata for playback queue

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -144,6 +144,7 @@
 import { globalVars } from "@/utils/constants";
 import downloadFiles from "@/utils/download";
 import { getHumanReadableFilesize } from "@/utils/filesizes";
+import { formatDuration } from "@/utils/files.js";
 import { getObjectProperty } from '@/utils/object.js';
 import { resourcesApi } from "@/api";
 import * as upload from "@/utils/upload";
@@ -343,17 +344,7 @@ export default {
       return getters.getTime(this.modified);
     },
     formattedDuration() {
-      if (!this.metadata?.duration) {
-        return "";
-      }
-      const seconds = this.metadata.duration;
-      const hours = Math.floor(seconds / 3600);
-      const minutes = Math.floor((seconds % 3600) / 60);
-      const secs = Math.floor(seconds % 60);
-      if (hours > 0) {
-        return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-      }
-      return `${minutes}:${secs.toString().padStart(2, '0')}`;
+      return formatDuration(this.metadata?.duration);
     },
     isListMode() {
       const mode = getters.viewMode();

--- a/frontend/src/components/prompts/PlaybackQueue.vue
+++ b/frontend/src/components/prompts/PlaybackQueue.vue
@@ -14,11 +14,11 @@
         <div
           v-for="(item, index) in formattedQueue"
           :key="`${item.path}-${index}`"
-          class="play-queue-item"
+          class="queue-item"
           :class="{ 'current': index === currentQueueIndex }"
           @click="navigateToItem(index)"
         >
-          <div class="item-icon">
+          <div class="queue-item-icon">
             <Icon
               :mimetype="item.type"
               :filename="item.name"
@@ -30,15 +30,23 @@
               :size="item.size"
             />
           </div>
-          <div class="item-name">
-            <span class="name">{{ item.name }}</span>
+          <!-- Metadata -->
+          <div class="queue-item-info">
+            <div class="queue-item-title">{{ item.title }}</div>
+            <div v-if="item.artist" class="queue-item-metadata">{{ item.artist }}</div>
+            <div v-if="item.album" class="queue-item-metadata">{{ item.album }}</div>
           </div>
-          <div class="item-indicator">
-            <span v-if="index === currentQueueIndex" class="current-track">
-              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
-              <i class="material-symbols">{{ isPlaying ? 'pause' : 'play_arrow' }}</i>
+          <!-- Duration + file type + play indicator -->
+          <div class="queue-item-meta">
+            <span v-if="item.duration" class="queue-item-duration">{{ item.duration }}</span>
+            <span class="file-type-badge">{{ item.fileType }}</span>
+            <span class="queue-item-indicator">
+              <span v-if="index === currentQueueIndex" class="current-track">
+                <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+                <i class="material-symbols">{{ isPlaying ? 'pause' : 'play_arrow' }}</i>
+              </span>
+              <span v-else class="track-number">{{ index + 1 }}</span>
             </span>
-            <span v-else class="track-number">{{ index + 1 }}</span>
           </div>
         </div>
       </div>
@@ -66,10 +74,11 @@
 <script>
 import { state, mutations, getters } from "@/store";
 import { url } from "@/utils";
-import { cyclePlaybackModes as cycleModes } from '@/utils/playbackQueue.js';
+import { cyclePlaybackModes as cycleModes, formatArtist } from '@/utils/playbackQueue.js';
 import Icon from "@/components/files/Icon.vue";
 import { resourcesApi } from "@/api";
 import { globalVars } from "@/utils/constants";
+import { formatDuration, getTypeFromMime, removeExtension } from "@/utils/files.js";
 
 export default {
   name: "PlaybackQueue",
@@ -118,16 +127,42 @@ export default {
       return modeIcons[this.playbackMode] || 'music_note';
     },
     formattedQueue() {
-      return this.playbackQueue.map((item) => ({
-        name: item.name,
-        path: item.path,
-        type: item.type,
-        source: item.source,
-        modified: item.modified,
-        size: item.size,
-        hasPreview: item.hasPreview,
-        thumbnailUrl: this.getThumbnailUrl(item),
-      }));
+      return this.playbackQueue.map((item) => {
+        const metadata = item.metadata || {};
+        // Title: fallback to filename without extension
+        const title = metadata.title || removeExtension(item.name);
+        // Artist formatted
+        const artist = formatArtist(metadata.artist);
+        // Album name with year
+        let album = '';
+        if (metadata.album) {
+          album = metadata.album;
+          if (metadata.year) {
+            album += ` (${metadata.year})`;
+          }
+        } else if (metadata.year) {
+          album = metadata.year;
+        }
+        // File type
+        const fileType = getTypeFromMime(item.type);
+        // Duration
+        const duration = formatDuration(metadata.duration);
+        return {
+          name: item.name,
+          path: item.path,
+          type: item.type,
+          source: item.source,
+          modified: item.modified,
+          size: item.size,
+          hasPreview: item.hasPreview,
+          thumbnailUrl: this.getThumbnailUrl(item),
+          title: title,
+          artist: artist,
+          album: album,
+          fileType: fileType,
+          duration: duration,
+        };
+      });
     },
     isPlaying() {
       return state.playbackQueue.isPlaying || false;
@@ -232,7 +267,8 @@ export default {
       if (this.queueCount === 0) return;
       this.$nextTick(() => {
         const list = this.$refs.QueueList;
-        const currentItem = list.querySelector('.play-queue-item.current');
+        if (!list) return;
+        const currentItem = list.querySelector('.queue-item.current');
         if (!currentItem) return;
 
         const listRect = list.getBoundingClientRect();
@@ -328,39 +364,38 @@ export default {
 .queue-list {
   overflow-y: auto;
   min-height: 0;
-  align-items: center;
   border-radius: 12px;
   padding: 0;
 }
 
-.play-queue-item {
+.queue-item {
   display: flex;
   align-items: center;
-  text-align: center;
-  padding: 0.35rem 0.85rem;
+  text-align: left;
+  padding: 0.2rem 0.85rem;
   cursor: pointer;
   transition: background-color 0.2s ease;
   gap: 0.5rem;
   border-radius: 12px;
 }
 
-.play-queue-item:hover {
+.queue-item:hover {
   background: var(--surfaceSecondary);
 }
 
-.play-queue-item.current {
+.queue-item.current {
   background: var(--primaryColor);
   color: white;
 }
 
-.play-queue-item.current .item-icon i,
-.play-queue-item.current .current-indicator,
-.item-indicator {
+.queue-item.current .queue-item-icon i,
+.queue-item.current .current-indicator,
+.queue-item-indicator {
   color: white;
   user-select: none;
 }
 
-.item-icon {
+.queue-item-icon {
   flex-shrink: 0;
   width: 2.65em;
   height: 2.65em;
@@ -368,21 +403,93 @@ export default {
   overflow: hidden;
 }
 
-.item-icon :deep(.image-preview) {
+.queue-item-icon :deep(.image-preview) {
   width: 100%;
   height: 100%;
   --icon-font-size: 1.8em;
 }
 
-.item-name {
+.queue-item-info {
   flex: 1;
-  padding: 0.2em 0.35em;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0.1em 0;
+  overflow: hidden;
+  line-height: 1.3;
+}
+
+.queue-item-title {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.95em;
+}
+
+.queue-item-metadata {
+  font-size: 0.8em;
+  opacity: 0.7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.queue-item.current .queue-item-metadata {
+  opacity: 0.85;
+}
+
+.queue-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  font-size: 0.8em;
+}
+
+.queue-item-duration {
+  opacity: 0.6;
+  font-variant-numeric: tabular-nums;
+}
+
+.file-type-badge {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  background: var(--surfaceSecondary);
+  padding: 0.1em 0.6em;
+  border-radius: 1em;
+  opacity: 0.7;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.queue-item.current .file-type-badge {
+  background: rgba(255,255,255,0.2);
+  color: white;
+  opacity: 1;
+}
+
+.queue-item-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8em;
+  font-size: 0.9rem;
 }
 
 .track-number {
   color: var(--textSecondary);
   font-weight: 600;
   user-select: none;
+}
+
+.queue-item.current .track-number {
+  color: white;
+}
+
+.current-track i.material-symbols {
+  font-size: 1.1rem;
 }
 
 .empty {

--- a/frontend/src/components/prompts/PlaybackQueue.vue
+++ b/frontend/src/components/prompts/PlaybackQueue.vue
@@ -39,7 +39,7 @@
           <!-- Duration + file type + play indicator -->
           <div class="queue-item-meta">
             <span v-if="item.duration" class="queue-item-duration">{{ item.duration }}</span>
-            <span class="file-type-badge">{{ item.fileType }}</span>
+            <span v-if="item.fileType" class="file-type-badge">{{ item.fileType }}</span>
             <span class="queue-item-indicator">
               <span v-if="index === currentQueueIndex" class="current-track">
                 <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -369,7 +369,7 @@ button:hover,
 .tree-node.current-item .material-symbols-outlined,
 .tree-node.drag-over .material-symbols-outlined,
 .search-entry:hover .material-symbols-outlined,
-.play-queue-item:hover .material-symbols-outlined {
+.queue-item:hover .material-symbols-outlined {
   font-variation-settings: 'FILL' 1;
 }
 

--- a/frontend/src/utils/files.js
+++ b/frontend/src/utils/files.js
@@ -35,3 +35,30 @@ export function removePrefix(filename, prefix = "") {
   return filename;
 }
 
+export function formatDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return '';
+  }
+  const totalSeconds = Math.floor(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(secs).padStart(2, '0')}`;
+}
+
+export function getTypeFromMime(mimeType) {
+  if (typeof mimeType !== 'string') return '';
+  const parts = mimeType.split('/');
+  return parts.length === 2 ? parts[1].toLowerCase() : '';
+}
+
+export function removeExtension(filename) {
+  if (typeof filename !== 'string') return '';
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot === -1) return filename;
+  if (lastDot === 0) return filename;
+  return filename.substring(0, lastDot);
+}

--- a/frontend/src/utils/playbackQueue.js
+++ b/frontend/src/utils/playbackQueue.js
@@ -242,3 +242,19 @@ export function navigatePlaybackQueue(direction) {
 
   return true;
 }
+
+/**
+ * @param {string} artist - Artist from metadata
+ * @returns {string} Formatted artist
+ */
+export function formatArtist(artist) {
+  if (typeof artist !== 'string' || !artist.trim()) {
+    return '';
+  }
+  // by common separators like ',', ';', or ' feat. ', ' ft. '
+  const parts = artist
+    .split(/[,;]|\s+(?:feat|ft)\.?\s+/i)
+    .map(s => s.trim())
+    .filter(Boolean);
+  return parts.join(' • ');
+}

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -277,6 +277,21 @@ export default {
     mutations.clearNavigation();
   },
   methods: {
+    // Fetches directory metadata and attaches it to listing items (for playback queue)
+    async attachMediaMetadata(listing, dirPath) {
+      if (!listing?.length) return;
+      try {
+        const isShare = getters.isShare();
+        const payload = isShare
+          ? await mediaApi.fetchDirectoryMediaMetadataPublic(dirPath, state.shareInfo.hash, localStorage.getItem(`sharepass:${state.shareInfo.hash}`) || '', true)
+          : await mediaApi.fetchDirectoryMediaMetadata(state.req.source, dirPath, true);
+        if (!payload?.items) return;
+        const metaMap = new Map(payload.items.filter(i => i.metadata).map(i => [i.name, i.metadata]));
+        listing.forEach(item => { if (metaMap.has(item.name)) item.metadata = metaMap.get(item.name); });
+      } catch (e) {
+        console.warn('Preview: directory metadata fetch failed', e);
+      }
+    },
     async loadPreviewForReq() {
       if (!getters.isLoggedIn() && !getters.isShare()) {
         return;
@@ -323,6 +338,11 @@ export default {
       if (state.req.path !== path) {
         return;
       }
+      await this.updatePreview();
+      if (isAv && this.listing) {
+        const directoryPath = url.removeLastDir(state.req.path) || '/';
+        await this.attachMediaMetadata(this.listing, directoryPath);
+      }
       this.subtitlesList = await this.subtitles();
       if (this.previewType === 'audio' && !this.useDefaultMediaPlayer && this.lyricsFetchedForPath !== state.req.path) {
         this.lyricsFetchedForPath = state.req.path;
@@ -343,7 +363,6 @@ export default {
           this.lyrics = [];
         }
       }
-      await this.updatePreview();
       mutations.resetSelected();
       mutations.addSelected({
         name: state.req.name,

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -290,7 +290,10 @@ export default {
       if (cachedMap) {
         listing.forEach(item => {
           if (cachedMap.has(item.name)) {
-            item.metadata = cachedMap.get(item.name);
+            const metadata = cachedMap.get(item.name);
+            item.metadata = item.path === state.req.path
+              ? { ...metadata, ...item.metadata }
+              : metadata;
           }
         });
         return;
@@ -304,7 +307,10 @@ export default {
         const metaMap = new Map(payload.items.filter(i => i.metadata).map(i => [i.name, i.metadata]));
         listing.forEach(item => {
           if (metaMap.has(item.name)) {
-            item.metadata = metaMap.get(item.name);
+          const metadata = metaMap.get(item.name);
+          item.metadata = item.path === state.req.path
+            ? { ...metadata, ...item.metadata }
+            : metadata;
           }
         });
         this.dirMetadataCache.set(cacheKey, metaMap);

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -77,8 +77,6 @@ import { convertToVTT, getSubtitleFormatExtension } from "@/utils/subtitles";
 import { globalVars } from "@/utils/constants";
 import { navigatePlaybackQueue } from "@/utils/playbackQueue.js";
 
-const DIR_METADATA_CACHE_KEY = 'mediaMetadataCache';
-
 export default {
   name: "preview",
   components: {
@@ -100,6 +98,7 @@ export default {
       avMetadataLoading: false,
       /** Skip duplicate media-metadata fetch when patchRequestFileMediaMetadata updates `req` for same path. */
       mediaEnrichDoneForPath: null,
+      dirMetadataCache: new Map(),
     };
   },
   computed: {
@@ -279,41 +278,15 @@ export default {
     mutations.clearNavigation();
   },
   methods: {
-    getDirCachedMediaMetadata(cacheKey) {
-      try {
-        const stored = sessionStorage.getItem(DIR_METADATA_CACHE_KEY);
-        if (!stored) return null;
-        const array = JSON.parse(stored);
-        if (!Array.isArray(array)) return null;
-        const cacheMap = new Map(array);
-        const entries = cacheMap.get(cacheKey);
-        if (!entries || !Array.isArray(entries)) return null;
-        return new Map(entries);
-      } catch (_) {
-        return null;
-      }
-    },
-    setDirCachedMediaMetadata(cacheKey, metaMap) {
-      try {
-        const stored = sessionStorage.getItem(DIR_METADATA_CACHE_KEY);
-        let cacheMap = new Map();
-        if (stored) {
-          const array = JSON.parse(stored);
-          if (Array.isArray(array)) cacheMap = new Map(array);
-        }
-        cacheMap.set(cacheKey, Array.from(metaMap.entries()));
-        sessionStorage.setItem(DIR_METADATA_CACHE_KEY, JSON.stringify(Array.from(cacheMap.entries())));
-      } catch (_) { /* ignore */ }
-    },
     async attachDirMediaMetadata(listing, dirPath) {
       // Fetches directory metadata and attaches it to the items for playback queue.
-      // gets cached for the current dir onto session storage -- it might look similar to enrichAvFromMediaApi but
+      // gets cached for the current preview -- it might look similar to enrichAvFromMediaApi but
       // this one gets called only once per dir (instead of per item) and doesn't carry album art.
       if (!listing?.length) return;
       const cacheKey = getters.isShare()
         ? `${state.shareInfo.hash}:${dirPath}`
         : `${state.req.source}:${dirPath}`;
-      const cachedMap = this.getDirCachedMediaMetadata(cacheKey);
+      const cachedMap = this.dirMetadataCache.get(cacheKey);
       if (cachedMap) {
         listing.forEach(item => {
           if (cachedMap.has(item.name)) {
@@ -334,7 +307,7 @@ export default {
             item.metadata = metaMap.get(item.name);
           }
         });
-        this.setDirCachedMediaMetadata(cacheKey, metaMap);
+        this.dirMetadataCache.set(cacheKey, metaMap);
       } catch (e) {
         console.warn('dir items metadata fetch failed', e);
       }

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -77,6 +77,8 @@ import { convertToVTT, getSubtitleFormatExtension } from "@/utils/subtitles";
 import { globalVars } from "@/utils/constants";
 import { navigatePlaybackQueue } from "@/utils/playbackQueue.js";
 
+const DIR_METADATA_CACHE_KEY = 'mediaMetadataCache';
+
 export default {
   name: "preview",
   components: {
@@ -277,19 +279,64 @@ export default {
     mutations.clearNavigation();
   },
   methods: {
-    // Fetches directory metadata and attaches it to listing items (for playback queue)
-    async attachMediaMetadata(listing, dirPath) {
+    getDirCachedMediaMetadata(cacheKey) {
+      try {
+        const stored = sessionStorage.getItem(DIR_METADATA_CACHE_KEY);
+        if (!stored) return null;
+        const array = JSON.parse(stored);
+        if (!Array.isArray(array)) return null;
+        const cacheMap = new Map(array);
+        const entries = cacheMap.get(cacheKey);
+        if (!entries || !Array.isArray(entries)) return null;
+        return new Map(entries);
+      } catch (_) {
+        return null;
+      }
+    },
+    setDirCachedMediaMetadata(cacheKey, metaMap) {
+      try {
+        const stored = sessionStorage.getItem(DIR_METADATA_CACHE_KEY);
+        let cacheMap = new Map();
+        if (stored) {
+          const array = JSON.parse(stored);
+          if (Array.isArray(array)) cacheMap = new Map(array);
+        }
+        cacheMap.set(cacheKey, Array.from(metaMap.entries()));
+        sessionStorage.setItem(DIR_METADATA_CACHE_KEY, JSON.stringify(Array.from(cacheMap.entries())));
+      } catch (_) { /* ignore */ }
+    },
+    async attachDirMediaMetadata(listing, dirPath) {
+      // Fetches directory metadata and attaches it to the items for playback queue.
+      // gets cached for the current dir onto session storage -- it might look similar to enrichAvFromMediaApi but
+      // this one gets called only once per dir (instead of per item) and doesn't carry album art.
       if (!listing?.length) return;
+      const cacheKey = getters.isShare()
+        ? `${state.shareInfo.hash}:${dirPath}`
+        : `${state.req.source}:${dirPath}`;
+      const cachedMap = this.getDirCachedMediaMetadata(cacheKey);
+      if (cachedMap) {
+        listing.forEach(item => {
+          if (cachedMap.has(item.name)) {
+            item.metadata = cachedMap.get(item.name);
+          }
+        });
+        return;
+      }
       try {
         const isShare = getters.isShare();
         const payload = isShare
-          ? await mediaApi.fetchDirectoryMediaMetadataPublic(dirPath, state.shareInfo.hash, localStorage.getItem(`sharepass:${state.shareInfo.hash}`) || '', true)
-          : await mediaApi.fetchDirectoryMediaMetadata(state.req.source, dirPath, true);
+          ? await mediaApi.fetchDirectoryMediaMetadataPublic(dirPath, state.shareInfo.hash, localStorage.getItem(`sharepass:${state.shareInfo.hash}`) || '', false)
+          : await mediaApi.fetchDirectoryMediaMetadata(state.req.source, dirPath, false);
         if (!payload?.items) return;
         const metaMap = new Map(payload.items.filter(i => i.metadata).map(i => [i.name, i.metadata]));
-        listing.forEach(item => { if (metaMap.has(item.name)) item.metadata = metaMap.get(item.name); });
+        listing.forEach(item => {
+          if (metaMap.has(item.name)) {
+            item.metadata = metaMap.get(item.name);
+          }
+        });
+        this.setDirCachedMediaMetadata(cacheKey, metaMap);
       } catch (e) {
-        console.warn('Preview: directory metadata fetch failed', e);
+        console.warn('dir items metadata fetch failed', e);
       }
     },
     async loadPreviewForReq() {
@@ -341,7 +388,7 @@ export default {
       await this.updatePreview();
       if (isAv && this.listing) {
         const directoryPath = url.removeLastDir(state.req.path) || '/';
-        await this.attachMediaMetadata(this.listing, directoryPath);
+        await this.attachDirMediaMetadata(this.listing, directoryPath);
       }
       this.subtitlesList = await this.subtitles();
       if (this.previewType === 'audio' && !this.useDefaultMediaPlayer && this.lyricsFetchedForPath !== state.req.path) {

--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -261,7 +261,9 @@ import {
   toggleLoop,
   getModeLabel,
   getModeIcon,
+  formatArtist
 } from '@/utils/playbackQueue.js';
+import { getTypeFromMime } from '@/utils/files.js';
 import AudioPanel from "@/components/files/AudioPanel.vue";
 import { getters, mutations, state } from '@/store';
 import { getObjectProperty } from '@/utils/object.js';
@@ -503,21 +505,10 @@ export default {
       return state.user.darkMode;
     },
     filetype() {
-      const mime = this.req.type || '';
-      const prefix = 'audio/';
-      if (mime.startsWith(prefix)) {
-        return mime.slice(prefix.length).toLowerCase();
-      }
-      return '';
+      return getTypeFromMime(this.req.type || '');
     },
     formattedArtist() {
-      if (!this.metadata?.artist) return '';
-      const parts = this.metadata.artist
-        // Common separators like 'feat.' 'ft.' ',' ';' '/' '&'
-        .split(/[,;/&]|\s+feat\.\s+|\s+ft\.\s+/i)
-        .map(s => s.trim())
-        .filter(Boolean);
-      return parts.join(' • ');
+      return formatArtist(this.metadata?.artist);
     },
     showButtons() {
       if (this.previewType === 'audio' && !this.isMobile && this.showDesktopPanel) {


### PR DESCRIPTION
<img height="318" alt="image" src="https://github.com/user-attachments/assets/2e092eef-16b3-4239-8c8c-0d7c43cf6eee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced media playback queue items with richer, UI-friendly metadata (title, optional artist/album/year, duration, file-type badge) and improved current-track indicators.
  * Audio/video previews now enrich directory entries with per-item media metadata, fetched once per directory and cached for reuse.

* **Bug Fixes**
  * Standardized duration, artist, and file-type display across media views using shared formatting utilities.
  * Updated queue auto-scroll/highlight behavior and hover styling to match the new queue item layout.
  * Removed a redundant preview update to streamline selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->