### PR TITLE
fix onlyoffice stale doc cache key on close v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ A database migration is required to go from v1.x to this version. See docs.
  - `/api/media/stream` is audio/video only (range-based chunking). Non-media inline viewing uses `GET /api/resources/view`. Both endpoints use the same `viewToken` from file metadata.
  - removed exiftool as an optional helper, always built with the supported libraries.
 
+ **BugFixes**:
+ - Fixed OnlyOffice reopening an older editor state after a document is modified (#2628) (#2578).
+
 ## v1.5.0
 
  **New Features**:

--- a/backend/internal/web/onlyOffice.go
+++ b/backend/internal/web/onlyOffice.go
@@ -764,7 +764,11 @@ func deleteOfficeId(source, path string, user *users.User) {
 	}, user)
 	if err != nil {
 		logger.Errorf("deleteOfficeId: failed to resolve realpath, source=%s, path=%s: %v", source, path, err)
-		utils.OnlyOfficeCache.Delete(path)
+		if fi != nil && fi.RealPath != "" {
+			utils.OnlyOfficeCache.Delete(fi.RealPath)
+		} else {
+			utils.OnlyOfficeCache.Delete(path)
+		}
 		return
 	}
 	utils.OnlyOfficeCache.Delete(fi.RealPath)

--- a/backend/internal/web/onlyOffice.go
+++ b/backend/internal/web/onlyOffice.go
@@ -762,16 +762,14 @@ func deleteOfficeId(source, path string, user *users.User) {
 		Expand:         false,
 		FollowSymlinks: true,
 	}, user)
+	key := path
+	if fi != nil && fi.RealPath != "" {
+		key = fi.RealPath
+	}
 	if err != nil {
 		logger.Errorf("deleteOfficeId: failed to resolve realpath, source=%s, path=%s: %v", source, path, err)
-		if fi != nil && fi.RealPath != "" {
-			utils.OnlyOfficeCache.Delete(fi.RealPath)
-		} else {
-			utils.OnlyOfficeCache.Delete(path)
-		}
-		return
 	}
-	utils.OnlyOfficeCache.Delete(fi.RealPath)
+	utils.OnlyOfficeCache.Delete(key)
 }
 
 // parseOnlyOfficeJWT parses the JWT token from OnlyOffice callback

