### PR TITLE
fix totp reset with existing verification code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. For commit 
 
  **BugFixes**:
  - Fixed OnlyOffice reopening an older editor state after a document is modified (#2633) (#2578).
+ - Cannot "Reset and generate new two-factor code" to reset the TOTP for a user (#2399) (#2641).
 
 ## v1.5.1
 

--- a/backend/auth/totp.go
+++ b/backend/auth/totp.go
@@ -150,7 +150,7 @@ func VerifyTotpCode(user *users.User, code string, userStore *users.Storage) err
 	if !found && user.TOTPSecret == "" {
 		return fmt.Errorf("OTP token not found in cache, please generate a new one")
 	}
-	useCache := found && user.TOTPSecret == ""
+	useCache := found
 	totpSecret := user.TOTPSecret // The encrypted or plaintext secret
 	totpNonce := user.TOTPNonce   // The nonce if encrypted, or empty if plaintext
 	if useCache {

--- a/backend/http/totp_test.go
+++ b/backend/http/totp_test.go
@@ -61,15 +61,15 @@ func TestVerifyOTP_CachedSecretTakesPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate old code: %v", err)
 	}
-	if _, err := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", oldCode), d); err == nil {
+	if _, verifyErr := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", oldCode), d); verifyErr == nil {
 		t.Error("expected old secret to be rejected")
 	}
 	newCode, err := totp.GenerateCode(newSecret, time.Now())
 	if err != nil {
 		t.Fatalf("failed to generate new code: %v", err)
 	}
-	if _, err := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", newCode), d); err != nil {
-		t.Fatalf("expected new secret to be accepted: %v", err)
+	if _, verifyErr := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", newCode), d); verifyErr != nil {
+		t.Fatalf("expected new secret to be accepted: %v", verifyErr)
 	}
 	updated, err := store.Users.Get(user.Username)
 	if err != nil {
@@ -98,7 +98,7 @@ func TestLogin_EnforcedOtp(t *testing.T) {
 	}
 
 	user.TOTPSecret = "SOMESECRET123456"
-	if _, err := loginHandler(httptest.NewRecorder(), otpRequest(user.Username, "", ""), d); err != nil {
-		t.Fatalf("expected login with TOTP to succed, got err=%v", err)
+	if _, loginErr := loginHandler(httptest.NewRecorder(), otpRequest(user.Username, "", ""), d); loginErr != nil {
+		t.Fatalf("expected login with TOTP to succed, got err=%v", loginErr)
 	}
 }

--- a/backend/http/totp_test.go
+++ b/backend/http/totp_test.go
@@ -1,0 +1,94 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gtsteffaniak/filebrowser/backend/auth"
+	"github.com/gtsteffaniak/filebrowser/backend/common/errors"
+	"github.com/gtsteffaniak/filebrowser/backend/database/users"
+	"github.com/pquerna/otp/totp"
+)
+
+func otpRequest(username, password, code string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/otp?username="+username, http.NoBody)
+	req.Header.Set("X-Password", password)
+	if code != "" {
+		req.Header.Set("X-Secret", code)
+	}
+	return req
+}
+
+func TestVerifyOTP_CachedSecretTakesPrecedence(t *testing.T) {
+	setupTestEnv(t)
+
+	oldSecret := "SOMEOLDSECRET123XD4"
+	user := &users.User{
+		ID:               1,
+		Username:         "test",
+		NonAdminEditable: users.NonAdminEditable{Password: "testPass"},
+		TOTPSecret:       oldSecret,
+		OtpEnabled:       true,
+	}
+	if err := store.Users.Save(user, true, true); err != nil {
+		t.Fatalf("failed to save user: %v", err)
+	}
+	t.Cleanup(func() { auth.TotpCache.Delete(user.Username) })
+
+	d := &requestContext{user: user}
+
+	rec := httptest.NewRecorder()
+	if _, err := generateOTPHandler(rec, otpRequest(user.Username, "testPass", ""), d); err != nil {
+		t.Fatalf("genration failed: %v", err)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	newSecret := strings.SplitN(resp["url"], "secret=", 2)[1]
+	if newSecret == oldSecret {
+		t.Fatal("expected a fresh secret")
+	}
+	oldCode, _ := totp.GenerateCode(oldSecret, time.Now())
+	if _, err := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", oldCode), d); err == nil {
+		t.Error("expected old secret to be rejected")
+	}
+	newCode, _ := totp.GenerateCode(newSecret, time.Now())
+	if _, err := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", newCode), d); err != nil {
+		t.Fatalf("expected new secret to be accepted: %v", err)
+	}
+	updated, err := store.Users.Get(user.Username)
+	if err != nil {
+		t.Fatalf("failed to reload user: %v", err)
+	}
+	if updated.TOTPSecret != newSecret {
+		t.Error("expected TOTPSecret to be updated to the new secret")
+	}
+	if _, found := auth.TotpCache.Get(user.Username); found {
+		t.Error("expected cache to be cleared after verification")
+	}
+}
+
+func TestLogin_EnforcedOtp(t *testing.T) {
+	setupTestEnv(t)
+	config.Auth.Key = "test-key"
+	config.Auth.TokenExpirationHours = 1
+	config.Auth.Methods.PasswordAuth.EnforcedOtp = true
+
+	user := &users.User{ID: 2, Username: "loginuser", LoginMethod: users.LoginMethodPassword}
+	d := &requestContext{user: user}
+
+	status, err := loginHandler(httptest.NewRecorder(), otpRequest(user.Username, "", ""), d)
+	if status != http.StatusForbidden || err != errors.ErrNoTotpConfigured {
+		t.Fatalf("expected login without TOTP to fail, got=%d err=%v", status, err)
+	}
+
+	user.TOTPSecret = "SOMESECRET123456"
+	if _, err := loginHandler(httptest.NewRecorder(), otpRequest(user.Username, "", ""), d); err != nil {
+		t.Fatalf("expected login with TOTP to succed, got err=%v", err)
+	}
+}

