### PR TITLE
fix token when returning from preview on shares with pass

### DIFF
--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -1070,10 +1070,18 @@ export const mutations = {
     emitStateChanged();
   },
   setShareInfo: (shareInfo) => {
-    if (state.shareInfo === shareInfo) {
-      return;
-    }
-    state.shareInfo = shareInfo;
+   // Merge with existing state
+   const merged = { ...state.shareInfo, ...shareInfo };
+   if (shareInfo.token === undefined && state.shareInfo.token) {
+     merged.token = state.shareInfo.token;
+   }
+   if (shareInfo.passwordValid === undefined && state.shareInfo.passwordValid !== undefined) {
+     merged.passwordValid = state.shareInfo.passwordValid;
+   }
+   if (JSON.stringify(merged) === JSON.stringify(state.shareInfo)) {
+     return;
+   }
+   state.shareInfo = merged;
     updateManifestLink();
     emitStateChanged();
   },


### PR DESCRIPTION
Fixes #2573 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Share information now updates more reliably, keeping existing token and password status when those values aren’t provided in a new update.
  * Reduced unnecessary refreshes by only applying changes when the combined share information actually differs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->