### PR TITLE
preserve files mod time with copy operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ A database migration is required to go from v1.x to this version. See docs.
    - if opt-in, every month a snapshot of your deployment config would be sent to developer servers
    - this will help me know what features are being used and what versions everyone is on over time. I will also provide a public dashboard with this information in the future. 
  - WebDAV now supports set modification time via the `X-OC-Mtime` header for clients that support it (#2626).
+ - Copy file operations (WebUI and WebDAV `COPY`) now will preserve their original modification time too (#2642).
 
  **Removed legacy (breaking)**:
  - `GET /api/raw` and `GET /public/api/raw` download routes — use `/api/resources/download` instead.

--- a/backend/internal/adapters/fs/fileutils/file.go
+++ b/backend/internal/adapters/fs/fileutils/file.go
@@ -193,14 +193,21 @@ func PreserveModTimes(src, dst string) error {
 		return os.Chtimes(dst, info.ModTime(), info.ModTime())
 	}
 	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
-			return err
+		if err != nil {
+			logger.Debugf("Error accessing %s to set mod time: %v", p, err)
+			return nil
+		}
+		if info.IsDir() {
+			return nil
 		}
 		rel, err := filepath.Rel(src, p)
 		if err != nil {
-			return err
+			return nil
 		}
-		return os.Chtimes(filepath.Join(dst, rel), info.ModTime(), info.ModTime())
+		if err := os.Chtimes(filepath.Join(dst, rel), info.ModTime(), info.ModTime()); err != nil {
+			logger.Debugf("Could not preserve modification time for %s: %v", filepath.Join(dst, rel), err)
+		}
+		return nil
 	})
 }
 

--- a/backend/internal/adapters/fs/fileutils/file.go
+++ b/backend/internal/adapters/fs/fileutils/file.go
@@ -113,7 +113,7 @@ func copySingleFile(source, dest string) error {
 	defer src.Close()
 
 	// Create the destination directory if needed.
-	err = os.MkdirAll(filepath.Dir(dest), PermDir)
+	err = os.MkdirAll(filepath.Dir(dest), EffectiveDirPerm())
 	if err != nil {
 		return err
 	}
@@ -139,14 +139,17 @@ func copySingleFile(source, dest string) error {
 		// The file was copied successfully, so we continue
 		logger.Debugf("Could not set file permissions for %s (this may be expected in restricted environments): %v", dest, err)
 	}
-
+	// Preserve source file mod time
+	if err := os.Chtimes(dest, srcInfo.ModTime(), srcInfo.ModTime()); err != nil {
+		logger.Debugf("Could not preserve modification time for %s: %v", dest, err)
+	}
 	return nil
 }
 
 // copyDirectory handles copying directories recursively.
 func copyDirectory(source, dest string) error {
 	// Create the destination directory.
-	err := os.MkdirAll(dest, PermDir)
+	err := os.MkdirAll(dest, EffectiveDirPerm())
 	if err != nil {
 		return err
 	}
@@ -178,6 +181,27 @@ func copyDirectory(source, dest string) error {
 	}
 
 	return nil
+}
+
+// PreserveModTimes copies the mod times from src onto dst, this is used by the webdav COPY handler
+func PreserveModTimes(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return os.Chtimes(dst, info.ModTime(), info.ModTime())
+	}
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(filepath.Join(dst, rel), info.ModTime(), info.ModTime())
+	})
 }
 
 // CommonPrefix returns the common directory path of provided files.

