### PR TITLE
updated with some api consolidation and changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. For commit 
 A database migration is required to go from v1.x to this version. See docs.
 
  **New Features**:
- - Download grant mechanism to distinguish between UI viewing and download.
+ - View grant mechanism to distinguish between UI viewing and download.
  - ffmpeg hardware acceleration detection and support via go-ffmpeg
   - video streaming is limited to viewing only.
  # - granular per source permissions and access

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ A database migration is required to go from v1.x to this version. See docs.
  - user updates are more granular, don't include entire user payload.
  - `user.id` has been moved to a backend property and all frontend apis now query users by username. Swagger has been updated.
  - removed legacy and deprecated properties from API responses and generated config output
+ - Moved stream api to `/media/stream`
+ - `/api/media/stream` is audio/video only (range-based chunking). Non-media inline viewing uses `GET /api/resources/view`. Both endpoints use the same `viewToken` from file metadata.
 
 ## v1.5.0
 

--- a/backend/common/utils/cache.go
+++ b/backend/common/utils/cache.go
@@ -12,5 +12,5 @@ var (
 	SearchResultsCache = cache.NewCache[string](15*time.Second, 1*time.Hour)
 	OnlyOfficeCache    = cache.NewCache[string](48*time.Hour, 1*time.Hour)
 	JwtCache           = cache.NewCache[string](1*time.Hour, 72*time.Hour)
-	StreamGrantsCache = cache.NewCache[StreamGrant](15 * time.Minute)
+	ViewGrantsCache = cache.NewCache[ViewGrant](15 * time.Minute)
 )

--- a/backend/common/utils/stream_grant.go
+++ b/backend/common/utils/stream_grant.go
@@ -1,8 +1,8 @@
 package utils
 
-// StreamGrant authorizes inline streaming of a single file for a specific viewer.
+// ViewGrant authorizes inline viewing/streaming of a single file for a specific viewer.
 // UserID is internal only and never exposed to clients.
