### PR TITLE
fix plyr scrub timestamp and improve the styles a bit

### DIFF
--- a/frontend/src/plyr/plyrScrubPreview.js
+++ b/frontend/src/plyr/plyrScrubPreview.js
@@ -431,8 +431,11 @@ export function enablePlyrScrubPreview(player, options) {
     if (clientX === null) {
       return;
     }
-    positionScrubPreviewPopup(popup, progress.getBoundingClientRect(), clientX);
-    positionScrubPreviewArrow(arrowEl, popup, clientX);
+    const progressRect = progress.getBoundingClientRect();
+    positionScrubPreviewPopup(popup, progressRect, clientX);
+    // clamp to the progress bar edges
+    const arrowClientX = Math.max(progressRect.left, Math.min(progressRect.right, clientX));
+    positionScrubPreviewArrow(arrowEl, popup, arrowClientX);
   };
 
   const updateTimeLabel = (percent) => {

--- a/frontend/src/plyr/plyrScrubPreview.js
+++ b/frontend/src/plyr/plyrScrubPreview.js
@@ -7,10 +7,11 @@ const DEFAULT_PREVIEW_WIDTH_PX = 600;
 const DEFAULT_MAX_PREVIEW_HEIGHT_PX = 600;
 const DEFAULT_PLACEHOLDER_ASPECT = 16 / 9;
 const DEFAULT_SCRUB_PERCENT_STEP = 2;
+const MAX_SCRUB_FETCH_PERCENT = 99; // 99 to never request a preview at the exact end of the media, it was causing an error.
 const MAX_CACHE_ENTRIES = 24;
 const VIEWPORT_MARGIN_PX = 16;
 const GAP_ABOVE_PROGRESS_PX = 14;
-const TIME_LABEL_HEIGHT_PX = 28;
+const ARROW_EDGE_MARGIN_PX = 14;
 
 /**
  * @param {number} percent
@@ -82,21 +83,30 @@ export function scrubClientXFromEvent(event) {
  * @returns {number}
  */
 export function scrubPercentFromEvent(progress, seek, event, step = DEFAULT_SCRUB_PERCENT_STEP) {
-  if (event?.currentTarget === seek) {
-    const attr = seek.getAttribute('seek-value');
-    const raw = attr !== null && attr !== '' ? Number(attr) : Number(seek.value);
-    return quantizeScrubPercent(raw, step);
-  }
+  return quantizeScrubPercent(scrubRawPercentFromEvent(progress, seek, event), step);
+}
+
+/**
+ * @param {HTMLElement} progress
+ * @param {HTMLInputElement} seek
+ * @param {Event} event
+ * @returns {number}
+ */
+export function scrubRawPercentFromEvent(progress, seek, event) {
   const clientX = scrubClientXFromEvent(event);
-  if (!progress || clientX === null) {
+  if (progress && clientX !== null) {
+    const rect = progress.getBoundingClientRect();
+    if (rect.width > 0) {
+      const raw = ((clientX - rect.left) / rect.width) * 100;
+      return Math.max(0, Math.min(100, raw));
+    }
+  }
+  if (!seek) {
     return 0;
   }
-  const rect = progress.getBoundingClientRect();
-  if (rect.width <= 0) {
-    return 0;
-  }
-  const raw = ((clientX - rect.left) / rect.width) * 100;
-  return quantizeScrubPercent(raw, step);
+  const attr = seek.getAttribute('seek-value');
+  const raw = attr !== null && attr !== '' ? Number(attr) : Number(seek.value);
+  return Number.isFinite(raw) ? Math.max(0, Math.min(100, raw)) : 0;
 }
 
 /**
@@ -129,7 +139,7 @@ export function fitScrubPreviewImageSize(
   const viewportMaxWidth = Math.max(1, viewportWidth - VIEWPORT_MARGIN_PX * 2);
   const viewportMaxHeight = Math.max(
     1,
-    progressTop - VIEWPORT_MARGIN_PX - GAP_ABOVE_PROGRESS_PX - TIME_LABEL_HEIGHT_PX,
+    progressTop - VIEWPORT_MARGIN_PX - GAP_ABOVE_PROGRESS_PX,
   );
   const maxWidth = Math.max(1, Math.min(maxWidthPx, viewportMaxWidth));
   const maxHeight = Math.max(1, Math.min(maxHeightPx, viewportMaxHeight));
@@ -159,6 +169,19 @@ export function getScrubPreviewMount(player) {
     return container;
   }
   return container instanceof HTMLElement ? container : document.body;
+}
+
+/**
+ * @param {HTMLElement} arrowEl
+ * @param {HTMLElement} popup
+ * @param {number} clientX
+ */
+export function positionScrubPreviewArrow(arrowEl, popup, clientX) {
+  const popupRect = popup.getBoundingClientRect();
+  const width = popupRect.width || 1;
+  const margin = ARROW_EDGE_MARGIN_PX;
+  const offset = Math.max(margin, Math.min(width - margin, clientX - popupRect.left));
+  arrowEl.style.left = `${offset}px`;
 }
 
 /**
@@ -224,9 +247,15 @@ export function enablePlyrScrubPreview(player, options) {
 
   const timeEl = document.createElement('span');
   timeEl.className = 'fb-scrub-preview__time';
+  timeEl.setAttribute('aria-hidden', 'true');
 
-  frame.append(img, loadingEl);
-  popup.append(frame, timeEl);
+  // small arrow below the frame that tracks the cursor
+  const arrowEl = document.createElement('div');
+  arrowEl.className = 'fb-scrub-preview__arrow';
+  arrowEl.setAttribute('aria-hidden', 'true');
+
+  frame.append(img, loadingEl, timeEl);
+  popup.append(frame, arrowEl);
 
   const ensurePopupMounted = () => {
     const mount = getScrubPreviewMount(player);
@@ -251,6 +280,7 @@ export function enablePlyrScrubPreview(player, options) {
 
   /** @type {Map<number, string>} */
   const cache = new Map();
+  let lastFailedPercent = null;
   let scrubbing = false;
   let hovering = false;
   let pendingPercent = null;
@@ -402,9 +432,10 @@ export function enablePlyrScrubPreview(player, options) {
       return;
     }
     positionScrubPreviewPopup(popup, progress.getBoundingClientRect(), clientX);
+    positionScrubPreviewArrow(arrowEl, popup, clientX);
   };
 
-  const updateTimeLabel = (percentInt) => {
+  const updateTimeLabel = (percent) => {
     const duration = typeof options.getDuration === 'function'
       ? options.getDuration()
       : player.duration;
@@ -412,7 +443,7 @@ export function enablePlyrScrubPreview(player, options) {
       timeEl.textContent = formatTime(0);
       return;
     }
-    timeEl.textContent = formatTime((duration / 100) * percentInt);
+    timeEl.textContent = formatTime((duration / 100) * percent);
   };
 
   const trimCache = () => {
@@ -461,6 +492,11 @@ export function enablePlyrScrubPreview(player, options) {
       applyCachedImage(target);
       return;
     }
+    if (target === lastFailedPercent) {
+      // Don't retry, but keep the spinner for feedback since can make the use think that the image fetched when isn't.
+      setLoading(true);
+      return;
+    }
     if (inFlightPercent !== null || fetchScheduled) {
       return;
     }
@@ -480,6 +516,10 @@ export function enablePlyrScrubPreview(player, options) {
         applyCachedImage(nextTarget);
         return;
       }
+      if (nextTarget === lastFailedPercent) {
+        setLoading(true);
+        return;
+      }
       if (inFlightPercent === nextTarget) {
         return;
       }
@@ -488,6 +528,10 @@ export function enablePlyrScrubPreview(player, options) {
       lastFetchAt = Date.now();
       void fetchPreview(nextTarget).finally(() => {
         if (!previewActive() || pendingPercent === null) {
+          return;
+        }
+        if (pendingPercent === lastFailedPercent) {
+          setLoading(true);
           return;
         }
         if (
@@ -519,6 +563,9 @@ export function enablePlyrScrubPreview(player, options) {
       const objectUrl = await fetchPreviewImage(url, controller.signal);
       cache.set(percentInt, objectUrl);
       lastFetchedPercent = percentInt;
+      if (lastFailedPercent === percentInt) {
+        lastFailedPercent = null;
+      }
       trimCache();
       if (previewActive() && pendingPercent === percentInt) {
         img.src = objectUrl;
@@ -526,8 +573,14 @@ export function enablePlyrScrubPreview(player, options) {
           markDisplayed(percentInt);
         }
       }
-    } catch {
+    } catch (err) {
       // Aborts and preview failures are expected while scrubbing quickly.
+      if (err?.name !== 'AbortError') {
+        lastFailedPercent = percentInt;
+        if (pendingPercent === percentInt) {
+          setLoading(true);
+        }
+      }
     } finally {
       if (inFlightPercent === percentInt) {
         inFlightPercent = null;
@@ -539,10 +592,15 @@ export function enablePlyrScrubPreview(player, options) {
   };
 
   const handlePreviewPosition = (event) => {
-    const percentInt = scrubPercentFromEvent(progress, seek, event, scrubPercentStep);
+    const rawPercent = scrubRawPercentFromEvent(progress, seek, event);
+    const percentInt = Math.min(
+      quantizeScrubPercent(rawPercent, scrubPercentStep),
+      MAX_SCRUB_FETCH_PERCENT,
+    );
     lastPositionEvent = event;
     positionPopup(event);
     show();
+    updateTimeLabel(rawPercent);
 
     // Same bucket — only reposition the popup, no image/time churn.
     if (percentInt === displayedPercent) {
@@ -550,7 +608,9 @@ export function enablePlyrScrubPreview(player, options) {
     }
 
     pendingPercent = percentInt;
-    updateTimeLabel(percentInt);
+    if (lastFailedPercent !== null && lastFailedPercent !== percentInt) {
+      lastFailedPercent = null;
+    }
 
     if (cache.has(percentInt)) {
       applyCachedImage(percentInt);
@@ -663,6 +723,7 @@ export function enablePlyrScrubPreview(player, options) {
       URL.revokeObjectURL(url);
     }
     cache.clear();
+    lastFailedPercent = null;
     popup.remove();
   };
 }

--- a/frontend/src/plyr/plyrSeekOnRelease.js
+++ b/frontend/src/plyr/plyrSeekOnRelease.js
@@ -20,6 +20,19 @@ export function readPlyrSeekPercent(input) {
 }
 
 /**
+ * @param {Event} event
+ * @returns {number | null}
+ */
+function clientXFromEvent(event) {
+  if (!event) return null;
+  if (Number.isFinite(event.clientX)) {
+    return event.clientX;
+  }
+  const touch = event.changedTouches?.[0] ?? event.touches?.[0];
+  return touch && Number.isFinite(touch.clientX) ? touch.clientX : null;
+}
+
+/**
  * @param {import('plyr').default} player
  * @param {Event} [event]
  */
@@ -28,6 +41,16 @@ export function commitPlyrSeek(player, event) {
   const duration = player?.duration;
   if (!seek || !Number.isFinite(duration) || duration <= 0) {
     return;
+  }
+  const progress = player?.elements?.progress;
+  const clientX = clientXFromEvent(event);
+  if (progress && clientX !== null) {
+    const rect = progress.getBoundingClientRect();
+    if (rect.width > 0) {
+      const percent = Math.max(0, Math.min(100, ((clientX - rect.left) / rect.width) * 100));
+      player.currentTime = (percent / 100) * duration;
+      return;
+    }
   }
   const target = event?.currentTarget instanceof HTMLInputElement ? event.currentTarget : seek;
   const percent = readPlyrSeekPercent(target);

--- a/frontend/src/views/files/plyrViewer.vue
+++ b/frontend/src/views/files/plyrViewer.vue
@@ -2602,13 +2602,24 @@ export default {
   position: relative;
   max-height: 600px;
   max-width: 600px;
-  border-radius: 4px;
+  border-radius: 14px;
   background: #000;
   border: 2px solid var(--primaryColor);
   box-shadow:
     0 0 0 1px rgba(0, 0, 0, 0.35),
     0 6px 20px rgba(0, 0, 0, 0.55),
     0 0 12px color-mix(in srgb, var(--primaryColor) 35%, transparent);
+}
+
+.fb-scrub-preview__frame::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 44%;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0));
+  pointer-events: none;
 }
 
 .fb-scrub-preview__loading {
@@ -2647,13 +2658,41 @@ export default {
 }
 
 .fb-scrub-preview__time {
-  display: block;
-  margin-top: 6px;
-  text-align: center;
+  position: absolute;
+  left: 50%;
+  bottom: 8px;
+  transform: translateX(-50%);
+  z-index: 1;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
+  line-height: 1;
   color: #fff;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.85);
+  white-space: nowrap;
+  text-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.9),
+    0 0 8px rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+}
+
+.fb-scrub-preview__arrow {
+  position: absolute;
+  top: calc(100% - 2px);
+  transform: translateX(-50%);
+  width: 14px;
+  height: 8px;
+  pointer-events: none;
+}
+
+.fb-scrub-preview__arrow::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 8px solid var(--primaryColor);
 }
 
 /* Big play button when pause/start the video */


### PR DESCRIPTION
This fixes the inaccurate timestamp when hovering the mouse that I mentioned before [here](https://github.com/gtsteffaniak/filebrowser/pull/2580#issuecomment-4827390586), the reason it was "inaccurate" is because was calculating it on percentage rather than use the raw cursor position. The previews still the same and are by percentage, didn't changed that.

Also capped the percent to 99% which fixes an issue where hovering in the end of the video (seeking in 100%) was causing errors, and also updated the styles a bit!

<img width="450" alt="1783628498953704955" src="https://github.com/user-attachments/assets/b48c09ea-7e08-47c3-9a19-a542aaeea67c" />

Now is more like the native plyr tooltip. The timestamp is inside the preview and the border has a tiny arrow that follows the cursor for better feedback :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved “scrub” preview experience with a redesigned popup, including a dedicated arrow indicator and refreshed styling.
  * Enhanced seek-on-release to calculate the target position from the progress bar under the pointer/touch for more accurate jumping.

* **Bug Fixes**
  * Refined scrub preview fetching to reduce repeated failed requests near the end of media while keeping the loading indicator consistent.
  * Improved popup sizing/placement for better vertical fit and more accurate timestamp positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->