### PR TITLE
Fix PDFs rendering as text instead of in the PDF viewer

### DIFF
--- a/backend/adapters/fs/files/content_test.go
+++ b/backend/adapters/fs/files/content_test.go
@@ -6,8 +6,53 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
+	"github.com/gtsteffaniak/filebrowser/backend/indexing/iteminfo"
 	"github.com/stretchr/testify/require"
 )
+
+// Regression: an ASCII-heavy PDF passes utils.IsTextFile's byte heuristic, but
+// processContent must NOT return its bytes as text content -- otherwise the
+// frontend opens it in the text editor instead of the PDF viewer (#pdf-as-text).
+func TestProcessContent_PDFDoesNotReturnTextContent(t *testing.T) {
+	pdfBody := "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" +
+		"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n" +
+		"trailer\n<< /Root 1 0 R >>\n%%EOF\n"
+	pdfFile := filepath.Join(t.TempDir(), "doc.pdf")
+	require.NoError(t, os.WriteFile(pdfFile, []byte(pdfBody), 0o644))
+
+	// Precondition: the byte heuristic really does misclassify this PDF as text,
+	// so without the type guard its raw bytes would be returned as content.
+	isText, err := utils.IsTextFile(pdfFile)
+	require.NoError(t, err)
+	require.True(t, isText, "precondition: ASCII-heavy PDF sniffs as text")
+
+	pdfInfo := &iteminfo.ExtendedFileInfo{
+		FileInfo: iteminfo.FileInfo{ItemInfo: iteminfo.ItemInfo{
+			Name: "doc.pdf",
+			Type: "application/pdf",
+			Size: int64(len(pdfBody)),
+		}},
+		RealPath: pdfFile,
+	}
+	processContent(pdfInfo, nil, utils.FileOptions{Content: true})
+	require.Empty(t, pdfInfo.Content, "PDF must not have text content populated")
+
+	// Control: a genuine text file still gets its content extracted.
+	txtBody := "hello text"
+	txtFile := filepath.Join(t.TempDir(), "notes.txt")
+	require.NoError(t, os.WriteFile(txtFile, []byte(txtBody), 0o644))
+	txtInfo := &iteminfo.ExtendedFileInfo{
+		FileInfo: iteminfo.FileInfo{ItemInfo: iteminfo.ItemInfo{
+			Name: "notes.txt",
+			Type: "text/plain",
+			Size: int64(len(txtBody)),
+		}},
+		RealPath: txtFile,
+	}
+	processContent(txtInfo, nil, utils.FileOptions{Content: true})
+	require.Equal(t, txtBody, txtInfo.Content, "text file should still return content")
+}
 
 func TestGetContent_UTF8Truncation(t *testing.T) {
 	// Get the path to the test file

--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -365,6 +365,15 @@ func processContent(info *iteminfo.ExtendedFileInfo, idx *indexing.Index, opts u
 		return
 	}
 
+	// Never extract text content for formats that must use a dedicated viewer.
+	// A PDF renders via the frontend iframe preview, not the text editor; and
+	// getContent's byte heuristic (utils.IsTextFile) misclassifies ASCII-heavy
+	// PDFs as text, which would ship the raw bytes as content and open the file
+	// in the editor instead of the PDF viewer.
+	if info.Type == "application/pdf" {
+		return
+	}
+
 	// Process text content for non-video, non-audio files
 	if info.Size < 20*1024*1024 { // 20 megabytes in bytes
 		content, err := getContent(info.RealPath)

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -348,6 +348,10 @@ export const getters = {
         return 'markdownViewer';
       }
 
+      // PDFs always use the iframe preview, never the text editor -- even when the
+      // backend returned a `content` field (some ASCII-heavy PDFs sniff as text).
+      if (state.req.type === 'application/pdf') return 'preview';
+
       if ('content' in state.req) return 'editor';
       if (state.req.type.startsWith('application/epub')) return 'epubViewer';
       if (state.req.type.startsWith('application/vnd.openxmlformats-officedocument.wordprocessingml.document')) return 'docViewer';

--- a/frontend/src/store/getters.test.js
+++ b/frontend/src/store/getters.test.js
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+// Import the real getters implementation directly (the global test setup mocks the
+// "@/store" barrel, so `getters` is not exported from there). getters.js binds to
+// the same mocked `state` singleton we mutate below.
+import { getters } from "@/store/getters.js";
+import { state } from "@/store";
+
+// Regression: a PDF must open in the PDF preview (iframe), never the text editor,
+// even when the backend included a `content` field for it. Some ASCII-heavy PDFs
+// pass the backend's text byte-heuristic and would otherwise be misrouted to the
+// editor by the generic `'content' in req -> editor` fallback.
+describe("getters.currentView PDF routing", () => {
+  beforeEach(() => {
+    state.navigation = { isTransitioning: false };
+    state.user = { username: "tester", disableViewingExt: "" };
+    state.route = { path: "/files/report.pdf" };
+  });
+
+  it("routes a PDF that has a content field to the preview, not the editor", () => {
+    state.req = {
+      type: "application/pdf",
+      name: "report.pdf",
+      content: "%PDF-1.4 catalog pages ...",
+    };
+    expect(getters.currentView()).toBe("preview");
+  });
+
+  it("routes a PDF without a content field to the preview", () => {
+    state.req = { type: "application/pdf", name: "report.pdf" };
+    expect(getters.currentView()).toBe("preview");
+  });
+
+  it("still routes a genuine text file with content to the editor", () => {
+    state.req = { type: "text/plain", name: "notes.txt", content: "hello" };
+    expect(getters.currentView()).toBe("editor");
+  });
+});


### PR DESCRIPTION
Some PDFs opened in the plain-text editor instead of the PDF viewer. The file's type was correctly application/pdf, but the backend returned the file's bytes in the `content` field: processContent() called getContent() for any non-audio/video file, and utils.IsTextFile() only checks the first 8KB for <5% null bytes and valid UTF-8. PDFs with an ASCII-heavy header (e.g. generated reports) pass that heuristic, so their raw bytes were shipped as `content`. The frontend's currentView() then returns 'editor' whenever a `content` field is present, ahead of the 'preview' fallback, so the PDF opened as text. PDFs with binary bytes early in the file failed the heuristic and rendered correctly, which is why only some PDFs were affected.

Backend: skip text-content extraction for application/pdf in processContent (root cause fix; also avoids shipping PDF bytes in the JSON response). Frontend: route application/pdf to 'preview' before the content->editor fallback in currentView (defense in depth).

Adds regression tests on both sides.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDFs now consistently open in preview mode instead of being treated as editable text.
  * Prevented raw PDF data from appearing as extracted document content.
  * Preserved editor behavior for genuine text files.

* **Tests**
  * Added coverage for PDF preview routing and content handling.
  * Added regression coverage confirming text files continue to display editable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->