### PR TITLE
fix http config section being dropped so trustedHeaders and disableRateLimit apply

### DIFF
--- a/backend/common/settings/config.go
+++ b/backend/common/settings/config.go
@@ -857,6 +857,7 @@ func loadConfigWithDefaults(configFile string, generate bool) error {
 		"integrations": true,
 		"frontend":     true,
 		"userDefaults": true,
+		"http":         true,
 	}
 
 	filteredConfig := make(map[string]interface{})

--- a/backend/common/settings/config_test.go
+++ b/backend/common/settings/config_test.go
@@ -94,6 +94,34 @@ func TestConfigLoadEnvVars(t *testing.T) {
 	}
 }
 
+func TestConfigLoadHttpSection(t *testing.T) {
+	testDir := t.TempDir()
+	configContent := []byte(`
+server:
+  sources:
+    - path: "."
+http:
+  trustedHeaders:
+    - X-Forwarded-For
+  disableRateLimit: true
+`)
+	configFile := filepath.Join(testDir, "config.yaml")
+	if err := os.WriteFile(configFile, configContent, 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	if err := loadConfigWithDefaults(configFile, true); err != nil {
+		t.Fatalf("error loading config file: %v", err)
+	}
+
+	if len(Config.Http.TrustedHeadersArray) != 1 || Config.Http.TrustedHeadersArray[0] != "X-Forwarded-For" {
+		t.Fatalf("expected trusted headers to contain X-Forwarded-For, got %v", Config.Http.TrustedHeadersArray)
+	}
+	if !Config.Http.DisableRateLimit {
+		t.Fatal("expected http.disableRateLimit to be true")
+	}
+}
+
 func TestConfigLoadSpecificValues(t *testing.T) {
 	// Create isolated test directory
 	testDir := t.TempDir()


### PR DESCRIPTION
According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), a PR should contain:

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.

## Summary

This restores the `http:` config section so `trustedHeaders` and `disableRateLimit` are applied instead of being silently dropped. With the section honored again, `X-Forwarded-For` from a trusted proxy is used for the client IP.

## Why this matters

Reported in #2560: users behind a reverse proxy set `http.trustedHeaders: [X-Forwarded-For]` but access logs still showed the proxy address `127.0.0.1` instead of the real client IP, and the setting had no effect.

The root cause is in `loadConfigWithDefaults` (`backend/common/settings/config.go`). After the first YAML pass, the loader filters the raw config down to a `validFields` whitelist of top-level `Settings` keys before the strict decode. That whitelist listed `server`, `auth`, `integrations`, `frontend`, and `userDefaults` but omitted `http`, even though `Settings` has a top-level `Http` field tagged `json:"http"`. As a result the whole `http:` block (including `trustedHeaders` and `disableRateLimit`) was stripped before decoding, so `Config.Http.TrustedHeadersArray` stayed empty, `setupHttp()` never built the `TrustedHeaders` map, and `getRemoteIP` never trusted `X-Forwarded-For`.

Adding `"http": true` to the whitelist preserves the section so it is decoded and applied.

## Testing

- Added a regression test (`TestConfigLoadHttpSection`) that loads a config with an `http:` section setting `trustedHeaders: [X-Forwarded-For]` and `disableRateLimit: true`, then asserts the section survives `loadConfigWithDefaults` (`Config.Http.TrustedHeadersArray` contains `X-Forwarded-For` and `Config.Http.DisableRateLimit` is true). This fails before the fix because the section is dropped.
- `go test ./common/settings/...`, `go vet ./common/settings/...`, `go build ./...`, and `gofmt` all pass locally.

Fixes #2560


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved config loading so `http` settings in YAML are now preserved and applied correctly.
  * Fixed an issue where certain HTTP options could be dropped during config parsing, causing them to be ignored.
  
* **Tests**
  * Added coverage to verify `http` configuration values load as expected, including trusted headers and rate-limit settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->