--- a/backend/internal/web/onlyOffice.go
+++ b/backend/internal/web/onlyOffice.go
@@ -15,8 +15,8 @@ import (
 
 	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
-	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/gtsteffaniak/go-logger/logger"
@@ -482,7 +482,7 @@ func processOnlyOfficeCallback(w http.ResponseWriter, r *http.Request, d *Contex
 		//
 		// When the document is fully closed by all editors,
 		// the document key should no longer be re-used.
-		deleteOfficeId(source, path)
+		deleteOfficeId(source, path, user)
 
 		// Send log event for document closure and clean up log context
 		if logContext := GetOnlyOfficeLogContext(data.Key); logContext != nil {
@@ -755,14 +755,19 @@ func GetOnlyOfficeId(realpath string) (string, error) {
 	return "", fmt.Errorf("document key not found")
 }
 
-func deleteOfficeId(source, path string) {
-	idx := indexing.GetIndex(source)
-	if idx == nil {
-		logger.Errorf("deleteOfficeId: failed to find source index for user home dir creation: %s", source)
+func deleteOfficeId(source, path string, user *users.User) {
+	fi, err := files.FileInfoFaster(utils.FileOptions{
+		Path:           path,
+		Source:         source,
+		Expand:         false,
+		FollowSymlinks: true,
+	}, user)
+	if err != nil {
+		logger.Errorf("deleteOfficeId: failed to resolve realpath, source=%s, path=%s: %v", source, path, err)
+		utils.OnlyOfficeCache.Delete(path)
 		return
 	}
-	realpath, _, _ := idx.GetRealPath(path)
-	utils.OnlyOfficeCache.Delete(realpath)
+	utils.OnlyOfficeCache.Delete(fi.RealPath)
 }
 
 // parseOnlyOfficeJWT parses the JWT token from OnlyOffice callback

--- a/backend/internal/web/onlyOffice_test.go
+++ b/backend/internal/web/onlyOffice_test.go
@@ -93,23 +93,34 @@ func TestDeleteOfficeId(t *testing.T) {
 	const rawPath = "/docs/document.docx"
 
 	tests := []struct {
-		name     string
-		resolve  func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error)
-		cacheKey string
+		name      string
+		resolve   func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error)
+		deleteKey string
+		remainKey string
 	}{
 		{
-			name: "deletes resolved realpath from cache",
+			name: "deletes resolved realpath",
 			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
 				return &iteminfo.ExtendedFileInfo{RealPath: "/some/path/document.docx"}, nil
 			},
-			cacheKey: "/some/path/document.docx",
+			deleteKey: "/some/path/document.docx",
+			remainKey: rawPath,
 		},
 		{
 			name: "fallback to raw path on error",
 			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
 				return nil, fmt.Errorf("could not resolve path")
 			},
-			cacheKey: rawPath,
+			deleteKey: rawPath,
+			remainKey: "/some/path/document.docx",
+		},
+		{
+			name: "also deletes realpath when partially resolved before erroring",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return &iteminfo.ExtendedFileInfo{RealPath: "/some/path/document.docx"}, fmt.Errorf("access check failed")
+			},
+			deleteKey: "/some/path/document.docx",
+			remainKey: rawPath,
 		},
 	}
 	for _, tt := range tests {
@@ -117,12 +128,25 @@ func TestDeleteOfficeId(t *testing.T) {
 			origFunc := files.FileInfoFasterFunc
 			t.Cleanup(func() { files.FileInfoFasterFunc = origFunc })
 			files.FileInfoFasterFunc = func(opts utils.FileOptions, user *users.User) (*iteminfo.ExtendedFileInfo, error) {
+				if opts.Path != rawPath {
+					t.Errorf("expected opts.Path=%q, got %q", rawPath, opts.Path)
+				}
+				if opts.Source != "source" {
+					t.Errorf("expected opts.Source=%q, got %q", "source", opts.Source)
+				}
+				if !opts.FollowSymlinks {
+					t.Error("expected FollowSymlinks=true")
+				}
 				return tt.resolve(opts)
 			}
-			utils.OnlyOfficeCache.Set(tt.cacheKey, "document-key")
+			utils.OnlyOfficeCache.Set(tt.deleteKey, "document-key")
+			utils.OnlyOfficeCache.Set(tt.remainKey, "other-key")
 			deleteOfficeId("source", rawPath, &users.User{})
-			if _, err := GetOnlyOfficeId(tt.cacheKey); err == nil {
-				t.Errorf("expected cache entry %q to be deleted", tt.cacheKey)
+			if _, err := GetOnlyOfficeId(tt.deleteKey); err == nil {
+				t.Errorf("expected cache entry %q to be deleted", tt.deleteKey)
+			}
+			if _, err := GetOnlyOfficeId(tt.remainKey); err != nil {
+				t.Errorf("expected cache entry %q to remain, but it was deleted", tt.remainKey)
 			}
 		})
 	}

--- a/backend/internal/web/onlyOffice_test.go
+++ b/backend/internal/web/onlyOffice_test.go
@@ -1,9 +1,14 @@
 package web
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 
+	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 )
 
@@ -83,6 +88,44 @@ func TestResolveOnlyOfficeDownloadURL(t *testing.T) {
 			t.Errorf("resolveOnlyOfficeDownloadURL() = %q, want empty", got)
 		}
 	})
+}
+func TestDeleteOfficeId(t *testing.T) {
+	const rawPath = "/docs/document.docx"
+
+	tests := []struct {
+		name     string
+		resolve  func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error)
+		cacheKey string
+	}{
+		{
+			name: "deletes resolved realpath from cache",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return &iteminfo.ExtendedFileInfo{RealPath: "/some/path/document.docx"}, nil
+			},
+			cacheKey: "/some/path/document.docx",
+		},
+		{
+			name: "fallback to raw path on error",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return nil, fmt.Errorf("could not resolve path")
+			},
+			cacheKey: rawPath,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origFunc := files.FileInfoFasterFunc
+			t.Cleanup(func() { files.FileInfoFasterFunc = origFunc })
+			files.FileInfoFasterFunc = func(opts utils.FileOptions, user *users.User) (*iteminfo.ExtendedFileInfo, error) {
+				return tt.resolve(opts)
+			}
+			utils.OnlyOfficeCache.Set(tt.cacheKey, "document-key")
+			deleteOfficeId("source", rawPath, &users.User{})
+			if _, err := GetOnlyOfficeId(tt.cacheKey); err == nil {
+				t.Errorf("expected cache entry %q to be deleted", tt.cacheKey)
+			}
+		})
+	}
 }
 
 func TestOnlyOfficeURLHostsMatch(t *testing.T) {


### PR DESCRIPTION
Fixes #2578 

Also added a test -- The issue basically was a path mismatch and it was "deleting" a non-existent key. Then OO kept using the stale one since it wasn't really deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OnlyOffice document-closure cache cleanup to be user-aware, improving real file path resolution and preventing reopening an older editor state after edits.
  * Cache cleanup now removes the correct entry whether resolved path lookup succeeds or fails, with a safe fallback to the original path.

* **Tests**
  * Added table-driven coverage to verify cache deletion using resolved real paths and fallback behavior when path resolution fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->