--- a/backend/internal/adapters/fs/fileutils/file.go
+++ b/backend/internal/adapters/fs/fileutils/file.go
@@ -192,16 +192,21 @@ func PreserveModTimes(src, dst string) error {
 	if !info.IsDir() {
 		return os.Chtimes(dst, info.ModTime(), info.ModTime())
 	}
-	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+	return filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			logger.Debugf("Error accessing %s to set mod time: %v", p, err)
 			return nil
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 		rel, err := filepath.Rel(src, p)
 		if err != nil {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			logger.Debugf("Error getting info for %s: %v", p, err)
 			return nil
 		}
 		if err := os.Chtimes(filepath.Join(dst, rel), info.ModTime(), info.ModTime()); err != nil {

--- a/backend/internal/adapters/fs/fileutils/file_test.go
+++ b/backend/internal/adapters/fs/fileutils/file_test.go
@@ -2,7 +2,9 @@ package fileutils
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestUnixModeToFileMode_setgid(t *testing.T) {
@@ -56,6 +58,55 @@ func TestCommonPrefix(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := CommonPrefix('/', tt.paths...); got != tt.want {
 				t.Errorf("CommonPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCopyFilePreservesModTime(t *testing.T) {
+	fileTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	testCases := map[string]struct {
+		isDir     bool
+		checkPath string
+	}{
+		"file":      {checkPath: ""},
+		"directory": {isDir: true, checkPath: "nested.txt"},
+	}
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			src := t.TempDir()
+			dst := filepath.Join(t.TempDir(), "dst")
+			srcPath := src
+			if tt.isDir {
+				nested := filepath.Join(src, "nested.txt")
+				if err := os.WriteFile(nested, []byte("hi"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chtimes(nested, fileTime, fileTime); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				srcPath = filepath.Join(src, "file.txt")
+				if err := os.WriteFile(srcPath, []byte("hi"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chtimes(srcPath, fileTime, fileTime); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := CopyFile(srcPath, dst); err != nil {
+				t.Fatal(err)
+			}
+			p := dst
+			if tt.checkPath != "" {
+				p = filepath.Join(dst, tt.checkPath)
+			}
+			got, err := os.Stat(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !got.ModTime().Equal(fileTime) {
+				t.Errorf("%s: got mtime = %v, want %v", p, got.ModTime(), fileTime)
 			}
 		})
 	}

--- a/backend/internal/web/webdav.go
+++ b/backend/internal/web/webdav.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -508,9 +510,54 @@ func webDAVHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, err
 			}
 		},
 	}
-
+	if r.Method == "COPY" {
+		if !userCanWrite(d.User.Permissions) {
+			return http.StatusForbidden, fmt.Errorf("user has no permission to modify")
+		}
+		srcRealPath := filepath.Join(scopePath, requestPath)
+		sw := &statusResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		wd.ServeHTTP(sw, r)
+		if destRealPath, ok := resolveDestination(r, prefix, scopePath); sw.status < 300 && ok {
+			if err := fileutils.PreserveModTimes(srcRealPath, destRealPath); err != nil {
+				logger.Debugf("could not preserve modification time on webdav copy: %v", err)
+			}
+		}
+		return 200, nil
+	}
 	wd.ServeHTTP(w, r)
 	return 200, nil // errors and responses (XML-formatted) are handled by webdav handler
+}
+
+// statusResponseWriter records the status code written by the wrapped handler
+type statusResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (sw *statusResponseWriter) WriteHeader(status int) {
+	sw.status = status
+	sw.ResponseWriter.WriteHeader(status)
+}
+
+// resolveDestination resolves the real fs path when doing a copy request
+func resolveDestination(r *http.Request, prefix, scopePath string) (string, bool) {
+	raw := r.Header.Get("Destination")
+	if raw == "" {
+		return "", false
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", false
+	}
+	rest, ok := strings.CutPrefix(u.Path, prefix)
+	if !ok || (rest != "" && rest[0] != '/') {
+		return "", false
+	}
+	rel := path.Clean("/" + rest)
+	if rel == "/" {
+		return "", false
+	}
+	return filepath.Join(scopePath, rel), true
 }
 
 func userCanWrite(permissions users.Permissions) bool {

--- a/backend/internal/web/webdav_test.go
+++ b/backend/internal/web/webdav_test.go
@@ -829,6 +829,44 @@ func TestWebDAV_PutIgnoresInvalidOCMtimeHeader(t *testing.T) {
 	}
 }
 
+func TestWebDAV_CopyPreservesModTime(t *testing.T) {
+	source1Path, _ := setupWebDAVTestEnv(t)
+	user := &users.User{
+		ID: 1,
+		FrontendUser: users.FrontendUser{
+			Username:    "testcopy",
+			Permissions: users.Permissions{Download: true, Create: true, Modify: true, Delete: true},
+		},
+		BackendScopes: []users.BackendScope{{Path: source1Path, Scope: "/"}},
+	}
+	fileTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	readme := filepath.Join(source1Path, "public", "readme.txt")
+	if err := os.Chtimes(readme, fileTime, fileTime); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("COPY", "/dav/source1/public/", nil)
+	req.SetPathValue("source", "source1")
+	req.SetPathValue("path", "/public/")
+	req.Header.Set("Destination", "/dav/source1/copy")
+	req.Header.Set("Depth", "infinity")
+
+	w := httptest.NewRecorder()
+	if _, err := webDAVHandler(w, req, &requestContext{User: user}); err != nil {
+		t.Fatalf("webDAVHandler: %v", err)
+	}
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected %d, got %d", http.StatusCreated, w.Code)
+	}
+	got, err := os.Stat(filepath.Join(source1Path, "copy", "readme.txt"))
+	if err != nil {
+		t.Fatalf("stat copy: %v", err)
+	}
+	if !got.ModTime().Equal(fileTime) {
+		t.Errorf("mtime = %v, want %v", got.ModTime(), fileTime)
+	}
+}
+
+
 // Helper function to initialize a test index - simplified for WebDAV tests
 func initTestIndex(t *testing.T, name, path string) {
 	// For WebDAV tests, indices are already initialized in setupWebDAVTestEnv


### PR DESCRIPTION
Fixes https://github.com/gtsteffaniak/filebrowser/issues/2627 and possibly also https://github.com/gtsteffaniak/filebrowser/issues/2461

Also works with WebDAV, but not with all clients. Some clients do a client-side copy with GET and PROPFIND requests, so it won't work with those.

Only files mtimes will be preserved, dirs was also possible but was a bit more complex for webdav + I haven't seen other file managers keep the dir mtime anyways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebDAV `COPY` operations now preserve source modification timestamps for both files and directories.
  * File copying now creates destination directories using the configured effective permission settings.
  * Destination resolution and success status handling remain consistent while metadata is preserved.
* **Tests**
  * Added unit coverage to verify copied files and directories retain modification times.
  * Added a WebDAV integration test validating timestamp preservation during `COPY`.
* **Chores**
  * Updated the changelog to note Web UI/WebDAV `COPY` modification time preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->