-type StreamGrant struct {
+type ViewGrant struct {
 	UserID    uint64
 	ShareHash string
 	Source    string

--- a/backend/http/httpRouter.go
+++ b/backend/http/httpRouter.go
@@ -32,6 +32,10 @@ import (
 //go:embed embed/*
 var assets embed.FS
 
+const (
+	mediaHandlerTimeout = 60 * time.Second
+)
+
 // GetEmbeddedAssets returns the embedded assets filesystem
 func GetEmbeddedAssets() embed.FS {
 	return assets
@@ -136,7 +140,7 @@ func StartHttp(ctx context.Context, shutdownComplete chan struct{}) {
 	api.HandleFunc("POST /resources/archive", withUser(archiveCreateHandler))
 	api.HandleFunc("POST /resources/unarchive", withUser(unarchiveHandler))
 	api.HandleFunc("GET /resources/download", withUser(downloadHandler))
-	api.HandleFunc("GET /resources/stream", withUser(streamHandler))
+	api.HandleFunc("GET /resources/view", withTimeout(mediaHandlerTimeout, withUserHelper(viewHandler)))
 	api.HandleFunc("GET /resources/preview", withTimeout(30*time.Second, withUserHelper(previewHandler)))
 	api.HandleFunc("POST /resources/pause", withUser(resourcePauseHandler))
 	publicApi.HandleFunc("GET /resources", withHashFile(publicGetResourceHandler))
@@ -147,9 +151,12 @@ func StartHttp(ctx context.Context, shutdownComplete chan struct{}) {
 	publicApi.HandleFunc("DELETE /resources/bulk", withHashFile(publicBulkDeleteHandler))
 	publicApi.HandleFunc("PATCH /resources", withHashFile(publicPatchHandler))
 	publicApi.HandleFunc("GET /resources/download", withHashFile(publicDownloadHandler))
-	publicApi.HandleFunc("GET /resources/stream", withHashFile(publicStreamHandler))
+	publicApi.HandleFunc("GET /resources/view", withTimeout(mediaHandlerTimeout, withHashFileHelper(publicViewHandler)))
 	publicApi.HandleFunc("GET /resources/preview", withTimeout(30*time.Second, withHashFileHelper(publicPreviewHandler)))
 	publicApi.HandleFunc("POST /resources/pause", withHashFile(publicPauseHandler))
+	// Legacy routes (backwards compatibility)
+	api.HandleFunc("GET /raw", withUser(downloadHandler))
+	publicApi.HandleFunc("GET /raw", withHashFile(publicDownloadHandler))
 
 	// ========================================
 	// Access Routes - /api/access/
@@ -196,11 +203,13 @@ func StartHttp(ctx context.Context, shutdownComplete chan struct{}) {
 	// ========================================
 	// Media Routes - /api/media/ (with public routes)
 	// ========================================
-	api.HandleFunc("GET /media/subtitles", withUser(subtitlesHandler))
-	api.HandleFunc("GET /media/metadata", withUser(metadataHandler))
-	api.HandleFunc("GET /media/lyrics", withUser(lyricsHandler))
-	publicApi.HandleFunc("GET /media/metadata", withHashFile(publicMetadataHandler))
-	publicApi.HandleFunc("GET /media/lyrics", withHashFile(publicLyricsHandler))
+	api.HandleFunc("GET /media/subtitles", withTimeout(mediaHandlerTimeout, withUserHelper(subtitlesHandler)))
+	api.HandleFunc("GET /media/metadata", withTimeout(mediaHandlerTimeout, withUserHelper(metadataHandler)))
+	api.HandleFunc("GET /media/lyrics", withTimeout(mediaHandlerTimeout, withUserHelper(lyricsHandler)))
+	api.HandleFunc("GET /media/stream", withTimeout(mediaHandlerTimeout, withUserHelper(streamHandler)))
+	publicApi.HandleFunc("GET /media/metadata", withTimeout(mediaHandlerTimeout, withHashFileHelper(publicMetadataHandler)))
+	publicApi.HandleFunc("GET /media/lyrics", withTimeout(mediaHandlerTimeout, withHashFileHelper(publicLyricsHandler)))
+	publicApi.HandleFunc("GET /media/stream", withTimeout(mediaHandlerTimeout, withHashFileHelper(publicStreamHandler)))
 
 	// ========================================
 	// OnlyOffice Routes - /api/office/ (with public routes)

--- a/backend/http/middleware.go
+++ b/backend/http/middleware.go
@@ -51,6 +51,19 @@ type HttpResponse struct {
 	Token   string `json:"token,omitempty"`
 }
 
+// requestTimeoutError is returned by withTimeout when the handler exceeds its budget.
+type requestTimeoutError struct {
+	timeout time.Duration
+}
+
+func newRequestTimeoutError(timeout time.Duration) error {
+	return &requestTimeoutError{timeout: timeout}
+}
+
+func (e *requestTimeoutError) Error() string {
+	return fmt.Sprintf("request timed out after %s", e.timeout)
+}
+
 var FileInfoFasterFunc = files.FileInfoFaster
 
 // Updated handleFunc to match the new signature
@@ -134,7 +147,8 @@ func withHashFileHelper(fn handleFunc) handleFunc {
 			(r.Method == "GET" && strings.Contains(r.URL.Path, "/resources/items")) ||
 			(r.Method == "GET" && strings.Contains(r.URL.Path, "/media/metadata")) ||
 			(r.Method == "GET" && strings.Contains(r.URL.Path, "/resources/download")) ||
-			(r.Method == "GET" && strings.Contains(r.URL.Path, "/resources/stream")) {
+			(r.Method == "GET" && strings.Contains(r.URL.Path, "/resources/view")) ||
+			(r.Method == "GET" && strings.Contains(r.URL.Path, "/media/stream")) {
 			return fn(w, r, data)
 		}
 		file, err := FileInfoFasterFunc(utils.FileOptions{
@@ -162,9 +176,9 @@ func withHashFileHelper(fn handleFunc) handleFunc {
 			file.OnlyOfficeId = ""
 		}
 		if file.Type != "directory" {
-			attachStreamToken(data, source.Name, path, file)
+			attachViewToken(data, source.Name, path, file)
 		} else {
-			attachStreamTokensForDirectory(data, source.Name, path, file)
+			attachViewTokensForDirectory(data, source.Name, path, file)
 		}
 		file.Path = utils.AddTrailingSlashIfNotExists(path)
 		// Set the file info in the `data` object
@@ -732,9 +746,8 @@ func withTimeoutHelper(timeout time.Duration, fn handleFunc) handleFunc {
 		// Call the handler and check for timeout
 		status, err := fn(w, r, data)
 
-		// Check if the context was cancelled due to timeout
 		if ctx.Err() == context.DeadlineExceeded {
-			return http.StatusRequestTimeout, fmt.Errorf("request timed out after %.0f seconds", timeout.Seconds())
+			return http.StatusRequestTimeout, newRequestTimeoutError(timeout)
 		}
 
 		return status, err

--- a/backend/http/middleware_test.go
+++ b/backend/http/middleware_test.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -336,4 +338,57 @@ func newHTTPRequest(t *testing.T, hash string, requestModifiers ...func(*http.Re
 		modify(r)
 	}
 	return r
+}
+
+func TestWithTimeoutReturnsJSONTimeoutReason(t *testing.T) {
+	t.Parallel()
+	timeout := 50 * time.Millisecond
+	handler := withTimeout(timeout, func(w http.ResponseWriter, r *http.Request, data *requestContext) (int, error) {
+		<-r.Context().Done()
+		return http.StatusOK, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestTimeout)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Fatalf("content-type = %q", ct)
+	}
+
+	var body HttpResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Status != http.StatusRequestTimeout {
+		t.Fatalf("body.status = %d", body.Status)
+	}
+	if body.Message != "request timed out after "+timeout.String() {
+		t.Fatalf("body.message = %q, want request timed out after %q", body.Message, timeout.String())
+	}
+}
+
+func TestWithTimeoutHandlerErrorBeforeDeadline(t *testing.T) {
+	t.Parallel()
+	handler := withTimeout(time.Second, func(w http.ResponseWriter, r *http.Request, data *requestContext) (int, error) {
+		return http.StatusBadRequest, context.Canceled
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	var body HttpResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Message != context.Canceled.Error() {
+		t.Fatalf("body.message = %q", body.Message)
+	}
 }

--- a/backend/http/resource.go
+++ b/backend/http/resource.go
@@ -132,7 +132,7 @@ func resourceGetHandler(w http.ResponseWriter, r *http.Request, d *requestContex
 		return http.StatusForbidden, fmt.Errorf("user is not allowed to get content, requires download permission")
 	}
 	if fileInfo.Type == "directory" {
-		attachStreamTokensForDirectory(d, source, path, fileInfo)
+		attachViewTokensForDirectory(d, source, path, fileInfo)
 		return renderJSON(w, r, fileInfo)
 	}
 	if algo := r.URL.Query().Get("checksum"); algo != "" {
@@ -145,7 +145,7 @@ func resourceGetHandler(w http.ResponseWriter, r *http.Request, d *requestContex
 		fileInfo.Checksums = make(map[string]string)
 		fileInfo.Checksums[algo] = checksum
 	}
-	attachStreamToken(d, source, path, fileInfo)
+	attachViewToken(d, source, path, fileInfo)
 	return renderJSON(w, r, fileInfo)
 }
 

--- a/backend/http/stream.go
+++ b/backend/http/stream.go
@@ -114,19 +114,19 @@ func streamFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContex
 	})
 }
 
-// streamHandler serves inline file content for UI viewing with a valid streamToken.
-// @Summary Stream content of a single file for inline viewing
-// @Description Returns raw file bytes for inline UI viewing in capped byte ranges. Requires a streamToken minted by GET /resources. Media files and restricted viewers must use Range requests; full-file GET responses are rejected. Never counts toward download limits or activity.
+// streamHandler serves inline audio/video content with a valid viewToken.
+// @Summary Stream content of a single media file for inline viewing
+// @Description Returns raw file bytes for inline UI viewing in capped byte ranges. Requires a viewToken minted by GET /resources. Media files must use Range requests; full-file GET responses are rejected. Never counts toward download limits or activity.
 // @Tags Resources
 // @Accept json
 // @Param source query string true "Source name for the file (required)"
 // @Param file query string true "File path"
-// @Param streamToken query string true "Opaque stream grant token from file metadata"
+// @Param viewToken query string true "Opaque view grant token from file metadata"
 // @Success 200 {file} file "Raw file content (inline)"
-// @Failure 403 {object} map[string]string "Missing or invalid stream token"
+// @Failure 403 {object} map[string]string "Missing or invalid view token"
 // @Failure 404 {object} map[string]string "File not found"
 // @Failure 500 {object} map[string]string "Internal server error"
-// @Router /api/resources/stream [get]
+// @Router /api/media/stream [get]
 func streamHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
 	if r.URL.Query().Get("archiveToken") != "" || r.URL.Query().Get("algo") != "" {
 		return http.StatusForbidden, fmt.Errorf("archives not supported on stream endpoint")
@@ -136,16 +136,19 @@ func streamHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (i
 	if len(fileList) != 1 {
 		return http.StatusForbidden, fmt.Errorf("stream supports single file only")
 	}
-	token := r.URL.Query().Get("streamToken")
+	token := r.URL.Query().Get("viewToken")
 	if token == "" {
-		return http.StatusForbidden, fmt.Errorf("stream token required")
+		return http.StatusForbidden, fmt.Errorf("view token required")
 	}
 	cleanPath, err := utils.SanitizePath(fileList[0])
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("invalid file path: %v", err)
 	}
-	if err = validateStreamGrant(token, d, source, cleanPath); err != nil {
+	if err = validateViewGrant(token, d, source, cleanPath); err != nil {
 		return http.StatusForbidden, err
+	}
+	if !isMediaStreamFile(filepath.Base(cleanPath)) {
+		return http.StatusForbidden, fmt.Errorf("stream endpoint supports audio and video only")
 	}
 
 	userscope, err := d.user.GetScopeForSourceName(source)
@@ -156,20 +159,20 @@ func streamHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (i
 	return streamFilesHandler(w, r, d, source, []string{scopedPath})
 }
 
-// publicStreamHandler serves inline file content from a public share with a valid streamToken.
-// @Summary Stream a single file from a public share for inline viewing
-// @Description Returns raw file bytes for inline UI viewing in capped byte ranges on a share link. Requires streamToken from GET /public/api/resources. Media files and shares with downloads disabled must use Range requests. Does not count toward download limits.
+// publicStreamHandler serves inline audio/video content from a public share with a valid viewToken.
+// @Summary Stream a single media file from a public share for inline viewing
+// @Description Returns raw file bytes for inline UI viewing in capped byte ranges on a share link. Requires viewToken from GET /public/api/resources. Media files must use Range requests. Does not count toward download limits.
 // @Tags Resources
 // @Accept json
 // @Produce octet-stream
 // @Param hash query string true "Share hash for authentication"
 // @Param file query string true "File path within the share"
-// @Param streamToken query string true "Opaque stream grant token from share file metadata"
+// @Param viewToken query string true "Opaque view grant token from share file metadata"
 // @Success 200 {file} file "Raw file content (inline)"
-// @Failure 403 {object} map[string]string "Missing or invalid stream token"
+// @Failure 403 {object} map[string]string "Missing or invalid view token"
 // @Failure 404 {object} map[string]string "Share or file not found"
 // @Failure 500 {object} map[string]string "Internal server error"
-// @Router /public/api/resources/stream [get]
+// @Router /public/api/media/stream [get]
 func publicStreamHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
 	if d.share.ShareType == "upload" {
 		return http.StatusNotImplemented, fmt.Errorf("streaming is disabled for upload shares")
@@ -181,9 +184,9 @@ func publicStreamHandler(w http.ResponseWriter, r *http.Request, d *requestConte
 	if len(files) != 1 {
 		return http.StatusForbidden, fmt.Errorf("stream supports single file only")
 	}
-	token := r.URL.Query().Get("streamToken")
+	token := r.URL.Query().Get("viewToken")
 	if token == "" {
-		return http.StatusForbidden, fmt.Errorf("stream token required")
+		return http.StatusForbidden, fmt.Errorf("view token required")
 	}
 	cleanFile, err := utils.SanitizePath(files[0])
 	if err != nil {
@@ -193,8 +196,11 @@ func publicStreamHandler(w http.ResponseWriter, r *http.Request, d *requestConte
 	if !ok {
 		return http.StatusInternalServerError, fmt.Errorf("source not found for share")
 	}
-	if err = validateStreamGrant(token, d, sourceInfo.Name, cleanFile); err != nil {
+	if err = validateViewGrant(token, d, sourceInfo.Name, cleanFile); err != nil {
 		return http.StatusForbidden, err
+	}
+	if !isMediaStreamFile(filepath.Base(cleanFile)) {
+		return http.StatusForbidden, fmt.Errorf("stream endpoint supports audio and video only")
 	}
 	scopedPath := utils.JoinPathAsUnix(d.share.Path, cleanFile)
 	status, err := streamFilesHandler(w, r, d, sourceInfo.Name, []string{scopedPath})

--- a/backend/http/stream_grant.go
+++ b/backend/http/stream_grant.go
@@ -10,65 +10,65 @@ import (
 	"github.com/gtsteffaniak/filebrowser/backend/indexing/iteminfo"
 )
 
-const streamGrantTTL = 15 * time.Minute
+const viewGrantTTL = 15 * time.Minute
 
-func normalizeStreamGrantPath(p string) string {
+func normalizeViewGrantPath(p string) string {
 	return filepath.ToSlash(strings.TrimSpace(p))
 }
 
-func mintStreamGrant(d *requestContext, source, filePath string) (string, error) {
+func mintViewGrant(d *requestContext, source, filePath string) (string, error) {
 	token, err := utils.RandomHex(16)
 	if err != nil {
 		return "", err
 	}
-	grant := utils.StreamGrant{
+	grant := utils.ViewGrant{
 		UserID:    d.user.ID,
 		ShareHash: d.share.Hash,
 		Source:    source,
-		Path:      normalizeStreamGrantPath(filePath),
-		ExpiresAt: time.Now().Add(streamGrantTTL).Unix(),
+		Path:      normalizeViewGrantPath(filePath),
+		ExpiresAt: time.Now().Add(viewGrantTTL).Unix(),
 	}
-	utils.StreamGrantsCache.Set(token, grant)
+	utils.ViewGrantsCache.Set(token, grant)
 	return token, nil
 }
 
-func validateStreamGrant(token string, d *requestContext, source, filePath string) error {
-	grant, ok := utils.StreamGrantsCache.Get(token)
+func validateViewGrant(token string, d *requestContext, source, filePath string) error {
+	grant, ok := utils.ViewGrantsCache.Get(token)
 	if !ok {
-		return fmt.Errorf("invalid or expired stream token")
+		return fmt.Errorf("invalid or expired view token")
 	}
 	if time.Now().Unix() > grant.ExpiresAt {
-		utils.StreamGrantsCache.Delete(token)
-		return fmt.Errorf("stream token expired")
+		utils.ViewGrantsCache.Delete(token)
+		return fmt.Errorf("view token expired")
 	}
 	if grant.UserID != d.user.ID {
-		return fmt.Errorf("stream token viewer mismatch")
+		return fmt.Errorf("view token viewer mismatch")
 	}
 	if grant.ShareHash != d.share.Hash {
-		return fmt.Errorf("stream token share mismatch")
+		return fmt.Errorf("view token share mismatch")
 	}
 	if grant.Source != source {
-		return fmt.Errorf("stream token source mismatch")
+		return fmt.Errorf("view token source mismatch")
 	}
-	if grant.Path != normalizeStreamGrantPath(filePath) {
-		return fmt.Errorf("stream token path mismatch")
+	if grant.Path != normalizeViewGrantPath(filePath) {
+		return fmt.Errorf("view token path mismatch")
 	}
 	return nil
 }
 
-func attachStreamToken(d *requestContext, source, filePath string, file *iteminfo.ExtendedFileInfo) {
+func attachViewToken(d *requestContext, source, filePath string, file *iteminfo.ExtendedFileInfo) {
 	if file == nil || file.Type == "directory" {
 		return
 	}
-	token, err := mintStreamGrant(d, source, filePath)
+	token, err := mintViewGrant(d, source, filePath)
 	if err != nil {
 		return
 	}
-	file.StreamToken = token
+	file.ViewToken = token
 }
 
 func indexFilePath(dirPath, name string) string {
-	dirPath = normalizeStreamGrantPath(dirPath)
+	dirPath = normalizeViewGrantPath(dirPath)
 	if dirPath == "" || dirPath == "/" {
 		return "/" + name
 	}
@@ -78,7 +78,7 @@ func indexFilePath(dirPath, name string) string {
 	return dirPath + name
 }
 
-func attachStreamTokensForDirectory(d *requestContext, source, dirPath string, file *iteminfo.ExtendedFileInfo) {
+func attachViewTokensForDirectory(d *requestContext, source, dirPath string, file *iteminfo.ExtendedFileInfo) {
 	if file == nil || file.Type != "directory" {
 		return
 	}
@@ -87,10 +87,10 @@ func attachStreamTokensForDirectory(d *requestContext, source, dirPath string, f
 			continue
 		}
 		childPath := indexFilePath(dirPath, file.Files[i].Name)
-		token, err := mintStreamGrant(d, source, childPath)
+		token, err := mintViewGrant(d, source, childPath)
 		if err != nil {
 			continue
 		}
-		file.Files[i].StreamToken = token
+		file.Files[i].ViewToken = token
 	}
 }

--- a/backend/http/stream_grant_test.go
+++ b/backend/http/stream_grant_test.go
@@ -12,73 +12,73 @@ import (
 	"github.com/gtsteffaniak/filebrowser/backend/indexing/iteminfo"
 )
 
-func TestMintAndValidateStreamGrant(t *testing.T) {
+func TestMintAndValidateViewGrant(t *testing.T) {
 	t.Parallel()
 	d := &requestContext{
 		user: &users.User{ID: 42, FrontendUser: users.FrontendUser{Username: "alice"}},
 	}
-	token, err := mintStreamGrant(d, "default", "/docs/readme.txt")
+	token, err := mintViewGrant(d, "default", "/docs/track.mp3")
 	if err != nil {
-		t.Fatalf("mintStreamGrant: %v", err)
+		t.Fatalf("mintViewGrant: %v", err)
 	}
 	if token == "" {
 		t.Fatal("expected non-empty token")
 	}
-	if err := validateStreamGrant(token, d, "default", "/docs/readme.txt"); err != nil {
-		t.Fatalf("validateStreamGrant: %v", err)
+	if err := validateViewGrant(token, d, "default", "/docs/track.mp3"); err != nil {
+		t.Fatalf("validateViewGrant: %v", err)
 	}
 }
 
-func TestValidateStreamGrantWrongUser(t *testing.T) {
+func TestValidateViewGrantWrongUser(t *testing.T) {
 	t.Parallel()
 	owner := &requestContext{user: &users.User{ID: 1}}
 	other := &requestContext{user: &users.User{ID: 2}}
-	token, err := mintStreamGrant(owner, "default", "/a.txt")
+	token, err := mintViewGrant(owner, "default", "/a.mp3")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := validateStreamGrant(token, other, "default", "/a.txt"); err == nil {
+	if err := validateViewGrant(token, other, "default", "/a.mp3"); err == nil {
 		t.Fatal("expected viewer mismatch error")
 	}
 }
 
-func TestValidateStreamGrantWrongPath(t *testing.T) {
+func TestValidateViewGrantWrongPath(t *testing.T) {
 	t.Parallel()
 	d := &requestContext{user: &users.User{ID: 1}}
-	token, err := mintStreamGrant(d, "default", "/a.txt")
+	token, err := mintViewGrant(d, "default", "/a.mp3")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := validateStreamGrant(token, d, "default", "/b.txt"); err == nil {
+	if err := validateViewGrant(token, d, "default", "/b.mp3"); err == nil {
 		t.Fatal("expected path mismatch error")
 	}
 }
 
-func TestValidateStreamGrantExpired(t *testing.T) {
+func TestValidateViewGrantExpired(t *testing.T) {
 	t.Parallel()
 	token, err := utils.RandomHex(16)
 	if err != nil {
 		t.Fatal(err)
 	}
-	utils.StreamGrantsCache.Set(token, utils.StreamGrant{
+	utils.ViewGrantsCache.Set(token, utils.ViewGrant{
 		UserID:    1,
 		Source:    "default",
-		Path:      "/a.txt",
+		Path:      "/a.mp3",
 		ExpiresAt: time.Now().Add(-time.Minute).Unix(),
 	})
 	d := &requestContext{user: &users.User{ID: 1}}
-	if err := validateStreamGrant(token, d, "default", "/a.txt"); err == nil {
+	if err := validateViewGrant(token, d, "default", "/a.mp3"); err == nil {
 		t.Fatal("expected expired token error")
 	}
 }
 
-func TestValidateStreamGrantShareBinding(t *testing.T) {
+func TestValidateViewGrantShareBinding(t *testing.T) {
 	t.Parallel()
 	d := &requestContext{
 		user:  &users.User{ID: 1},
 		share: share.Share{ShareColumns: share.ShareColumns{Hash: "abc123"}},
 	}
-	token, err := mintStreamGrant(d, "srv", "/file.txt")
+	token, err := mintViewGrant(d, "srv", "/file.mp3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,42 +86,108 @@ func TestValidateStreamGrantShareBinding(t *testing.T) {
 		user:  &users.User{ID: 1},
 		share: share.Share{ShareColumns: share.ShareColumns{Hash: "other"}},
 	}
-	if err := validateStreamGrant(token, wrongShare, "srv", "/file.txt"); err == nil {
+	if err := validateViewGrant(token, wrongShare, "srv", "/file.mp3"); err == nil {
 		t.Fatal("expected share mismatch error")
 	}
 }
 
+func TestAttachViewTokenForAllFileTypes(t *testing.T) {
+	t.Parallel()
+	d := &requestContext{user: &users.User{ID: 7}}
+	audio := &iteminfo.ExtendedFileInfo{
+		FileInfo: iteminfo.FileInfo{
+			ItemInfo: iteminfo.ItemInfo{Name: "song.mp3", Type: "audio/mpeg"},
+		},
+	}
+	attachViewToken(d, "default", "/song.mp3", audio)
+	if audio.ViewToken == "" {
+		t.Fatal("expected view token on audio file")
+	}
+	doc := &iteminfo.ExtendedFileInfo{
+		FileInfo: iteminfo.FileInfo{
+			ItemInfo: iteminfo.ItemInfo{Name: "readme.txt", Type: "text/plain"},
+		},
+	}
+	attachViewToken(d, "default", "/readme.txt", doc)
+	if doc.ViewToken == "" {
+		t.Fatal("expected view token on non-media file")
+	}
+}
 
-func TestAttachStreamTokensForDirectory(t *testing.T) {
+func TestAttachViewTokensForDirectory(t *testing.T) {
 	t.Parallel()
 	d := &requestContext{user: &users.User{ID: 7}}
 	file := &iteminfo.ExtendedFileInfo{
 		FileInfo: iteminfo.FileInfo{
 			ItemInfo: iteminfo.ItemInfo{Type: "directory"},
 			Files: []iteminfo.ExtendedItemInfo{
-				{ItemInfo: iteminfo.ItemInfo{Name: "a.jpg", Type: "image/jpeg"}},
+				{ItemInfo: iteminfo.ItemInfo{Name: "song.mp3", Type: "audio/mpeg"}},
+				{ItemInfo: iteminfo.ItemInfo{Name: "photo.jpg", Type: "image/jpeg"}},
 				{ItemInfo: iteminfo.ItemInfo{Name: "nested", Type: "directory"}},
 			},
 		},
 	}
-	attachStreamTokensForDirectory(d, "Downloads", "/photos/", file)
-	if file.Files[0].StreamToken == "" {
-		t.Fatal("expected stream token on directory child file")
+	attachViewTokensForDirectory(d, "Downloads", "/media/", file)
+	if file.Files[0].ViewToken == "" {
+		t.Fatal("expected view token on audio file")
 	}
-	if file.Files[1].StreamToken != "" {
-		t.Fatal("did not expect stream token on directory child folder")
+	if file.Files[1].ViewToken == "" {
+		t.Fatal("expected view token on image file")
 	}
-	token := file.Files[0].StreamToken
-	if err := validateStreamGrant(token, d, "Downloads", "/photos/a.jpg"); err != nil {
-		t.Fatalf("validate child grant: %v", err)
+	if file.Files[2].ViewToken != "" {
+		t.Fatal("did not expect token on directory child folder")
+	}
+	if err := validateViewGrant(file.Files[0].ViewToken, d, "Downloads", "/media/song.mp3"); err != nil {
+		t.Fatalf("validate audio grant: %v", err)
+	}
+	if err := validateViewGrant(file.Files[1].ViewToken, d, "Downloads", "/media/photo.jpg"); err != nil {
+		t.Fatalf("validate image grant: %v", err)
 	}
 }
 
 func TestStreamHandlerRejectsMissingToken(t *testing.T) {
 	t.Parallel()
 	d := &requestContext{user: &users.User{ID: 1}}
-	req := httptest.NewRequest(http.MethodGet, "/api/resources/stream?source=default&file=/a.txt", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/media/stream?source=default&file=/a.mp3", nil)
 	status, err := streamHandler(httptest.NewRecorder(), req, d)
+	if status != http.StatusForbidden || err == nil {
+		t.Fatalf("expected 403, got status=%d err=%v", status, err)
+	}
+}
+
+func TestStreamHandlerRejectsNonMedia(t *testing.T) {
+	t.Parallel()
+	d := &requestContext{user: &users.User{ID: 1}}
+	token, err := mintViewGrant(d, "default", "/doc.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/media/stream?source=default&file=/doc.pdf&viewToken="+token, nil)
+	status, err := streamHandler(httptest.NewRecorder(), req, d)
+	if status != http.StatusForbidden || err == nil {
+		t.Fatalf("expected 403 for non-media, got status=%d err=%v", status, err)
+	}
+}
+
+func TestViewHandlerRejectsMedia(t *testing.T) {
+	t.Parallel()
+	d := &requestContext{user: &users.User{ID: 1}}
+	token, err := mintViewGrant(d, "default", "/clip.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/resources/view?source=default&file=/clip.mp4&viewToken="+token, nil)
+	status, err := viewHandler(httptest.NewRecorder(), req, d)
+	if status != http.StatusForbidden || err == nil {
+		t.Fatalf("expected 403 for media on view endpoint, got status=%d err=%v", status, err)
+	}
+}
+
+func TestViewHandlerRejectsMissingToken(t *testing.T) {
+	t.Parallel()
+	d := &requestContext{user: &users.User{ID: 1}}
+	req := httptest.NewRequest(http.MethodGet, "/api/resources/view?source=default&file=/a.txt", nil)
+	status, err := viewHandler(httptest.NewRecorder(), req, d)
 	if status != http.StatusForbidden || err == nil {
 		t.Fatalf("expected 403, got status=%d err=%v", status, err)
 	}
@@ -130,7 +196,7 @@ func TestStreamHandlerRejectsMissingToken(t *testing.T) {
 func TestStreamHandlerRejectsMultiFile(t *testing.T) {
 	t.Parallel()
 	d := &requestContext{user: &users.User{ID: 1}}
-	req := httptest.NewRequest(http.MethodGet, "/api/resources/stream?source=default&file=/a.txt&file=/b.txt&streamToken=tok", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/media/stream?source=default&file=/a.mp3&file=/b.mp3&viewToken=tok", nil)
 	status, err := streamHandler(httptest.NewRecorder(), req, d)
 	if status != http.StatusForbidden || err == nil {
 		t.Fatalf("expected 403 for multi-file, got status=%d err=%v", status, err)
@@ -140,14 +206,24 @@ func TestStreamHandlerRejectsMultiFile(t *testing.T) {
 func TestStreamHandlerRejectsArchiveParams(t *testing.T) {
 	t.Parallel()
 	d := &requestContext{user: &users.User{ID: 1}}
-	req := httptest.NewRequest(http.MethodGet, "/api/resources/stream?source=default&file=/a.txt&streamToken=tok&algo=zip", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/media/stream?source=default&file=/a.mp3&viewToken=tok&algo=zip", nil)
 	status, err := streamHandler(httptest.NewRecorder(), req, d)
 	if status != http.StatusForbidden || err == nil {
 		t.Fatalf("expected 403 for algo param, got status=%d err=%v", status, err)
 	}
-	req = httptest.NewRequest(http.MethodGet, "/api/resources/stream?source=default&file=/a.txt&streamToken=tok&archiveToken=abc", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/media/stream?source=default&file=/a.mp3&viewToken=tok&archiveToken=abc", nil)
 	status, err = streamHandler(httptest.NewRecorder(), req, d)
 	if status != http.StatusForbidden || err == nil {
 		t.Fatalf("expected 403 for archiveToken param, got status=%d err=%v", status, err)
+	}
+}
+
+func TestViewHandlerRejectsArchiveParams(t *testing.T) {
+	t.Parallel()
+	d := &requestContext{user: &users.User{ID: 1}}
+	req := httptest.NewRequest(http.MethodGet, "/api/resources/view?source=default&file=/a.txt&viewToken=tok&algo=zip", nil)
+	status, err := viewHandler(httptest.NewRecorder(), req, d)
+	if status != http.StatusForbidden || err == nil {
+		t.Fatalf("expected 403 for algo param, got status=%d err=%v", status, err)
 	}
 }

--- a/backend/http/stream_range.go
+++ b/backend/http/stream_range.go
@@ -17,18 +17,9 @@ const maxStreamRangeBytes = 4 << 20 // 4 MiB
 var errStreamRangeInvalid = errors.New("invalid byte range")
 
 // streamUseRangeOnly reports whether the stream endpoint must serve capped partial
-// content only (never a full-file 200 response).
-func streamUseRangeOnly(d *requestContext, displayFileName string) bool {
-	if isMediaStreamFile(displayFileName) {
-		return true
-	}
-	if d.share.Hash != "" && d.share.DisableDownload {
-		return true
-	}
-	if d.share.Hash == "" && d.user != nil && !d.user.Permissions.Download {
-		return true
-	}
-	return false
+// content only (never a full-file 200 response). The stream endpoint is media-only.
+func streamUseRangeOnly(_ *requestContext, _ string) bool {
+	return true
 }
 
 func isMediaStreamFile(displayFileName string) bool {

--- a/backend/http/stream_range_test.go
+++ b/backend/http/stream_range_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gtsteffaniak/filebrowser/backend/database/share"
 	"github.com/gtsteffaniak/filebrowser/backend/database/users"
 )
 
@@ -66,28 +65,10 @@ func TestStreamUseRangeOnly(t *testing.T) {
 	t.Parallel()
 	mediaCtx := &requestContext{user: &users.User{FrontendUser: users.FrontendUser{Permissions: users.Permissions{Download: true}}}}
 	if !streamUseRangeOnly(mediaCtx, "clip.mp4") {
-		t.Fatal("expected range-only for video")
+		t.Fatal("expected range-only for stream endpoint")
 	}
-	if streamUseRangeOnly(mediaCtx, "notes.txt") {
-		t.Fatal("did not expect range-only for text when download allowed")
-	}
-
-	noDownload := &requestContext{user: &users.User{FrontendUser: users.FrontendUser{Permissions: users.Permissions{Download: false}}}}
-	if !streamUseRangeOnly(noDownload, "notes.txt") {
-		t.Fatal("expected range-only without download permission")
-	}
-
-	shareCtx := &requestContext{
-		user: &users.User{FrontendUser: users.FrontendUser{Permissions: users.Permissions{Download: true}}},
-		share: share.Share{
-			ShareColumns: share.ShareColumns{Hash: "abc"},
-			ShareSettings: share.ShareSettings{
-				FrontendShareInfo: share.FrontendShareInfo{DisableDownload: true},
-			},
-		},
-	}
-	if !streamUseRangeOnly(shareCtx, "notes.txt") {
-		t.Fatal("expected range-only for share with downloads disabled")
+	if !streamUseRangeOnly(mediaCtx, "notes.txt") {
+		t.Fatal("stream endpoint is always range-only")
 	}
 }
 

--- a/backend/http/view.go
+++ b/backend/http/view.go
@@ -1,0 +1,117 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
+)
+
+func viewFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, source string, scopedFileList []string) (int, error) {
+	if len(scopedFileList) != 1 {
+		return http.StatusForbidden, fmt.Errorf("view supports single file only")
+	}
+	scopedFilePath := scopedFileList[0]
+	displayName := filepath.Base(scopedFilePath)
+	if isMediaStreamFile(displayName) {
+		return http.StatusForbidden, fmt.Errorf("view endpoint does not support audio or video; use /media/stream")
+	}
+	return serveSingleFile(w, r, d, source, scopedFilePath, displayName, serveSingleFileOptions{
+		forceInline: true,
+		rangeOnly:   false,
+	})
+}
+
+// viewHandler serves inline file content for UI viewing with a valid viewToken.
+// @Summary View content of a single non-media file inline
+// @Description Returns raw file bytes for inline UI viewing. Requires a viewToken minted by GET /resources. Never counts toward download limits or activity and does not require download permission.
+// @Tags Resources
+// @Accept json
+// @Param source query string true "Source name for the file (required)"
+// @Param file query string true "File path"
+// @Param viewToken query string true "Opaque view grant token from file metadata"
+// @Success 200 {file} file "Raw file content (inline)"
+// @Failure 403 {object} map[string]string "Missing or invalid view token"
+// @Failure 404 {object} map[string]string "File not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /api/resources/view [get]
+func viewHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
+	if r.URL.Query().Get("archiveToken") != "" || r.URL.Query().Get("algo") != "" {
+		return http.StatusForbidden, fmt.Errorf("archives not supported on view endpoint")
+	}
+	source := r.URL.Query().Get("source")
+	fileList := r.URL.Query()["file"]
+	if len(fileList) != 1 {
+		return http.StatusForbidden, fmt.Errorf("view supports single file only")
+	}
+	token := r.URL.Query().Get("viewToken")
+	if token == "" {
+		return http.StatusForbidden, fmt.Errorf("view token required")
+	}
+	cleanPath, err := utils.SanitizePath(fileList[0])
+	if err != nil {
+		return http.StatusBadRequest, fmt.Errorf("invalid file path: %v", err)
+	}
+	if err = validateViewGrant(token, d, source, cleanPath); err != nil {
+		return http.StatusForbidden, err
+	}
+
+	userscope, err := d.user.GetScopeForSourceName(source)
+	if err != nil {
+		return http.StatusForbidden, err
+	}
+	scopedPath := utils.JoinPathAsUnix(userscope, cleanPath)
+	return viewFilesHandler(w, r, d, source, []string{scopedPath})
+}
+
+// publicViewHandler serves inline file content from a public share with a valid viewToken.
+// @Summary View a single non-media file from a public share inline
+// @Description Returns raw file bytes for inline UI viewing on a share link. Requires viewToken from GET /public/api/resources. Does not count toward download limits.
+// @Tags Resources
+// @Accept json
+// @Produce octet-stream
+// @Param hash query string true "Share hash for authentication"
+// @Param file query string true "File path within the share"
+// @Param viewToken query string true "Opaque view grant token from share file metadata"
+// @Success 200 {file} file "Raw file content (inline)"
+// @Failure 403 {object} map[string]string "Missing or invalid view token"
+// @Failure 404 {object} map[string]string "Share or file not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /public/api/resources/view [get]
+func publicViewHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
+	if d.share.ShareType == "upload" {
+		return http.StatusNotImplemented, fmt.Errorf("viewing is disabled for upload shares")
+	}
+	if r.URL.Query().Get("archiveToken") != "" || r.URL.Query().Get("algo") != "" {
+		return http.StatusForbidden, fmt.Errorf("archives not supported on view endpoint")
+	}
+	files := r.URL.Query()["file"]
+	if len(files) != 1 {
+		return http.StatusForbidden, fmt.Errorf("view supports single file only")
+	}
+	token := r.URL.Query().Get("viewToken")
+	if token == "" {
+		return http.StatusForbidden, fmt.Errorf("view token required")
+	}
+	cleanFile, err := utils.SanitizePath(files[0])
+	if err != nil {
+		return http.StatusBadRequest, fmt.Errorf("invalid file path: %v", err)
+	}
+	sourceInfo, ok := config.Server.SourceMap[d.share.SourcePath]
+	if !ok {
+		return http.StatusInternalServerError, fmt.Errorf("source not found for share")
+	}
+	if err = validateViewGrant(token, d, sourceInfo.Name, cleanFile); err != nil {
+		return http.StatusForbidden, err
+	}
+	scopedPath := utils.JoinPathAsUnix(d.share.Path, cleanFile)
+	status, err := viewFilesHandler(w, r, d, sourceInfo.Name, []string{scopedPath})
+	if err != nil {
+		if status == http.StatusForbidden {
+			return http.StatusForbidden, fmt.Errorf("access denied")
+		}
+		return status, fmt.Errorf("error viewing file")
+	}
+	return status, nil
+}

--- a/backend/indexing/iteminfo/fileinfo.go
+++ b/backend/indexing/iteminfo/fileinfo.go
@@ -20,8 +20,8 @@ type ItemInfo struct {
 // This avoids adding memory overhead to indexed items
 type ExtendedItemInfo struct {
 	ItemInfo
-	Metadata    *MediaMetadata `json:"metadata,omitempty"`    // optional media metadata (audio/video only)
-	StreamToken string         `json:"streamToken,omitempty"` // opaque token for inline streaming via /resources/stream
+	Metadata    *MediaMetadata `json:"metadata,omitempty"`  // optional media metadata (audio/video only)
+	ViewToken   string         `json:"viewToken,omitempty"` // opaque token for inline viewing via /resources/view or /media/stream
 }
 
 // FileInfo describes a file.
@@ -69,5 +69,5 @@ type ExtendedFileInfo struct {
 	Hash         string                `json:"hash,omitempty"`         // hash for the file -- used for sharing
 	RealPath     string                `json:"-"`
 	PinnedItems  []string              `json:"pinnedItems,omitempty"` // pinned item names in this directory listing
-	StreamToken  string                `json:"streamToken,omitempty"` // opaque token for inline streaming via /resources/stream
+	ViewToken    string                `json:"viewToken,omitempty"`   // opaque token for inline viewing via /resources/view or /media/stream
 }

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -1425,6 +1425,76 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/media/stream": {
+            "get": {
+                "description": "Returns raw file bytes for inline UI viewing in capped byte ranges. Requires a viewToken minted by GET /resources. Media files must use Range requests; full-file GET responses are rejected. Never counts toward download limits or activity.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Resources"
+                ],
+                "summary": "Stream content of a single media file for inline viewing",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source name for the file (required)",
+                        "name": "source",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path",
+                        "name": "file",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque view grant token from file metadata",
+                        "name": "viewToken",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw file content (inline)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "403": {
+                        "description": "Missing or invalid view token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "File not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/media/subtitles": {
             "get": {
                 "description": "Returns raw subtitle content from external files or embedded streams",
@@ -2535,76 +2605,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/resources/stream": {
-            "get": {
-                "description": "Returns raw file bytes for inline UI viewing in capped byte ranges. Requires a streamToken minted by GET /resources. Media files and restricted viewers must use Range requests; full-file GET responses are rejected. Never counts toward download limits or activity.",
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Resources"
-                ],
-                "summary": "Stream content of a single file for inline viewing",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Source name for the file (required)",
-                        "name": "source",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "File path",
-                        "name": "file",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Opaque stream grant token from file metadata",
-                        "name": "streamToken",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Raw file content (inline)",
-                        "schema": {
-                            "type": "file"
-                        }
-                    },
-                    "403": {
-                        "description": "Missing or invalid stream token",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "File not found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/resources/unarchive": {
             "post": {
                 "description": "Extracts a zip or tar.gz archive on the server into the given destination directory. Server-side only; no extracted bytes are returned. Supports extracting to a different source via toSource. Requires create permission. Archive size is checked against server.maxArchiveSizeGB limit if configured.\n\n**Request body parameters:**\n- **fromSource** (string, required): Source name where the archive file lives. Example: ` + "`" + `\"default\"` + "`" + `\n- **toSource** (string, optional): Source name where contents will be extracted. Defaults to fromSource if omitted. Example: ` + "`" + `\"restored\"` + "`" + `\n- **path** (string, required): Path to the archive file (on fromSource). Must be .zip, .tar.gz, or .tgz. Example: ` + "`" + `\"/downloads/data.zip\"` + "`" + `\n- **destination** (string, required): Directory path (on toSource) to extract into. Example: ` + "`" + `\"/projects/imported\"` + "`" + `\n- **deleteAfter** (boolean, optional): If true, delete the archive file after successful extraction. Default: false. Example: ` + "`" + `true` + "`" + `",
@@ -2668,6 +2668,76 @@ const docTemplate = `{
                     },
                     "413": {
                         "description": "Request Entity Too Large (archive size exceeds maxArchiveSizeGB limit)",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/resources/view": {
+            "get": {
+                "description": "Returns raw file bytes for inline UI viewing. Requires a viewToken minted by GET /resources. Never counts toward download limits or activity and does not require download permission.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Resources"
+                ],
+                "summary": "View content of a single non-media file inline",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source name for the file (required)",
+                        "name": "source",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path",
+                        "name": "file",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque view grant token from file metadata",
+                        "name": "viewToken",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw file content (inline)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "403": {
+                        "description": "Missing or invalid view token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "File not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -4129,6 +4199,79 @@ const docTemplate = `{
                 }
             }
         },
+        "/public/api/media/stream": {
+            "get": {
+                "description": "Returns raw file bytes for inline UI viewing in capped byte ranges on a share link. Requires viewToken from GET /public/api/resources. Media files must use Range requests. Does not count toward download limits.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Resources"
+                ],
+                "summary": "Stream a single media file from a public share for inline viewing",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share hash for authentication",
+                        "name": "hash",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path within the share",
+                        "name": "file",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque view grant token from share file metadata",
+                        "name": "viewToken",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw file content (inline)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "403": {
+                        "description": "Missing or invalid view token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Share or file not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/public/api/resources": {
             "get": {
                 "description": "Returns metadata for files or directories accessible via a public share link. Browsing is disabled for upload-only shares.",
@@ -4874,9 +5017,9 @@ const docTemplate = `{
                 }
             }
         },
-        "/public/api/resources/stream": {
+        "/public/api/resources/view": {
             "get": {
-                "description": "Returns raw file bytes for inline UI viewing in capped byte ranges on a share link. Requires streamToken from GET /public/api/resources. Media files and shares with downloads disabled must use Range requests. Does not count toward download limits.",
+                "description": "Returns raw file bytes for inline UI viewing on a share link. Requires viewToken from GET /public/api/resources. Does not count toward download limits.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4886,7 +5029,7 @@ const docTemplate = `{
                 "tags": [
                     "Resources"
                 ],
-                "summary": "Stream a single file from a public share for inline viewing",
+                "summary": "View a single non-media file from a public share inline",
                 "parameters": [
                     {
                         "type": "string",
@@ -4904,8 +5047,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Opaque stream grant token from share file metadata",
-                        "name": "streamToken",
+                        "description": "Opaque view grant token from share file metadata",
+                        "name": "viewToken",
                         "in": "query",
                         "required": true
                     }
@@ -4918,7 +5061,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "Missing or invalid stream token",
+                        "description": "Missing or invalid view token",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -5836,10 +5979,6 @@ const docTemplate = `{
                     "description": "associated index source for the file",
                     "type": "string"
                 },
-                "streamToken": {
-                    "description": "opaque token for inline streaming via /resources/stream",
-                    "type": "string"
-                },
                 "subtitles": {
                     "description": "subtitles for video files",
                     "type": "array",
@@ -5853,6 +5992,10 @@ const docTemplate = `{
                 },
                 "type": {
                     "description": "type of the file, either \"directory\" or a file mimetype",
+                    "type": "string"
+                },
+                "viewToken": {
+                    "description": "opaque token for inline viewing via /resources/view or /media/stream",
                     "type": "string"
                 }
             }
@@ -5892,12 +6035,12 @@ const docTemplate = `{
                     "description": "length in bytes for regular files",
                     "type": "integer"
                 },
-                "streamToken": {
-                    "description": "opaque token for inline streaming via /resources/stream",
-                    "type": "string"
-                },
                 "type": {
                     "description": "type of the file, either \"directory\" or a file mimetype",
+                    "type": "string"
+                },
+                "viewToken": {
+                    "description": "opaque token for inline viewing via /resources/view or /media/stream",
                     "type": "string"
                 }
             }

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -1414,6 +1414,76 @@
                 }
             }
         },
+        "/api/media/stream": {
+            "get": {
+                "description": "Returns raw file bytes for inline UI viewing in capped byte ranges. Requires a viewToken minted by GET /resources. Media files must use Range requests; full-file GET responses are rejected. Never counts toward download limits or activity.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Resources"
+                ],
+                "summary": "Stream content of a single media file for inline viewing",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source name for the file (required)",
+                        "name": "source",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path",
+                        "name": "file",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque view grant token from file metadata",
+                        "name": "viewToken",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw file content (inline)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "403": {
+                        "description": "Missing or invalid view token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "File not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/media/subtitles": {
             "get": {
                 "description": "Returns raw subtitle content from external files or embedded streams",
@@ -2524,76 +2594,6 @@
                 }
             }
         },
-        "/api/resources/stream": {
-            "get": {
-                "description": "Returns raw file bytes for inline UI viewing in capped byte ranges. Requires a streamToken minted by GET /resources. Media files and restricted viewers must use Range requests; full-file GET responses are rejected. Never counts toward download limits or activity.",
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Resources"
-                ],
-                "summary": "Stream content of a single file for inline viewing",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Source name for the file (required)",
-                        "name": "source",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "File path",
-                        "name": "file",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Opaque stream grant token from file metadata",
-                        "name": "streamToken",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Raw file content (inline)",
-                        "schema": {
-                            "type": "file"
-                        }
-                    },
-                    "403": {
-                        "description": "Missing or invalid stream token",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "File not found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/resources/unarchive": {
             "post": {
                 "description": "Extracts a zip or tar.gz archive on the server into the given destination directory. Server-side only; no extracted bytes are returned. Supports extracting to a different source via toSource. Requires create permission. Archive size is checked against server.maxArchiveSizeGB limit if configured.\n\n**Request body parameters:**\n- **fromSource** (string, required): Source name where the archive file lives. Example: `\"default\"`\n- **toSource** (string, optional): Source name where contents will be extracted. Defaults to fromSource if omitted. Example: `\"restored\"`\n- **path** (string, required): Path to the archive file (on fromSource). Must be .zip, .tar.gz, or .tgz. Example: `\"/downloads/data.zip\"`\n- **destination** (string, required): Directory path (on toSource) to extract into. Example: `\"/projects/imported\"`\n- **deleteAfter** (boolean, optional): If true, delete the archive file after successful extraction. Default: false. Example: `true`",
@@ -2657,6 +2657,76 @@
                     },
                     "413": {
                         "description": "Request Entity Too Large (archive size exceeds maxArchiveSizeGB limit)",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/resources/view": {
+            "get": {
+                "description": "Returns raw file bytes for inline UI viewing. Requires a viewToken minted by GET /resources. Never counts toward download limits or activity and does not require download permission.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Resources"
+                ],
+                "summary": "View content of a single non-media file inline",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source name for the file (required)",
+                        "name": "source",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path",
+                        "name": "file",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque view grant token from file metadata",
+                        "name": "viewToken",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw file content (inline)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "403": {
+                        "description": "Missing or invalid view token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "File not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -4118,6 +4188,79 @@
                 }
             }
         },
+        "/public/api/media/stream": {
+            "get": {
+                "description": "Returns raw file bytes for inline UI viewing in capped byte ranges on a share link. Requires viewToken from GET /public/api/resources. Media files must use Range requests. Does not count toward download limits.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Resources"
+                ],
+                "summary": "Stream a single media file from a public share for inline viewing",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share hash for authentication",
+                        "name": "hash",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path within the share",
+                        "name": "file",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque view grant token from share file metadata",
+                        "name": "viewToken",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw file content (inline)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "403": {
+                        "description": "Missing or invalid view token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Share or file not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/public/api/resources": {
             "get": {
                 "description": "Returns metadata for files or directories accessible via a public share link. Browsing is disabled for upload-only shares.",
@@ -4863,9 +5006,9 @@
                 }
             }
         },
-        "/public/api/resources/stream": {
+        "/public/api/resources/view": {
             "get": {
-                "description": "Returns raw file bytes for inline UI viewing in capped byte ranges on a share link. Requires streamToken from GET /public/api/resources. Media files and shares with downloads disabled must use Range requests. Does not count toward download limits.",
+                "description": "Returns raw file bytes for inline UI viewing on a share link. Requires viewToken from GET /public/api/resources. Does not count toward download limits.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4875,7 +5018,7 @@
                 "tags": [
                     "Resources"
                 ],
-                "summary": "Stream a single file from a public share for inline viewing",
+                "summary": "View a single non-media file from a public share inline",
                 "parameters": [
                     {
                         "type": "string",
@@ -4893,8 +5036,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "Opaque stream grant token from share file metadata",
-                        "name": "streamToken",
+                        "description": "Opaque view grant token from share file metadata",
+                        "name": "viewToken",
                         "in": "query",
                         "required": true
                     }
@@ -4907,7 +5050,7 @@
                         }
                     },
                     "403": {
-                        "description": "Missing or invalid stream token",
+                        "description": "Missing or invalid view token",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -5825,10 +5968,6 @@
                     "description": "associated index source for the file",
                     "type": "string"
                 },
-                "streamToken": {
-                    "description": "opaque token for inline streaming via /resources/stream",
-                    "type": "string"
-                },
                 "subtitles": {
                     "description": "subtitles for video files",
                     "type": "array",
@@ -5842,6 +5981,10 @@
                 },
                 "type": {
                     "description": "type of the file, either \"directory\" or a file mimetype",
+                    "type": "string"
+                },
+                "viewToken": {
+                    "description": "opaque token for inline viewing via /resources/view or /media/stream",
                     "type": "string"
                 }
             }
@@ -5881,12 +6024,12 @@
                     "description": "length in bytes for regular files",
                     "type": "integer"
                 },
-                "streamToken": {
-                    "description": "opaque token for inline streaming via /resources/stream",
-                    "type": "string"
-                },
                 "type": {
                     "description": "type of the file, either \"directory\" or a file mimetype",
+                    "type": "string"
+                },
+                "viewToken": {
+                    "description": "opaque token for inline viewing via /resources/view or /media/stream",
                     "type": "string"
                 }
             }

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -496,9 +496,6 @@ definitions:
       source:
         description: associated index source for the file
         type: string
-      streamToken:
-        description: opaque token for inline streaming via /resources/stream
-        type: string
       subtitles:
         description: subtitles for video files
         items:
@@ -509,6 +506,9 @@ definitions:
         type: string
       type:
         description: type of the file, either "directory" or a file mimetype
+        type: string
+      viewToken:
+        description: opaque token for inline viewing via /resources/view or /media/stream
         type: string
     type: object
   iteminfo.ExtendedItemInfo:
@@ -535,11 +535,11 @@ definitions:
       size:
         description: length in bytes for regular files
         type: integer
-      streamToken:
-        description: opaque token for inline streaming via /resources/stream
-        type: string
       type:
         description: type of the file, either "directory" or a file mimetype
+        type: string
+      viewToken:
+        description: opaque token for inline viewing via /resources/view or /media/stream
         type: string
     type: object
   iteminfo.FileInfo:
@@ -3397,6 +3397,56 @@ paths:
       summary: Directory with media metadata
       tags:
       - Media
+  /api/media/stream:
+    get:
+      consumes:
+      - application/json
+      description: Returns raw file bytes for inline UI viewing in capped byte ranges.
+        Requires a viewToken minted by GET /resources. Media files must use Range
+        requests; full-file GET responses are rejected. Never counts toward download
+        limits or activity.
+      parameters:
+      - description: Source name for the file (required)
+        in: query
+        name: source
+        required: true
+        type: string
+      - description: File path
+        in: query
+        name: file
+        required: true
+        type: string
+      - description: Opaque view grant token from file metadata
+        in: query
+        name: viewToken
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Raw file content (inline)
+          schema:
+            type: file
+        "403":
+          description: Missing or invalid view token
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: File not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Stream content of a single media file for inline viewing
+      tags:
+      - Resources
   /api/media/subtitles:
     get:
       consumes:
@@ -4174,56 +4224,6 @@ paths:
       summary: Get image preview
       tags:
       - Resources
-  /api/resources/stream:
-    get:
-      consumes:
-      - application/json
-      description: Returns raw file bytes for inline UI viewing in capped byte ranges.
-        Requires a streamToken minted by GET /resources. Media files and restricted
-        viewers must use Range requests; full-file GET responses are rejected. Never
-        counts toward download limits or activity.
-      parameters:
-      - description: Source name for the file (required)
-        in: query
-        name: source
-        required: true
-        type: string
-      - description: File path
-        in: query
-        name: file
-        required: true
-        type: string
-      - description: Opaque stream grant token from file metadata
-        in: query
-        name: streamToken
-        required: true
-        type: string
-      responses:
-        "200":
-          description: Raw file content (inline)
-          schema:
-            type: file
-        "403":
-          description: Missing or invalid stream token
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "404":
-          description: File not found
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal server error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      summary: Stream content of a single file for inline viewing
-      tags:
-      - Resources
   /api/resources/unarchive:
     post:
       consumes:
@@ -4287,6 +4287,55 @@ paths:
               type: string
             type: object
       summary: Extract an archive on the server
+      tags:
+      - Resources
+  /api/resources/view:
+    get:
+      consumes:
+      - application/json
+      description: Returns raw file bytes for inline UI viewing. Requires a viewToken
+        minted by GET /resources. Never counts toward download limits or activity
+        and does not require download permission.
+      parameters:
+      - description: Source name for the file (required)
+        in: query
+        name: source
+        required: true
+        type: string
+      - description: File path
+        in: query
+        name: file
+        required: true
+        type: string
+      - description: Opaque view grant token from file metadata
+        in: query
+        name: viewToken
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Raw file content (inline)
+          schema:
+            type: file
+        "403":
+          description: Missing or invalid view token
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: File not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: View content of a single non-media file inline
       tags:
       - Resources
   /api/settings:
@@ -5278,6 +5327,57 @@ paths:
       summary: Directory with media metadata (public share)
       tags:
       - Media
+  /public/api/media/stream:
+    get:
+      consumes:
+      - application/json
+      description: Returns raw file bytes for inline UI viewing in capped byte ranges
+        on a share link. Requires viewToken from GET /public/api/resources. Media
+        files must use Range requests. Does not count toward download limits.
+      parameters:
+      - description: Share hash for authentication
+        in: query
+        name: hash
+        required: true
+        type: string
+      - description: File path within the share
+        in: query
+        name: file
+        required: true
+        type: string
+      - description: Opaque view grant token from share file metadata
+        in: query
+        name: viewToken
+        required: true
+        type: string
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: Raw file content (inline)
+          schema:
+            type: file
+        "403":
+          description: Missing or invalid view token
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Share or file not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Stream a single media file from a public share for inline viewing
+      tags:
+      - Resources
   /public/api/resources:
     get:
       consumes:
@@ -5797,14 +5897,12 @@ paths:
       summary: Get image/video preview from a public share
       tags:
       - Resources
-  /public/api/resources/stream:
+  /public/api/resources/view:
     get:
       consumes:
       - application/json
-      description: Returns raw file bytes for inline UI viewing in capped byte ranges
-        on a share link. Requires streamToken from GET /public/api/resources. Media
-        files and shares with downloads disabled must use Range requests. Does not
-        count toward download limits.
+      description: Returns raw file bytes for inline UI viewing on a share link. Requires
+        viewToken from GET /public/api/resources. Does not count toward download limits.
       parameters:
       - description: Share hash for authentication
         in: query
@@ -5816,9 +5914,9 @@ paths:
         name: file
         required: true
         type: string
-      - description: Opaque stream grant token from share file metadata
+      - description: Opaque view grant token from share file metadata
         in: query
-        name: streamToken
+        name: viewToken
         required: true
         type: string
       produces:
@@ -5829,7 +5927,7 @@ paths:
           schema:
             type: file
         "403":
-          description: Missing or invalid stream token
+          description: Missing or invalid view token
           schema:
             additionalProperties:
               type: string
@@ -5846,7 +5944,7 @@ paths:
             additionalProperties:
               type: string
             type: object
-      summary: Stream a single file from a public share for inline viewing
+      summary: View a single non-media file from a public share inline
       tags:
       - Resources
   /public/api/share/image:

--- a/frontend/src/api/media.js
+++ b/frontend/src/api/media.js
@@ -101,3 +101,43 @@ export async function fetchDirectoryMediaMetadataPublic(path, hash, password = "
   const data = await response.json();
   return adjustedData(data);
 }
+
+// GET /api/media/stream — audio/video bytes via viewToken (range-based, not download-metered).
+export function getStreamURL(source, path, viewToken) {
+  if (!source || source === undefined || source === null) {
+    throw new Error('no source provided')
+  }
+  if (!viewToken) {
+    throw new Error('view token required')
+  }
+  try {
+    const params = {
+      source: source,
+      file: path,
+      viewToken: viewToken,
+      sessionId: state.sessionId,
+    }
+    const apiPath = getApiPath('media/stream', params)
+    return window.origin + apiPath
+  } catch (err) {
+    notify.showError(err.message || 'Error getting stream URL')
+    throw err
+  }
+}
+
+// GET /public/api/media/stream
+export function getStreamURLPublic(share, files, viewToken) {
+  if (!viewToken) {
+    throw new Error('view token required')
+  }
+  const fileArray = Array.isArray(files) ? files : [files]
+  const params = {
+    file: fileArray,
+    hash: share.hash,
+    token: share.token,
+    viewToken: viewToken,
+    sessionId: state.sessionId,
+  }
+  const apiPath = getPublicApiPath('media/stream', params)
+  return window.origin + apiPath
+}

--- a/frontend/src/api/resources.js
+++ b/frontend/src/api/resources.js
@@ -8,7 +8,9 @@ import {
 } from '@/utils/appNotifications'
 import { getApiPath, getPublicApiPath } from '@/utils/url.js'
 import { adjustedData, fetchURL } from './utils'
-import { getObjectProperty } from '@/utils/object' 
+import { getObjectProperty } from '@/utils/object'
+import { isMediaFile } from '@/utils/mediaFile'
+import { getStreamURL, getStreamURLPublic } from './media'
 
 export { fetchPreviewImage } from '@/utils/previewRequests'
 
@@ -824,49 +826,6 @@ export async function checksum(source, path, algo) {
   }
 }
 
-export function getStreamURL(source, path, streamToken) {
-  if (!source || source === undefined || source === null) {
-    throw new Error('no source provided')
-  }
-  if (!streamToken) {
-    throw new Error('stream token required')
-  }
-  try {
-    const params = {
-      source: source,
-      file: path,
-      streamToken: streamToken,
-      sessionId: state.sessionId,
-    }
-    const apiPath = getApiPath('resources/stream', params)
-    return window.origin + apiPath
-  } catch (err) {
-    notify.showError(err.message || 'Error getting stream URL')
-    throw err
-  }
-}
-
-/**
- * Stream URL for inline viewing. Requires streamToken; returns null when unavailable
- * so callers do not fall back to metered /download URLs.
- * Pass allowDownloadFallback=true only for HTML sibling assets without tokens.
- */
-export function getViewURL(source, path, streamToken, shareInfo = null, allowDownloadFallback = false) {
-  if (streamToken) {
-    if (shareInfo) {
-      return getStreamURLPublic(shareInfo, [path], streamToken)
-    }
-    return getStreamURL(source, path, streamToken)
-  }
-  if (!allowDownloadFallback) {
-    return null
-  }
-  if (shareInfo) {
-    return getDownloadURLPublic(shareInfo, [path], true)
-  }
-  return getDownloadURL(source, path, true)
-}
-
 /**
  * URL to open a file inline in a new browser tab via the download endpoint.
  * Uses inline disposition and respects download permissions and share limits.
@@ -878,20 +837,71 @@ export function getOpenFileURL(source, path, shareInfo = null) {
   return getDownloadURL(source, path, true)
 }
 
-export function getStreamURLPublic(share, files, streamToken) {
-  if (!streamToken) {
-    throw new Error('stream token required')
+// GET /api/resources/view — inline non-media bytes via viewToken (not download-metered).
+export function getRawViewURL(source, path, viewToken) {
+  if (!source || source === undefined || source === null) {
+    throw new Error('no source provided')
+  }
+  if (!viewToken) {
+    throw new Error('view token required')
+  }
+  try {
+    const params = {
+      source: source,
+      file: path,
+      viewToken: viewToken,
+      sessionId: state.sessionId,
+    }
+    const apiPath = getApiPath('resources/view', params)
+    return window.origin + apiPath
+  } catch (err) {
+    notify.showError(err.message || 'Error getting view URL')
+    throw err
+  }
+}
+
+// GET /public/api/resources/view
+export function getRawViewURLPublic(share, files, viewToken) {
+  if (!viewToken) {
+    throw new Error('view token required')
   }
   const fileArray = Array.isArray(files) ? files : [files]
   const params = {
     file: fileArray,
     hash: share.hash,
     token: share.token,
-    streamToken: streamToken,
+    viewToken: viewToken,
     sessionId: state.sessionId,
   }
-  const apiPath = getPublicApiPath('resources/stream', params)
+  const apiPath = getPublicApiPath('resources/view', params)
   return window.origin + apiPath
+}
+
+/**
+ * URL for inline viewing. Routes audio/video to /media/stream and other files to /resources/view.
+ */
+export function getViewURL(source, path, viewToken, shareInfo = null, allowDownloadFallback = false, mimeOrName = '') {
+  const typeHint = mimeOrName || path
+
+  if (viewToken) {
+    if (isMediaFile(typeHint)) {
+      if (shareInfo) {
+        return getStreamURLPublic(shareInfo, [path], viewToken)
+      }
+      return getStreamURL(source, path, viewToken)
+    }
+    if (shareInfo) {
+      return getRawViewURLPublic(shareInfo, [path], viewToken)
+    }
+    return getRawViewURL(source, path, viewToken)
+  }
+  if (!allowDownloadFallback) {
+    return null
+  }
+  if (shareInfo) {
+    return getDownloadURLPublic(shareInfo, [path], true)
+  }
+  return getDownloadURL(source, path, true)
 }
 
 export function getDownloadURL(source, path, inline, useExternal) {

--- a/frontend/src/api/resources.view.test.js
+++ b/frontend/src/api/resources.view.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/constants", () => ({
+  globalVars: {
+    baseURL: "/",
+    externalUrl: "",
+  },
+}));
+
+vi.mock("@/store", () => ({
+  getters: { isShare: () => false },
+  state: {
+    sessionId: "test-session",
+    shareInfo: { subPath: "", hash: "", token: "" },
+    req: { parentDirItems: [{ name: "app.js", viewToken: "sibling-view-token" }] },
+  },
+}));
+
+vi.mock("@/api/media", () => ({
+  getStreamURL: (_source, path, viewToken) =>
+    `http://localhost/api/media/stream?file=${encodeURIComponent(path)}&viewToken=${viewToken}`,
+  getStreamURLPublic: () => "http://localhost/public/stream",
+}));
+
+import { getViewURL } from "@/api/resources";
+
+describe("getViewURL", () => {
+  it("routes audio to media stream with viewToken", () => {
+    const url = getViewURL(
+      "src",
+      "/music/song.mp3",
+      "view-tok",
+      null,
+      false,
+      "audio/mpeg",
+    );
+    expect(url).toContain("/api/media/stream");
+    expect(url).toContain("viewToken=view-tok");
+  });
+
+  it("routes documents to resources view with viewToken", () => {
+    const url = getViewURL(
+      "src",
+      "/docs/readme.txt",
+      "view-tok",
+      null,
+      false,
+      "text/plain",
+    );
+    expect(url).toContain("/api/resources/view");
+    expect(url).toContain("viewToken=view-tok");
+  });
+
+  it("returns null without viewToken when fallback disabled", () => {
+    expect(getViewURL("src", "/a.txt", null, null, false, "text/plain")).toBeNull();
+  });
+});

--- a/frontend/src/components/files/Icon.vue
+++ b/frontend/src/components/files/Icon.vue
@@ -16,6 +16,7 @@
         size: size,
         type: mimetype,
         viewToken: viewToken,
+        parentDirItems: parentDirItemsForPreview,
       }"
       :is-thumbnail="true"
       :add-load-delay="true"
@@ -240,6 +241,17 @@ export default {
       const typeInfo = this.getIconForType();
       return typeInfo.simpleType === '3d-model';
     },
+    /** Directory listing items for sibling viewToken lookup in 3D previews. */
+    parentDirItemsForPreview() {
+      const req = state.req;
+      if (!req) {
+        return undefined;
+      }
+      if (req.type === "directory" && req.items?.length) {
+        return req.items;
+      }
+      return req.parentDirItems;
+    },
     gallerySizeKey() {
       // Returns gallery size to force 3D preview re-initialization on size change
       // Also includes view mode to handle view changes
@@ -340,6 +352,7 @@ export default {
             size: this.size,
             type: this.mimetype,
             viewToken: this.viewToken,
+            parentDirItems: this.parentDirItemsForPreview,
           },
         };
         return;

--- a/frontend/src/components/files/Icon.vue
+++ b/frontend/src/components/files/Icon.vue
@@ -15,7 +15,7 @@
         source: source,
         size: size,
         type: mimetype,
-        streamToken: streamToken,
+        viewToken: viewToken,
       }"
       :is-thumbnail="true"
       :add-load-delay="true"
@@ -91,7 +91,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    streamToken: {
+    viewToken: {
       type: String,
       default: "",
     },
@@ -339,7 +339,7 @@ export default {
             source,
             size: this.size,
             type: this.mimetype,
-            streamToken: this.streamToken,
+            viewToken: this.viewToken,
           },
         };
         return;

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -44,7 +44,7 @@
         :source="source"
         :size="size"
         :isShared="isShared"
-        :streamToken="streamToken"
+        :viewToken="viewToken"
       />
     </div>
 
@@ -118,7 +118,7 @@
         :source="source"
         :size="size"
         :isShared="isShared"
-        :streamToken="streamToken"
+        :viewToken="viewToken"
       />
     </div>
 
@@ -226,7 +226,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    streamToken: {
+    viewToken: {
       type: String,
       default: "",
     },

--- a/frontend/src/components/prompts/UserEdit.vue
+++ b/frontend/src/components/prompts/UserEdit.vue
@@ -333,13 +333,13 @@ export default {
     },
     normalizeFormUser(raw) {
       const user = { ...(raw ?? {}) };
-      if (user.permissions == null && user.account?.permissions != null) {
+      if ((user.permissions === null || user.permissions === undefined) && user.account?.permissions !== null && user.account?.permissions !== undefined) {
         user.permissions = { ...user.account.permissions };
-        if (user.permissions.download == null) {
+        if (user.permissions.download === null || user.permissions.download === undefined) {
           user.permissions.download = true;
         }
       }
-      if (user.permissions == null) {
+      if (user.permissions === null || user.permissions === undefined) {
         user.permissions = this.defaultPermissions();
       }
       return user;

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -934,19 +934,23 @@ export const mutations = {
     }
   },
   getPrefetchUrl: (item) => {
+    const viewToken = item.viewToken;
+    const typeHint = item.type || item.name;
     if (getters.isShare()) {
       return resourcesApi.getViewURL(
         item.source,
         item.path,
-        item.streamToken,
+        viewToken,
         {
           path: item.path,
           hash: state.shareInfo.hash,
           token: state.shareInfo.token,
         },
+        false,
+        typeHint,
       );
     }
-    return resourcesApi.getViewURL(item.source, item.path, item.streamToken);
+    return resourcesApi.getViewURL(item.source, item.path, viewToken, null, false, typeHint);
   },
   setNavigationShow: (show) => {
     if (state.navigation.show === show) {

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -8,7 +8,7 @@ export interface FileListItem {
   source?: string;
   modified?: string;
   hasPreview?: boolean;
-  streamToken?: string;
+  viewToken?: string;
   isShared?: boolean;
   pinned?: boolean;
   hidden?: boolean;
@@ -34,7 +34,7 @@ export interface ReqObject {
   modified?: string;
   hasPreview?: boolean;
   subtitles?: unknown[];
-  streamToken?: string;
+  viewToken?: string;
   parentDirItems?: FileListItem[];
 
   // Directory listing properties
@@ -167,7 +167,7 @@ export interface StoreState {
       source: string;
       size?: number;
       type: string;
-      streamToken?: string;
+      viewToken?: string;
       parentDirItems?: FileListItem[];
     };
   } | null;

--- a/frontend/src/utils/htmlPreview.test.js
+++ b/frontend/src/utils/htmlPreview.test.js
@@ -9,16 +9,34 @@ vi.mock("@/utils/constants", () => ({
 
 vi.mock("@/store", () => ({
   getters: { isShare: () => false },
-  state: { shareInfo: { subPath: "", hash: "", token: "" } },
+  state: {
+    shareInfo: { subPath: "", hash: "", token: "" },
+    req: {
+      parentDirItems: [
+        { name: "app.js", viewToken: "view-token" },
+        { name: "theme.css", viewToken: "view-token" },
+        { name: "a.png", viewToken: "view-token" },
+        { name: "small.png", viewToken: "view-token" },
+        { name: "large.png", viewToken: "view-token" },
+        { name: "roboto.woff2", viewToken: "view-token" },
+        { name: "bg.png", viewToken: "view-token" },
+        { name: "photo.jpg", viewToken: "view-token" },
+        { name: "photo-2x.jpg", viewToken: "view-token" },
+        { name: "other.html", viewToken: "view-token" },
+      ],
+    },
+  },
 }));
 
 vi.mock("@/api/resources", () => ({
   getDownloadURL: (_source, path) =>
     `http://localhost/api/resources/download?file=${encodeURIComponent(path)}&inline=true`,
-  getViewURL: (_source, path) =>
-    `http://localhost/api/resources/stream?file=${encodeURIComponent(path)}&streamToken=test-token`,
   getDownloadURLPublic: () => "http://localhost/public/download",
+  getViewURL: (_source, path) =>
+    `http://localhost/api/resources/view?file=${encodeURIComponent(path)}&viewToken=test-view-token`,
 }));
+
+vi.mock("@/api/media", () => ({}));
 
 import {
   buildHtmlPreview,

--- a/frontend/src/utils/htmlPreview.test.js
+++ b/frontend/src/utils/htmlPreview.test.js
@@ -13,16 +13,18 @@ vi.mock("@/store", () => ({
     shareInfo: { subPath: "", hash: "", token: "" },
     req: {
       parentDirItems: [
-        { name: "app.js", viewToken: "view-token" },
-        { name: "theme.css", viewToken: "view-token" },
-        { name: "a.png", viewToken: "view-token" },
-        { name: "small.png", viewToken: "view-token" },
-        { name: "large.png", viewToken: "view-token" },
-        { name: "roboto.woff2", viewToken: "view-token" },
-        { name: "bg.png", viewToken: "view-token" },
-        { name: "photo.jpg", viewToken: "view-token" },
-        { name: "photo-2x.jpg", viewToken: "view-token" },
-        { name: "other.html", viewToken: "view-token" },
+        { name: "app.js", path: "/files/app.js", viewToken: "view-token" },
+        { name: "theme.css", path: "/files/theme.css", viewToken: "view-token" },
+        { name: "app.js", path: "/pages/app.js", viewToken: "view-token" },
+        { name: "theme.css", path: "/pages/theme.css", viewToken: "view-token" },
+        { name: "a.png", path: "/pages/a.png", viewToken: "view-token" },
+        { name: "small.png", path: "/docs/small.png", viewToken: "view-token" },
+        { name: "large.png", path: "/docs/large.png", viewToken: "view-token" },
+        { name: "roboto.woff2", path: "/site/fonts/roboto.woff2", viewToken: "view-token" },
+        { name: "bg.png", path: "/images/bg.png", viewToken: "view-token" },
+        { name: "photo.jpg", path: "/pages/photo.jpg", viewToken: "view-token" },
+        { name: "photo-2x.jpg", path: "/pages/photo-2x.jpg", viewToken: "view-token" },
+        { name: "other.html", path: "/pages/other.html", viewToken: "view-token" },
       ],
     },
   },
@@ -32,8 +34,15 @@ vi.mock("@/api/resources", () => ({
   getDownloadURL: (_source, path) =>
     `http://localhost/api/resources/download?file=${encodeURIComponent(path)}&inline=true`,
   getDownloadURLPublic: () => "http://localhost/public/download",
-  getViewURL: (_source, path) =>
-    `http://localhost/api/resources/view?file=${encodeURIComponent(path)}&viewToken=test-view-token`,
+  getViewURL: (_source, path, viewToken, _share, allowDownloadFallback) => {
+    if (viewToken) {
+      return `http://localhost/api/resources/view?file=${encodeURIComponent(path)}&viewToken=${viewToken}`;
+    }
+    if (allowDownloadFallback) {
+      return `http://localhost/api/resources/download?file=${encodeURIComponent(path)}&inline=true`;
+    }
+    return null;
+  },
 }));
 
 vi.mock("@/api/media", () => ({}));
@@ -45,6 +54,7 @@ import {
   rewriteCssContent,
   rewriteSrcset,
 } from "./htmlPreview";
+import { state } from "@/store";
 
 describe("isLocalResourceReference", () => {
   it("treats relative paths as local", () => {
@@ -68,7 +78,7 @@ describe("isLocalResourceReference", () => {
 });
 
 describe("buildPreviewResourceUrl", () => {
-  it("rewrites relative paths for any file type", () => {
+  it("rewrites relative paths for same-directory siblings", () => {
     const base = "/files/index.html";
     expect(buildPreviewResourceUrl("./app.js", base, "src")).toContain(
       encodeURIComponent("/files/app.js"),
@@ -76,9 +86,26 @@ describe("buildPreviewResourceUrl", () => {
     expect(buildPreviewResourceUrl("theme.css", base, "src")).toContain(
       encodeURIComponent("/files/theme.css"),
     );
-    expect(buildPreviewResourceUrl("../img/a.png", base, "src")).toContain(
-      encodeURIComponent("/img/a.png"),
+  });
+
+  it("leaves paths outside the sibling directory unchanged when no token exists", () => {
+    expect(buildPreviewResourceUrl("../img/a.png", "/files/index.html", "src")).toBe(
+      "../img/a.png",
     );
+  });
+
+  it("does not match sibling tokens from a different directory", () => {
+    const original = state.req.parentDirItems;
+    state.req.parentDirItems = [
+      { name: "app.js", path: "/other/app.js", viewToken: "wrong-token" },
+    ];
+    try {
+      const url = buildPreviewResourceUrl("app.js", "/files/index.html", "src");
+      expect(url).toBe("app.js");
+      expect(url).not.toContain("wrong-token");
+    } finally {
+      state.req.parentDirItems = original;
+    }
   });
 
   it("leaves external URLs unchanged", () => {

--- a/frontend/src/utils/htmlPreview.ts
+++ b/frontend/src/utils/htmlPreview.ts
@@ -1,7 +1,7 @@
 import DOMPurify from "dompurify";
 import { getViewURL } from "@/api/resources";
 import { getters, state } from "@/store";
-import { resolveRelativePath } from "@/utils/url";
+import { getParentDir, resolveRelativePath } from "@/utils/url";
 
 export const HTML_SANITIZE_CONFIG = {
   USE_PROFILES: { html: true, svg: true, svgFilters: true },
@@ -46,18 +46,40 @@ const RESOURCE_ATTRIBUTES: Array<[string, string]> = [
 
 const ALLOWED_ABSOLUTE_URI_PATTERN = /^(https?:|data:|mailto:|tel:|#)/i;
 
-function viewTokenForSibling(resolvedPath: string): string | undefined {
+function viewTokenForSibling(
+  resolvedPath: string,
+  baseFilePath: string,
+): string | undefined {
   const items = state.req?.parentDirItems;
   if (!items?.length) {
     return undefined;
   }
+
+  const exact = items.find((entry) => entry.path === resolvedPath);
+  if (exact?.viewToken) {
+    return exact.viewToken;
+  }
+
+  const resolvedDir = getParentDir(resolvedPath);
+  const baseDir = getParentDir(baseFilePath);
+  if (resolvedDir !== baseDir) {
+    return undefined;
+  }
+
   const name = resolvedPath.split("/").filter(Boolean).pop();
   if (!name) {
     return undefined;
   }
-  const item = items.find(
-    (entry) => entry.name === name || entry.path === resolvedPath || entry.path?.endsWith(`/${name}`),
-  );
+
+  const item = items.find((entry) => {
+    if (entry.name !== name) {
+      return false;
+    }
+    if (entry.path) {
+      return getParentDir(entry.path) === resolvedDir;
+    }
+    return resolvedDir === baseDir;
+  });
   return item?.viewToken;
 }
 
@@ -82,11 +104,12 @@ export function buildPreviewResourceUrl(
   }
 
   const resolvedPath = resolveRelativePath(baseFilePath, href);
-  const viewToken = viewTokenForSibling(resolvedPath);
+  const viewToken = viewTokenForSibling(resolvedPath, baseFilePath);
 
   try {
+    let viewUrl;
     if (getters.isShare()) {
-      return getViewURL(
+      viewUrl = getViewURL(
         source,
         resolvedPath,
         viewToken,
@@ -95,11 +118,13 @@ export function buildPreviewResourceUrl(
           hash: state.shareInfo.hash,
           token: state.shareInfo.token,
         },
-        !viewToken,
+        false,
         resolvedPath,
       );
+    } else {
+      viewUrl = getViewURL(source, resolvedPath, viewToken, null, false, resolvedPath);
     }
-    return getViewURL(source, resolvedPath, viewToken, null, !viewToken, resolvedPath);
+    return viewUrl ?? href;
   } catch {
     return href;
   }

--- a/frontend/src/utils/htmlPreview.ts
+++ b/frontend/src/utils/htmlPreview.ts
@@ -46,6 +46,21 @@ const RESOURCE_ATTRIBUTES: Array<[string, string]> = [
 
 const ALLOWED_ABSOLUTE_URI_PATTERN = /^(https?:|data:|mailto:|tel:|#)/i;
 
+function viewTokenForSibling(resolvedPath: string): string | undefined {
+  const items = state.req?.parentDirItems;
+  if (!items?.length) {
+    return undefined;
+  }
+  const name = resolvedPath.split("/").filter(Boolean).pop();
+  if (!name) {
+    return undefined;
+  }
+  const item = items.find(
+    (entry) => entry.name === name || entry.path === resolvedPath || entry.path?.endsWith(`/${name}`),
+  );
+  return item?.viewToken;
+}
+
 export function isLocalResourceReference(href: string): boolean {
   if (!href || typeof href !== "string") {
     return false;
@@ -67,22 +82,24 @@ export function buildPreviewResourceUrl(
   }
 
   const resolvedPath = resolveRelativePath(baseFilePath, href);
+  const viewToken = viewTokenForSibling(resolvedPath);
 
   try {
     if (getters.isShare()) {
       return getViewURL(
         source,
         resolvedPath,
-        null,
+        viewToken,
         {
           path: state.shareInfo.subPath,
           hash: state.shareInfo.hash,
           token: state.shareInfo.token,
         },
-        true,
+        !viewToken,
+        resolvedPath,
       );
     }
-    return getViewURL(source, resolvedPath, null, null, true);
+    return getViewURL(source, resolvedPath, viewToken, null, !viewToken, resolvedPath);
   } catch {
     return href;
   }

--- a/frontend/src/utils/mediaFile.js
+++ b/frontend/src/utils/mediaFile.js
@@ -1,0 +1,19 @@
+const MEDIA_EXTENSIONS = new Set([
+  '.mp3', '.mp4', '.m4a', '.flac', '.wav', '.ogg', '.oga', '.opus',
+  '.webm', '.mkv', '.avi', '.mov', '.wmv', '.m4v', '.aac', '.wma',
+])
+
+/** @param {string | undefined | null} typeOrName MIME type or file name */
+export function isMediaFile(typeOrName) {
+  if (!typeOrName || typeof typeOrName !== 'string') {
+    return false
+  }
+  if (typeOrName.startsWith('audio/') || typeOrName.startsWith('video/')) {
+    return true
+  }
+  const dot = typeOrName.lastIndexOf('.')
+  if (dot < 0) {
+    return false
+  }
+  return MEDIA_EXTENSIONS.has(typeOrName.slice(dot).toLowerCase())
+}

--- a/frontend/src/utils/mediaFile.test.js
+++ b/frontend/src/utils/mediaFile.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isMediaFile } from "./mediaFile";
+
+describe("isMediaFile", () => {
+  it("detects audio and video MIME types", () => {
+    expect(isMediaFile("audio/mpeg")).toBe(true);
+    expect(isMediaFile("video/mp4")).toBe(true);
+  });
+
+  it("detects common media extensions", () => {
+    expect(isMediaFile("track.flac")).toBe(true);
+    expect(isMediaFile("clip.MP4")).toBe(true);
+  });
+
+  it("rejects non-media types", () => {
+    expect(isMediaFile("application/pdf")).toBe(false);
+    expect(isMediaFile("readme.txt")).toBe(false);
+    expect(isMediaFile("model/gltf+json")).toBe(false);
+  });
+});

--- a/frontend/src/views/files/DocViewer.vue
+++ b/frontend/src/views/files/DocViewer.vue
@@ -159,14 +159,23 @@ export default defineComponent({
           ? resourcesApi.getViewURL(
               state.req.source,
               state.req.path,
-              state.req.streamToken,
+              state.req.viewToken,
               {
                 path: state.shareInfo.subPath,
                 hash: state.shareInfo.hash,
                 token: state.shareInfo.token,
               },
+              false,
+              state.req.type || state.req.name,
             )
-          : resourcesApi.getViewURL(state.req.source, state.req.path, state.req.streamToken);
+          : resourcesApi.getViewURL(
+              state.req.source,
+              state.req.path,
+              state.req.viewToken,
+              null,
+              false,
+              state.req.type || state.req.name,
+            );
 
         if (!downloadUrl) {
           throw new Error("Could not retrieve a valid download URL from the API.");

--- a/frontend/src/views/files/EpubViewer.vue
+++ b/frontend/src/views/files/EpubViewer.vue
@@ -80,14 +80,23 @@ export default defineComponent({
         ? resourcesApi.getViewURL(
             state.req.source,
             state.req.path,
-            state.req.streamToken,
+            state.req.viewToken,
             {
               path: state.shareInfo.subPath,
               hash: state.shareInfo.hash,
               token: state.shareInfo.token,
             },
+            false,
+            state.req.type || state.req.name,
           )
-        : resourcesApi.getViewURL(state.req.source, state.req.path, state.req.streamToken);
+        : resourcesApi.getViewURL(
+            state.req.source,
+            state.req.path,
+            state.req.viewToken,
+            null,
+            false,
+            state.req.type || state.req.name,
+          );
 
       // 2. Initialize the EPUB book
       this.book = ePub(epubUrl);

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -85,7 +85,7 @@
             v-bind:hasDuration="hasDuration"
             v-bind:isShared="item.isShared"
             v-bind:pinned="item.pinned"
-            v-bind:streamToken="item.streamToken"
+            v-bind:viewToken="item.viewToken"
           />
         </div>
 
@@ -116,7 +116,7 @@
             v-bind:hasDuration="hasDuration"
             v-bind:isShared="item.isShared"
             v-bind:pinned="item.pinned"
-            v-bind:streamToken="item.streamToken"
+            v-bind:viewToken="item.viewToken"
           />
         </div>
 
@@ -148,7 +148,7 @@
             v-bind:hasDuration="hasDuration"
             v-bind:isShared="item.isShared"
             v-bind:pinned="item.pinned"
-            v-bind:streamToken="item.streamToken"
+            v-bind:viewToken="item.viewToken"
           />
         </div>
 

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -171,6 +171,8 @@ export default {
       return state.req.type === 'application/pdf';
     },
     raw() {
+      const viewToken = state.req.viewToken;
+      const typeHint = state.req.type || state.req.name;
       const isHeicOrHeif = state.req.type === "image/heic" || state.req.type === "image/heif";
 
       if (state.isSafari && isHeicOrHeif) {
@@ -178,15 +180,17 @@ export default {
           return resourcesApi.getViewURL(
             state.req.source,
             state.req.path,
-            state.req.streamToken,
+            viewToken,
             {
               path: state.shareInfo.subPath,
               hash: state.shareInfo.hash,
               token: state.shareInfo.token,
             },
+            false,
+            typeHint,
           );
         }
-        return resourcesApi.getViewURL(state.req.source, state.req.path, state.req.streamToken);
+        return resourcesApi.getViewURL(state.req.source, state.req.path, viewToken, null, false, typeHint);
       }
 
       const getRawPreview = isRawImageMimeType(state.req.type) && globalVars.exiftoolAvailable;
@@ -208,15 +212,17 @@ export default {
         return resourcesApi.getViewURL(
           state.req.source,
           state.req.path,
-          state.req.streamToken,
+        viewToken,
           {
             path: state.shareInfo.subPath,
             hash: state.shareInfo.hash,
             token: state.shareInfo.token,
           },
+          false,
+          typeHint,
         );
       }
-      return resourcesApi.getViewURL(state.req.source, state.req.path, state.req.streamToken);
+      return resourcesApi.getViewURL(state.req.source, state.req.path, viewToken, null, false, typeHint);
     },
     isDarkMode() {
       return getters.isDarkMode();
@@ -563,22 +569,26 @@ export default {
     },
 
     prefetchUrl(item) {
+      const viewToken = item.viewToken || state.req.viewToken;
+      const typeHint = item.type || item.name;
       if (getters.isShare()) {
         return this.fullSize
           ? resourcesApi.getViewURL(
               state.req.source,
               item.path,
-              item.streamToken || state.req.streamToken,
+              viewToken,
               {
                 path: item.path,
                 hash: state.shareInfo?.hash,
                 token: state.shareInfo?.token,
               },
+              false,
+              typeHint,
             )
           : resourcesApi.getPreviewURLPublic(item.path);
       }
       return this.fullSize
-        ? resourcesApi.getViewURL(state.req.source, item.path, item.streamToken)
+        ? resourcesApi.getViewURL(state.req.source, item.path, viewToken, null, false, typeHint)
         : resourcesApi.getPreviewURL(
             state.req.source,
             item.path,

--- a/frontend/src/views/files/ThreeJs.vue
+++ b/frontend/src/views/files/ThreeJs.vue
@@ -121,7 +121,7 @@ export default {
     isMobile() { return getters.isMobile(); },
     hasAnimations() { return this.animations && this.animations.length > 0; },
     modelUrl() {
-      return this.resourceDownloadUrl(this.fbdata.path);
+      return this.resourceViewUrl(this.fbdata.path);
     },
     fileExtension() {
       return this.fbdata.name ? this.fbdata.name.split('.').pop().toLowerCase() : '';
@@ -338,23 +338,39 @@ export default {
       }
     },
 
-    /** Download URL for a model or sibling asset. 3D loaders need full files; stream tokens only cover listed paths. */
-    resourceDownloadUrl(filePath) {
+    /** View URL for a model or sibling asset via viewToken (non-metered). */
+    resourceViewUrl(filePath) {
       if (!filePath) {
         return "";
       }
+      const viewToken = this.resolveViewTokenForPath(filePath);
+      const typeHint = filePath.split("/").pop() || filePath;
       if (getters.isShare()) {
-        return resourcesApi.getOpenFileURL(
+        return resourcesApi.getViewURL(
           this.fbdata.source,
           filePath,
+          viewToken,
           {
             path: state.shareInfo.subPath,
             hash: state.shareInfo.hash,
             token: state.shareInfo.token,
           },
+          false,
+          typeHint,
         );
       }
-      return resourcesApi.getOpenFileURL(this.fbdata.source, filePath);
+      return resourcesApi.getViewURL(this.fbdata.source, filePath, viewToken, null, false, typeHint);
+    },
+
+    resolveViewTokenForPath(filePath) {
+      if (filePath === this.fbdata.path && this.fbdata.viewToken) {
+        return this.fbdata.viewToken;
+      }
+      const name = filePath.split("/").filter(Boolean).pop();
+      const sibling = this.fbdata.parentDirItems?.find(
+        (item) => item.name === name || item.path === filePath,
+      );
+      return sibling?.viewToken;
     },
 
     resolveTextureUrl(url) {
@@ -364,12 +380,16 @@ export default {
       if (url.startsWith("blob:") || url.startsWith("data:")) {
         return url;
       }
-      if (url.includes("/api/resources/stream?") || url.includes("/api/resources/download?")) {
+      if (
+        url.includes("/api/media/stream?") ||
+        url.includes("/api/resources/view?") ||
+        url.includes("/api/resources/download?")
+      ) {
         try {
           const parsed = new URL(url, window.origin);
           const filePath = parsed.searchParams.get("file") || parsed.searchParams.getAll("file")[0];
           if (filePath) {
-            return this.resourceDownloadUrl(filePath);
+            return this.resourceViewUrl(filePath);
           }
         } catch {
           return url;
@@ -402,7 +422,7 @@ export default {
       } else {
         texturePath = `${modelDir}/textures/${filename}`;
       }
-      return this.resourceDownloadUrl(texturePath);
+      return this.resourceViewUrl(texturePath);
     },
 
     async loadModel() {
@@ -487,7 +507,7 @@ export default {
       // Remove trailing slash if present before replacing extension
       const cleanPath = this.fbdata.path.replace(/\/$/, '');
       const mtlPath = cleanPath.replace(/\.obj$/i, '.mtl');
-      const mtlUrl = this.resourceDownloadUrl(mtlPath);
+      const mtlUrl = this.resourceViewUrl(mtlPath);
       if (!mtlUrl) {
         this.doLoad(loader);
         return;

--- a/frontend/src/views/files/ThreeJs.vue
+++ b/frontend/src/views/files/ThreeJs.vue
@@ -115,6 +115,8 @@ export default {
       loadTimer: null,
       hasInitialized: false,
       isInView: false,
+      viewTokenByPath: {},
+      fetchedDirs: new Set(),
     };
   },
   computed: {
@@ -344,9 +346,13 @@ export default {
         return "";
       }
       const viewToken = this.resolveViewTokenForPath(filePath);
+      if (!viewToken) {
+        return "";
+      }
       const typeHint = filePath.split("/").pop() || filePath;
+      let url;
       if (getters.isShare()) {
-        return resourcesApi.getViewURL(
+        url = resourcesApi.getViewURL(
           this.fbdata.source,
           filePath,
           viewToken,
@@ -358,18 +364,117 @@ export default {
           false,
           typeHint,
         );
+      } else {
+        url = resourcesApi.getViewURL(this.fbdata.source, filePath, viewToken, null, false, typeHint);
       }
-      return resourcesApi.getViewURL(this.fbdata.source, filePath, viewToken, null, false, typeHint);
+      return url || "";
+    },
+
+    normalizeAssetPath(filePath) {
+      if (!filePath) {
+        return filePath;
+      }
+      const trimmed = filePath.replace(/\/+$/, "");
+      return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+    },
+
+    indexViewTokens(items) {
+      if (!items?.length) {
+        return;
+      }
+      for (const item of items) {
+        if (item.path && item.viewToken) {
+          this.viewTokenByPath[this.normalizeAssetPath(item.path)] = item.viewToken;
+        }
+      }
+    },
+
+    directoryListingPath(dirPath) {
+      const normalized = this.normalizeAssetPath(dirPath);
+      return `${normalized}/`;
+    },
+
+    async fetchDirectoryTokens(dirPath) {
+      const listingPath = this.directoryListingPath(dirPath);
+      if (this.fetchedDirs.has(listingPath)) {
+        return;
+      }
+      this.fetchedDirs.add(listingPath);
+      try {
+        let listing;
+        if (getters.isShare()) {
+          listing = await resourcesApi.fetchFilesPublic(
+            listingPath,
+            state.shareInfo.hash,
+            "",
+            false,
+            false,
+          );
+        } else {
+          listing = await resourcesApi.fetchFiles(
+            this.fbdata.source,
+            listingPath,
+            false,
+            false,
+          );
+        }
+        if (listing?.type === "directory" && listing.items?.length) {
+          this.indexViewTokens(listing.items);
+        }
+      } catch {
+        // Missing or inaccessible directories are ignored.
+      }
+    },
+
+    async prefetchAssetViewTokens() {
+      this.indexViewTokens(this.fbdata.parentDirItems);
+      if (this.fbdata.path && this.fbdata.viewToken) {
+        this.viewTokenByPath[this.normalizeAssetPath(this.fbdata.path)] = this.fbdata.viewToken;
+      }
+
+      const modelDir = removeLastDir(this.fbdata.path);
+      await this.fetchDirectoryTokens(modelDir);
+      await this.fetchDirectoryTokens(`${modelDir}/textures`);
     },
 
     resolveViewTokenForPath(filePath) {
-      if (filePath === this.fbdata.path && this.fbdata.viewToken) {
+      const normalizedPath = this.normalizeAssetPath(filePath);
+      if (this.viewTokenByPath[normalizedPath]) {
+        return this.viewTokenByPath[normalizedPath];
+      }
+      if (
+        this.normalizeAssetPath(this.fbdata.path) === normalizedPath &&
+        this.fbdata.viewToken
+      ) {
         return this.fbdata.viewToken;
       }
-      const name = filePath.split("/").filter(Boolean).pop();
-      const sibling = this.fbdata.parentDirItems?.find(
-        (item) => item.name === name || item.path === filePath,
+      const items = this.fbdata.parentDirItems;
+      if (!items?.length) {
+        return undefined;
+      }
+
+      const exact = items.find(
+        (item) => this.normalizeAssetPath(item.path) === normalizedPath,
       );
+      if (exact?.viewToken) {
+        return exact.viewToken;
+      }
+
+      const fileDir = removeLastDir(normalizedPath);
+      const name = normalizedPath.split("/").filter(Boolean).pop();
+      if (!name) {
+        return undefined;
+      }
+
+      const sibling = items.find((item) => {
+        if (item.name !== name) {
+          return false;
+        }
+        if (item.path) {
+          return removeLastDir(this.normalizeAssetPath(item.path)) === fileDir;
+        }
+        return fileDir === removeLastDir(this.fbdata.path);
+      });
       return sibling?.viewToken;
     },
 
@@ -426,8 +531,9 @@ export default {
     },
 
     async loadModel() {
+      await this.prefetchAssetViewTokens();
       if (!this.modelUrl) {
-        this.loading = false;
+        this.handleError(new Error("No view token available for model"), "Failed to load model");
         return;
       }
       this.loading = true;
@@ -736,6 +842,8 @@ export default {
     },
     
     reinit() {
+      this.viewTokenByPath = {};
+      this.fetchedDirs = new Set();
       this.cleanup();
       this.initScene();
       void this.loadModel();


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated inline viewing for non-media files via a new view flow.
  * Media playback now routes through `/api/media/stream` (and public equivalent), enforcing audio/video-only streaming.
  * 3D previews and document/ebook viewers updated to use the new viewing flow.

* **Bug Fixes**
  * Improved request timeout responses with clearer JSON error details.
  * Updated generated preview/open links to consistently use view tokens for both files and directories.
  * Added backward-compatible `/raw` and `/api/raw` download routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->