### PR TITLE
fix onlyoffice stale doc cache key on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file. For commit guidelines, please refer to [Standard Version](https://github.com/conventional-changelog/standard-version).
 
-## v1.5.0
+## v1.5.2
+
+ **BugFixes**:
+ - Fixed OnlyOffice reopening an older editor state after a document is modified (#2633) (#2578).
+
+## v1.5.1
 
  **BugFixes**:
  - fix http config section being dropped so trustedHeaders and disableRateLimit apply (#2602) (#2560)

--- a/backend/http/onlyOffice.go
+++ b/backend/http/onlyOffice.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gtsteffaniak/filebrowser/backend/adapters/fs/files"
 	"github.com/gtsteffaniak/filebrowser/backend/common/settings"
 	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
-	"github.com/gtsteffaniak/filebrowser/backend/indexing"
+	"github.com/gtsteffaniak/filebrowser/backend/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/indexing/iteminfo"
 	"github.com/gtsteffaniak/go-logger/logger"
 )
@@ -482,7 +482,7 @@ func processOnlyOfficeCallback(w http.ResponseWriter, r *http.Request, d *reques
 		//
 		// When the document is fully closed by all editors,
 		// the document key should no longer be re-used.
-		deleteOfficeId(source, path)
+		deleteOfficeId(source, path, user)
 
 		// Send log event for document closure and clean up log context
 		if logContext := getOnlyOfficeLogContext(data.Key); logContext != nil {
@@ -755,14 +755,21 @@ func getOnlyOfficeId(realpath string) (string, error) {
 	return "", fmt.Errorf("document key not found")
 }
 
-func deleteOfficeId(source, path string) {
-	idx := indexing.GetIndex(source)
-	if idx == nil {
-		logger.Errorf("deleteOfficeId: failed to find source index for user home dir creation: %s", source)
-		return
+func deleteOfficeId(source, path string, user *users.User) {
+	fi, err := files.FileInfoFaster(utils.FileOptions{
+		Path:           path,
+		Source:         source,
+		Expand:         false,
+		FollowSymlinks: true,
+	}, store.Access, user, store.Share)
+	key := path
+	if fi != nil && fi.RealPath != "" {
+		key = fi.RealPath
 	}
-	realpath, _, _ := idx.GetRealPath(path)
-	utils.OnlyOfficeCache.Delete(realpath)
+	if err != nil {
+		logger.Errorf("deleteOfficeId: failed to resolve realpath, source=%s, path=%s: %v", source, path, err)
+	}
+	utils.OnlyOfficeCache.Delete(key)
 }
 
 // parseOnlyOfficeJWT parses the JWT token from OnlyOffice callback

--- a/backend/http/onlyOffice_test.go
+++ b/backend/http/onlyOffice_test.go
@@ -148,6 +148,10 @@ func TestDeleteOfficeId(t *testing.T) {
 			}
 			utils.OnlyOfficeCache.Set(tt.deleteKey, "document-key")
 			utils.OnlyOfficeCache.Set(tt.remainKey, "other-key")
+			t.Cleanup(func() {
+				utils.OnlyOfficeCache.Delete(tt.deleteKey)
+				utils.OnlyOfficeCache.Delete(tt.remainKey)
+			})
 			deleteOfficeId("source", rawPath, &users.User{})
 			if _, err := getOnlyOfficeId(tt.deleteKey); err == nil {
 				t.Errorf("expected cache entry %q to be deleted", tt.deleteKey)

--- a/backend/http/onlyOffice_test.go
+++ b/backend/http/onlyOffice_test.go
@@ -1,8 +1,17 @@
 package http
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/adapters/fs/files"
+	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
+	"github.com/gtsteffaniak/filebrowser/backend/database/access"
+	"github.com/gtsteffaniak/filebrowser/backend/database/share"
+	"github.com/gtsteffaniak/filebrowser/backend/database/storage/bolt"
+	"github.com/gtsteffaniak/filebrowser/backend/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/indexing/iteminfo"
 )
 
 func TestResolveOnlyOfficeDownloadURL(t *testing.T) {
@@ -81,6 +90,73 @@ func TestResolveOnlyOfficeDownloadURL(t *testing.T) {
 			t.Errorf("resolveOnlyOfficeDownloadURL() = %q, want empty", got)
 		}
 	})
+}
+
+func TestDeleteOfficeId(t *testing.T) {
+	const rawPath = "/docs/document.docx"
+
+	tests := []struct {
+		name      string
+		resolve   func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error)
+		deleteKey string
+		remainKey string
+	}{
+		{
+			name: "deletes resolved realpath",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return &iteminfo.ExtendedFileInfo{RealPath: "/some/path/document.docx"}, nil
+			},
+			deleteKey: "/some/path/document.docx",
+			remainKey: rawPath,
+		},
+		{
+			name: "fallback to raw path on error",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return nil, fmt.Errorf("could not resolve path")
+			},
+			deleteKey: rawPath,
+			remainKey: "/some/path/document.docx",
+		},
+		{
+			name: "also deletes realpath when partially resolved before erroring",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return &iteminfo.ExtendedFileInfo{RealPath: "/some/path/document.docx"}, fmt.Errorf("access check failed")
+			},
+			deleteKey: "/some/path/document.docx",
+			remainKey: rawPath,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origStore := store
+			store = &bolt.BoltStore{Access: &access.Storage{}, Share: &share.Storage{}}
+			t.Cleanup(func() { store = origStore })
+
+			origFunc := files.FileInfoFasterFunc
+			t.Cleanup(func() { files.FileInfoFasterFunc = origFunc })
+			files.FileInfoFasterFunc = func(opts utils.FileOptions, accessStore *access.Storage, user *users.User, shareStore *share.Storage) (*iteminfo.ExtendedFileInfo, error) {
+				if opts.Path != rawPath {
+					t.Errorf("expected opts.Path=%q, got %q", rawPath, opts.Path)
+				}
+				if opts.Source != "source" {
+					t.Errorf("expected opts.Source=%q, got %q", "source", opts.Source)
+				}
+				if !opts.FollowSymlinks {
+					t.Error("expected FollowSymlinks=true")
+				}
+				return tt.resolve(opts)
+			}
+			utils.OnlyOfficeCache.Set(tt.deleteKey, "document-key")
+			utils.OnlyOfficeCache.Set(tt.remainKey, "other-key")
+			deleteOfficeId("source", rawPath, &users.User{})
+			if _, err := getOnlyOfficeId(tt.deleteKey); err == nil {
+				t.Errorf("expected cache entry %q to be deleted", tt.deleteKey)
+			}
+			if _, err := getOnlyOfficeId(tt.remainKey); err != nil {
+				t.Errorf("expected cache entry %q to remain, but it was deleted", tt.remainKey)
+			}
+		})
+	}
 }
 
 func TestOnlyOfficeURLHostsMatch(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/gtsteffaniak/filebrowser/issues/2578 -- Same as https://github.com/gtsteffaniak/filebrowser/pull/2628 but ported to v1.5.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document cleanup after OnlyOffice editing sessions, preventing older editor state from reopening after modifications.
  * Ensured OnlyOffice cache entries are deleted using resolved file paths and correct user context, with reliable fallback when full resolution isn’t available.

* **Tests**
  * Added table-driven coverage for cache deletion success, full-resolution failure, and partial-resolution error scenarios.

* **Documentation**
  * Updated the changelog to include the new v1.5.2 bug fix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->