### PR TITLE
fix dropdown position if not enough space

### DIFF
--- a/frontend/src/components/MenuOptionList.vue
+++ b/frontend/src/components/MenuOptionList.vue
@@ -11,7 +11,7 @@
         @keydown.esc.prevent="$emit('close')"
       />
     </div>
-    <div ref="scroll" class="menu-option-list-scroll">
+    <div ref="scroll" class="menu-option-list-scroll" :style="scrollStyle">
       <button
         v-for="option in filteredOptions"
         :key="optionKey(option.value)"
@@ -64,6 +64,10 @@ export default {
       type: String,
       default: "",
     },
+    maxHeight: {
+      type: Number,
+      default: undefined,
+    },
   },
 
   emits: ["select", "update:searchQuery", "close"],
@@ -90,6 +94,12 @@ export default {
       return this.normalizedOptions.filter((option) => {
         return String(option.label).toLowerCase().includes(query);
       });
+    },
+    scrollStyle() {
+      if (this.maxHeight !== undefined) {
+        return { maxHeight: `${this.maxHeight}px` };
+      }
+      return {};
     },
   },
 
@@ -128,7 +138,7 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 0.1em;
-  max-height: 50vh;
+  max-height: 14rem;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/frontend/src/components/MenuOptionList.vue
+++ b/frontend/src/components/MenuOptionList.vue
@@ -96,7 +96,7 @@ export default {
       });
     },
     scrollStyle() {
-      if (this.maxHeight !== undefined) {
+      if (this.maxHeight !== undefined  && this.maxHeight !== null) {
         return { maxHeight: `${this.maxHeight}px` };
       }
       return {};

--- a/frontend/src/components/MenuOptionList.vue
+++ b/frontend/src/components/MenuOptionList.vue
@@ -128,7 +128,7 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 0.1em;
-  max-height: 14rem;
+  max-height: 50vh;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/frontend/src/components/settings/ExpandDropdown.vue
+++ b/frontend/src/components/settings/ExpandDropdown.vue
@@ -67,6 +67,7 @@
               :search-query="searchQuery"
               :search-placeholder="searchPlaceholder"
               :empty-label="emptyLabel"
+              :max-height="dropdownMaxHeight"
               @select="selectOption"
               @update:search-query="searchQuery = $event"
               @close="close"
@@ -174,6 +175,7 @@ export default {
       localInputId: `expand-dropdown-${expandDropdownIdCounter}`,
       panelResizeObserver: null,
       expandUpward: false,
+      dropdownMaxHeight: null,
     };
   },
 
@@ -350,17 +352,14 @@ export default {
         const viewportHeight = window.innerHeight;
         const spaceBelow = viewportHeight - rect.bottom;
         const spaceAbove = rect.top;
-        const minPanelHeight = 180;
-        if (spaceBelow >= minPanelHeight) {
-          this.expandUpward = false;
-        } else if (spaceAbove >= minPanelHeight) {
-          this.expandUpward = true;
-        } else {
-          // Not enough space either way, so pick the larger side
-          this.expandUpward = spaceAbove > spaceBelow;
-        }
+        this.expandUpward = spaceAbove > spaceBelow;
+        const padding = 15;
+        const cap = viewportHeight * 0.5; // 50vh
+        const availableSpace = this.expandUpward ? spaceAbove : spaceBelow;
+        this.dropdownMaxHeight = Math.max(100, Math.min(availableSpace - padding, cap));
       } else {
         this.expandUpward = false;
+        this.dropdownMaxHeight = null;
       }
       this.panelOpen = false;
       this.isExpanded = true;
@@ -398,6 +397,7 @@ export default {
       this.searchQuery = "";
       this.overlayStyle = {};
       this.expandUpward = false;
+      this.dropdownMaxHeight = null;
       this.unobservePanelResize();
     },
     onPanelAfterLeave() {
@@ -445,6 +445,14 @@ export default {
         style.top = `${anchorRect.bottom - 1}px`;
       }
       this.overlayStyle = style;
+      if (this.open) {
+        const padding = 15;
+        const cap = viewportHeight * 0.5;
+        const spaceBelow = viewportHeight - anchorRect.bottom;
+        const spaceAbove = anchorRect.top;
+        const availableSpace = this.expandUpward ? spaceAbove : spaceBelow;
+        this.dropdownMaxHeight = Math.max(100, Math.min(availableSpace - padding, cap));
+      }
     },
     onViewportChange() {
       if (this.open) {

--- a/frontend/src/components/settings/ExpandDropdown.vue
+++ b/frontend/src/components/settings/ExpandDropdown.vue
@@ -10,7 +10,7 @@
     <div
       ref="anchor"
       class="expand-dropdown-anchor menu-panel no-select border-radius"
-      :class="{ 'dark-mode': isDarkMode }"
+      :class="{ 'dark-mode': isDarkMode, 'expand-upward': open && expandUpward }"
     >
       <button
         ref="trigger"
@@ -40,7 +40,7 @@
         v-if="open"
         ref="overlay"
         class="expand-dropdown-overlay"
-        :class="{ 'dark-mode': isDarkMode }"
+        :class="{ 'dark-mode': isDarkMode, 'expand-upward': expandUpward }"
         :style="overlayStyle"
       >
         <transition
@@ -54,6 +54,7 @@
             v-if="panelOpen"
             ref="panel"
             class="expand-dropdown-body menu-panel no-select border-radius"
+            :class="{ 'expand-upward': expandUpward }"
             role="listbox"
             :aria-multiselectable="allowMultiple ? 'true' : 'false'"
             :aria-label="resolvedAriaLabel"
@@ -172,6 +173,7 @@ export default {
       overlayStyle: {},
       localInputId: `expand-dropdown-${expandDropdownIdCounter}`,
       panelResizeObserver: null,
+      expandUpward: false,
     };
   },
 
@@ -341,6 +343,25 @@ export default {
       if (this.disabled || this.open) {
         return;
       }
+      // Decide if open upward
+      const anchor = this.$refs.anchor;
+      if (anchor) {
+        const rect = anchor.getBoundingClientRect();
+        const viewportHeight = window.innerHeight;
+        const spaceBelow = viewportHeight - rect.bottom;
+        const spaceAbove = rect.top;
+        const minPanelHeight = 180;
+        if (spaceBelow >= minPanelHeight) {
+          this.expandUpward = false;
+        } else if (spaceAbove >= minPanelHeight) {
+          this.expandUpward = true;
+        } else {
+          // Not enough space either way, so pick the larger side
+          this.expandUpward = spaceAbove > spaceBelow;
+        }
+      } else {
+        this.expandUpward = false;
+      }
       this.panelOpen = false;
       this.isExpanded = true;
       this.updateOverlayPosition();
@@ -376,6 +397,7 @@ export default {
       this.isExpanded = false;
       this.searchQuery = "";
       this.overlayStyle = {};
+      this.expandUpward = false;
       this.unobservePanelResize();
     },
     onPanelAfterLeave() {
@@ -410,14 +432,19 @@ export default {
         return;
       }
       const anchorRect = anchor.getBoundingClientRect();
-
-      this.overlayStyle = {
+      const viewportHeight = window.innerHeight;
+      const style = {
         position: "fixed",
-        top: `${anchorRect.bottom - 1}px`,
         left: `${anchorRect.left}px`,
         width: `${anchorRect.width}px`,
         zIndex: 1000,
       };
+      if (this.expandUpward) {
+        style.bottom = `${viewportHeight - anchorRect.top + 1}px`;
+      } else {
+        style.top = `${anchorRect.bottom - 1}px`;
+      }
+      this.overlayStyle = style;
     },
     onViewportChange() {
       if (this.open) {
@@ -501,11 +528,26 @@ export default {
   border-bottom-color: var(--background);
 }
 
+.expand-dropdown--open .expand-dropdown-anchor.expand-upward {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+  border-bottom-left-radius: var(--borderRadius);
+  border-bottom-right-radius: var(--borderRadius);
+  border-bottom-color: var(--surfaceSecondary);
+  border-top-color: var(--background);
+}
+
 .expand-dropdown-overlay {
   box-sizing: border-box;
   background: transparent;
   overflow: visible;
   z-index: 1000;
+}
+
+.expand-dropdown-overlay.expand-upward {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
 }
 
 .expand-dropdown-body {
@@ -522,6 +564,18 @@ export default {
   padding: 0 0.5em 0.5em;
   justify-content: flex-start;
   align-items: stretch;
+}
+
+.expand-dropdown-body.expand-upward {
+  border-top-left-radius: var(--borderRadius) !important;
+  border-top-right-radius: var(--borderRadius) !important;
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+  border-top-width: 1px;
+  border-bottom-width: 0;
+  margin-top: 0;
+  padding-top: 0.5em;
+  padding-bottom: 0;
 }
 
 .expand-dropdown-trigger {


### PR DESCRIPTION
The dropdown was always opening downward, but if there's not much space the list can go off-screen making difficult to select something. Was more noticeable on the language selector since that one is at the bottom. So now if there's not enough space in the viewport will open upwards instead.

Before:

<img width="1261" height="219" alt="1782849084472424036" src="https://github.com/user-attachments/assets/c0ad9727-800f-4e71-b5cc-4f22bcf5d9d6" />

Now:

<img height="372" alt="1782849094946315776" src="https://github.com/user-attachments/assets/276cb004-60cd-4058-9c61-cfefaea277e2" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Dropdown menus now automatically expand upward when there isn’t enough space below.
  * The dropdown options list can be constrained to a configurable maximum height for improved responsiveness.

* **Bug Fixes**
  * Improved overlay positioning and visual styling so upward-expanding dropdowns remain properly aligned and connected to the trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->