### PR TITLE
add webdav X-OC-Mtime header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ A database migration is required to go from v1.x to this version. See docs.
    - The current state of the audio panel now is stored into local storage.
    - More gestures: Swipe up to enter/exit fullscreen, long-press to change playback speed, single tap to pause (#2575).
  - Added `F4` shortcut to refresh the current directory and metadata (#2600).
+ - WebDAV now supports set modification time via the `X-OC-Mtime` header for clients that support it (#2626).
 
  **Removed legacy (breaking)**:
  - `GET /api/raw` and `GET /public/api/raw` download routes — use `/api/resources/download` instead.

--- a/backend/internal/web/webdav.go
+++ b/backend/internal/web/webdav.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -202,9 +204,28 @@ func (ffs *filteredFileSystem) checkAccess(requestPath string) error {
 // filteredFile wraps a webdav.File and filters Readdir results based on FileInfoFaster
 type filteredFile struct {
 	webdav.File
-	fs          *filteredFileSystem
-	requestPath string // The request path (without user scope)
-	isDir       bool   // Whether this is a directory
+	fs           *filteredFileSystem
+	requestPath  string    // The request path (without user scope)
+	isDir        bool      // Whether this is a directory
+	desiredMtime time.Time // client-requested mtime (with X-OC-Mtime header)
+}
+
+// closes the file and if a client-requested mtime was captured for a new file, applies it after the write completes
+func (ff *filteredFile) Close() error {
+	err := ff.File.Close()
+	if err != nil {
+		return err
+	}
+	if !ff.desiredMtime.IsZero() {
+		dir, ok := ff.fs.fs.(webdav.Dir)
+		if ok {
+			realPath := filepath.Join(string(dir), filepath.FromSlash(ff.requestPath))
+			if chtimesErr := os.Chtimes(realPath, time.Now(), ff.desiredMtime); chtimesErr != nil {
+				logger.Errorf("failed to set mtime on %s: %v", realPath, chtimesErr)
+			}
+		}
+	}
+	return nil
 }
 
 func (ff *filteredFile) Readdir(count int) ([]os.FileInfo, error) {
@@ -305,13 +326,26 @@ func (ffs *filteredFileSystem) OpenFile(ctx context.Context, requestPath string,
 		return nil, err
 	}
 
+	// only new uploads carry mtime
+	var desiredMtime time.Time
+	if flag&os.O_CREATE != 0 && ffs.httpReq != nil {
+		if raw := ffs.httpReq.Header.Get("X-OC-Mtime"); raw != "" {
+			if seconds, parseErr := strconv.ParseFloat(raw, 64); parseErr == nil {
+				desiredMtime = time.Unix(int64(seconds), 0)
+			} else {
+				logger.Debugf("OpenFile: invalid X-OC-Mtime header %q for %s: %v", raw, requestPath, parseErr)
+			}
+		}
+	}
+
 	// Wrap the file to filter directory listings
 	// name is the request path (without user scope)
 	return &filteredFile{
-		File:        file,
-		fs:          ffs,
-		requestPath: requestPath,
-		isDir:       stat.IsDir(),
+		File:         file,
+		fs:           ffs,
+		requestPath:  requestPath,
+		isDir:        stat.IsDir(),
+		desiredMtime: desiredMtime,
 	}, nil
 }
 

--- a/backend/internal/web/webdav_test.go
+++ b/backend/internal/web/webdav_test.go
@@ -793,6 +793,30 @@ func TestWebDAV_PutSetsMtimeFromOCHeader(t *testing.T) {
 	put("updated!", time.Date(2021, 6, 7, 8, 9, 10, 0, time.UTC), http.StatusCreated)
 }
 
+func TestWebDAV_PutIgnoresInvalidOCMtimeHeader(t *testing.T) {
+	source1Path, _ := setupWebDAVTestEnv(t)
+	user := &users.User{
+		ID: 1,
+		FrontendUser: users.FrontendUser{
+			Username:    "mtimeuser2",
+			Permissions: users.Permissions{Download: true, Create: true, Modify: true, Delete: true},
+		},
+		BackendScopes: []users.BackendScope{{Path: source1Path, Scope: "/"}},
+	}
+	req := httptest.NewRequest(http.MethodPut, "/dav/source1/public/file2.txt", strings.NewReader("hi"))
+	req.SetPathValue("source", "source1")
+	req.SetPathValue("path", "/public/file2.txt")
+	req.Header.Set("X-OC-Mtime", "not-a-number")
+
+	w := httptest.NewRecorder()
+	if _, err := webDAVHandler(w, req, &requestContext{User: user}); err != nil {
+		t.Fatalf("webDAVHandler: %v", err)
+	}
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected %d, got %d", http.StatusCreated, w.Code)
+	}
+}
+
 // Helper function to initialize a test index - simplified for WebDAV tests
 func initTestIndex(t *testing.T, name, path string) {
 	// For WebDAV tests, indices are already initialized in setupWebDAVTestEnv

--- a/backend/internal/web/webdav_test.go
+++ b/backend/internal/web/webdav_test.go
@@ -803,6 +803,9 @@ func TestWebDAV_PutIgnoresInvalidOCMtimeHeader(t *testing.T) {
 		},
 		BackendScopes: []users.BackendScope{{Path: source1Path, Scope: "/"}},
 	}
+	filePath := filepath.Join(source1Path, "public", "file2.txt")
+
+	before := time.Now()
 	req := httptest.NewRequest(http.MethodPut, "/dav/source1/public/file2.txt", strings.NewReader("hi"))
 	req.SetPathValue("source", "source1")
 	req.SetPathValue("path", "/public/file2.txt")
@@ -812,8 +815,17 @@ func TestWebDAV_PutIgnoresInvalidOCMtimeHeader(t *testing.T) {
 	if _, err := webDAVHandler(w, req, &requestContext{User: user}); err != nil {
 		t.Fatalf("webDAVHandler: %v", err)
 	}
+	after := time.Now()
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected %d, got %d", http.StatusCreated, w.Code)
+	}
+
+	got, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if got.ModTime().Before(before.Add(-time.Second)) || got.ModTime().After(after.Add(time.Second)) {
+		t.Errorf("mtime = %v, want between %v and %v", got.ModTime(), before, after)
 	}
 }
 

--- a/backend/internal/web/webdav_test.go
+++ b/backend/internal/web/webdav_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/app"
@@ -748,6 +750,47 @@ func TestWebDAV_IndexingStates(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test that PUT with X-OC-Mtime header applies the mod time to the file on initial creation and on overwrite
+func TestWebDAV_PutSetsMtimeFromOCHeader(t *testing.T) {
+	source1Path, _ := setupWebDAVTestEnv(t)
+
+	user := &users.User{
+		ID: 1,
+		FrontendUser: users.FrontendUser{
+			Username:    "mtimeuser",
+			Permissions: users.Permissions{Download: true, Create: true, Modify: true, Delete: true},
+		},
+		BackendScopes: []users.BackendScope{{Path: source1Path, Scope: "/"}},
+	}
+	filePath := filepath.Join(source1Path, "public", "file.txt")
+
+	put := func(body string, mtime time.Time, wantStatus int) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPut, "/dav/source1/public/file.txt", strings.NewReader(body))
+		req.SetPathValue("source", "source1")
+		req.SetPathValue("path", "/public/file.txt")
+		req.Header.Set("X-OC-Mtime", strconv.FormatInt(mtime.Unix(), 10))
+
+		w := httptest.NewRecorder()
+		if _, err := webDAVHandler(w, req, &requestContext{User: user}); err != nil {
+			t.Fatalf("webDAVHandler: %v", err)
+		}
+		if w.Code != wantStatus {
+			t.Fatalf("expected %d, got %d", wantStatus, w.Code)
+		}
+
+		got, err := os.Stat(filePath)
+		if err != nil {
+			t.Fatalf("stat file: %v", err)
+		}
+		if !got.ModTime().Equal(mtime) {
+			t.Errorf("mtime = %v, want %v", got.ModTime(), mtime)
+		}
+	}
+	put("hi", time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC), http.StatusCreated)
+	put("updated!", time.Date(2021, 6, 7, 8, 9, 10, 0, time.UTC), http.StatusCreated)
 }
 
 // Helper function to initialize a test index - simplified for WebDAV tests


### PR DESCRIPTION
This should fix https://github.com/gtsteffaniak/filebrowser/discussions/2621 (discussion)

With this we can now specify a desired modification time when uploading (or overwriting) via the `X-OC-Mtime` header that some clients like rclone, (or by uploading via curl) support.

I found this useful too, like the op of the discussion. I have some files that I don't want to lose the mod time, and was more or less easy to add :p

Hope all is fine tho, I don't use go that often and got a bit confused with the recent backend changes :c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebDAV uploads now support setting the file modification time using the client-provided `X-OC-Mtime` header during create/overwrite.

* **Bug Fixes**
  * WebDAV PUT operations now preserve modification timestamps correctly, including overwrite scenarios.

* **Tests**
  * Added tests to confirm valid `X-OC-Mtime` values update the on-disk `ModTime`, and invalid values are safely ignored while the upload still succeeds.

* **Documentation**
  * Updated the v2.0.0 changelog to note `X-OC-Mtime` support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->