### PR TITLE
Beta/v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v1.5.0
 
+ **BugFixes**:
+ - fix http config section being dropped so trustedHeaders and disableRateLimit apply (#2602) (#2560)
+ - fix upload shares with password (#2589) (#2573)
+ - fix token when returning from preview on shares with pass (#2588) (#2465)
+ - fix share undefined url after editing (#2567) (#2523)
+
+## v1.5.0
+
  **New Features**:
  - Added basic html viewer with relative reference support (#2522)
  - Shares can have pinned files, requires a user to have edit access to share (#2522)

--- a/backend/common/settings/config.go
+++ b/backend/common/settings/config.go
@@ -857,6 +857,7 @@ func loadConfigWithDefaults(configFile string, generate bool) error {
 		"integrations": true,
 		"frontend":     true,
 		"userDefaults": true,
+		"http":         true,
 	}
 
 	filteredConfig := make(map[string]interface{})

--- a/backend/common/settings/config_test.go
+++ b/backend/common/settings/config_test.go
@@ -94,6 +94,34 @@ func TestConfigLoadEnvVars(t *testing.T) {
 	}
 }
 
+func TestConfigLoadHttpSection(t *testing.T) {
+	testDir := t.TempDir()
+	configContent := []byte(`
+server:
+  sources:
+    - path: "."
+http:
+  trustedHeaders:
+    - X-Forwarded-For
+  disableRateLimit: true
+`)
+	configFile := filepath.Join(testDir, "config.yaml")
+	if err := os.WriteFile(configFile, configContent, 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	if err := loadConfigWithDefaults(configFile, true); err != nil {
+		t.Fatalf("error loading config file: %v", err)
+	}
+
+	if len(Config.Http.TrustedHeadersArray) != 1 || Config.Http.TrustedHeadersArray[0] != "X-Forwarded-For" {
+		t.Fatalf("expected trusted headers to contain X-Forwarded-For, got %v", Config.Http.TrustedHeadersArray)
+	}
+	if !Config.Http.DisableRateLimit {
+		t.Fatal("expected http.disableRateLimit to be true")
+	}
+}
+
 func TestConfigLoadSpecificValues(t *testing.T) {
 	// Create isolated test directory
 	testDir := t.TempDir()

--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -798,24 +798,18 @@ export default {
           payload.enableOnlyOffice = false;
         }
 
-        const res = await shareApi.create(payload);
+        await shareApi.create(payload);
 
-        if (!this.isEditMode && !this.editingLink) {
-          this.links.push(res);
-          this.sort();
-        } else if (this.editingLink) {
-          // Update the link in the local list
-          const index = this.links.findIndex(l => l.hash === this.editingLink.hash);
-          if (index !== -1) {
-            this.links.splice(index, 1, res);
-          }
-          this.editingLink = null;
-          // emit event to reload shares in settings view
-          eventBus.emit('sharesChanged');
-        } else {
+        if (this.isEditMode) {
           // emit event to reload shares in settings view
           eventBus.emit('sharesChanged');
           mutations.closeTopPrompt();
+        } else {
+          // refrest the shares list when editing or creating from listing view
+          const refreshed = await this.refreshShares();
+          if (!refreshed) return;
+          this.editingLink = null;
+          eventBus.emit('sharesChanged');
         }
 
         this.time = "";
@@ -829,6 +823,21 @@ export default {
           // didn't come from api, show error to user
           notify.showError(err);
         }
+      }
+    },
+    async refreshShares() {
+      if (this.isEditMode) return true;
+      this.linksLoading = true;
+      try {
+        const links = await shareApi.get(this.item.path, this.item.source);
+        this.links = links;
+        this.sort();
+        return true;
+      } catch (err) {
+        console.error(err);
+        return false;
+      } finally {
+        this.linksLoading = false;
       }
     },
     /**

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -1070,10 +1070,18 @@ export const mutations = {
     emitStateChanged();
   },
   setShareInfo: (shareInfo) => {
-    if (state.shareInfo === shareInfo) {
-      return;
-    }
-    state.shareInfo = shareInfo;
+   // Merge with existing state
+   const merged = { ...state.shareInfo, ...shareInfo };
+   if (shareInfo.token === undefined && state.shareInfo.token) {
+     merged.token = state.shareInfo.token;
+   }
+   if (shareInfo.passwordValid === undefined && state.shareInfo.passwordValid !== undefined) {
+     merged.passwordValid = state.shareInfo.passwordValid;
+   }
+   if (JSON.stringify(merged) === JSON.stringify(state.shareInfo)) {
+     return;
+   }
+   state.shareInfo = merged;
     updateManifestLink();
     emitStateChanged();
   },

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -170,7 +170,7 @@
 
   <!-- Upload Share Target -->
   <!-- Only show upload interface if password is validated (or no password required) -->
-  <div v-else-if="!shareInfo.hasPassword || state.share?.passwordValid" class="upload-share-embed">
+  <div v-else-if="!shareInfo.hasPassword || shareInfo.passwordValid" class="upload-share-embed">
     <Upload :initialItems="null" />
   </div>
 </template>


### PR DESCRIPTION
## What's Changed

 **BugFixes**:
 - fix http config section being dropped so trustedHeaders and disableRateLimit apply (#2602) (#2560)
 - fix upload shares with password (#2589) (#2573)
 - fix token when returning from preview on shares with pass (#2588) (#2465)
 - fix share undefined url after editing (#2567) (#2523)

## New Contributors
* @mvanhorn made their first contribution in https://github.com/gtsteffaniak/filebrowser/pull/2602

**Full Changelog**: https://github.com/gtsteffaniak/filebrowser/compare/v1.5.0-beta...v1.5.1-beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed HTTP configuration handling for trusted headers and rate-limiting settings.
  - Fixed password-protected upload shares and improved password validation during share previews.
  - Preserved share access tokens and password status when updating share information.
  - Fixed share URLs after editing existing shares.
  - Improved share list refresh behavior after creating or editing shares.
  - Corrected upload visibility for password-protected shared links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->