--- a/backend/http/totp_test.go
+++ b/backend/http/totp_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"net/url"
 	"testing"
 	"time"
 
@@ -26,7 +26,7 @@ func otpRequest(username, password, code string) *http.Request {
 func TestVerifyOTP_CachedSecretTakesPrecedence(t *testing.T) {
 	setupTestEnv(t)
 
-	oldSecret := "SOMEOLDSECRET123XD4"
+	oldSecret := "SOMEOLDSECRET234"
 	user := &users.User{
 		ID:               1,
 		Username:         "test",
@@ -49,15 +49,25 @@ func TestVerifyOTP_CachedSecretTakesPrecedence(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	newSecret := strings.SplitN(resp["url"], "secret=", 2)[1]
+	u, err := url.Parse(resp["url"])
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+	newSecret := u.Query().Get("secret")
 	if newSecret == oldSecret {
 		t.Fatal("expected a fresh secret")
 	}
-	oldCode, _ := totp.GenerateCode(oldSecret, time.Now())
+	oldCode, err := totp.GenerateCode(oldSecret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate old code: %v", err)
+	}
 	if _, err := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", oldCode), d); err == nil {
 		t.Error("expected old secret to be rejected")
 	}
-	newCode, _ := totp.GenerateCode(newSecret, time.Now())
+	newCode, err := totp.GenerateCode(newSecret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate new code: %v", err)
+	}
 	if _, err := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", newCode), d); err != nil {
 		t.Fatalf("expected new secret to be accepted: %v", err)
 	}


### PR DESCRIPTION
should fix https://github.com/gtsteffaniak/filebrowser/issues/2399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * One-time passcode verification now uses cached authentication secrets when available, even if an existing TOTP secret/nonce is already present.
  * OTP “reset and generate new code” no longer allows resetting a user’s TOTP.
* **Tests**
  * Added HTTP-layer coverage to confirm cached-secret precedence during OTP verification.
  * Added tests for enforced-OTP login behavior (denied when TOTP isn’t configured; allowed after configuration).
* **Documentation**
  * Updated the changelog with the two-factor reset/generation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->