### PR TITLE
preserve dir modtime with copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ A database migration is required to go from v1.x to this version. See docs.
    - if opt-in, every month a snapshot of your deployment config would be sent to developer servers
    - this will help me know what features are being used and what versions everyone is on over time. I will also provide a public dashboard with this information in the future. 
  - WebDAV now supports set modification time via the `X-OC-Mtime` header for clients that support it (#2626).
- - Copy file operations (WebUI and WebDAV `COPY`) now will preserve their original modification time too (#2642).
+ - Copy operations now will preserve their original modification time too (#2642) (#2647): 
+    - WebUI preserves both, files and directories.
+    - WebDAV `COPY` only preserve files, is limitation we have with webdav.
 
  **Removed legacy (breaking)**:
  - `GET /api/raw` and `GET /public/api/raw` download routes — use `/api/resources/download` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ A database migration is required to go from v1.x to this version. See docs.
    - if opt-in, every month a snapshot of your deployment config would be sent to developer servers
    - this will help me know what features are being used and what versions everyone is on over time. I will also provide a public dashboard with this information in the future. 
  - WebDAV now supports set modification time via the `X-OC-Mtime` header for clients that support it (#2626).
- - Copy operations now will preserve their original modification time too (#2642) (#2647): 
+ - Copy operations now preserve their original modification times (#2642) (#2647):
     - WebUI preserves both, files and directories.
-    - WebDAV `COPY` only preserve files, is limitation we have with webdav.
+    - WebDAV `COPY` preserves modification times only for files, is limitation we have with webdav.
 
  **Removed legacy (breaking)**:
  - `GET /api/raw` and `GET /public/api/raw` download routes — use `/api/resources/download` instead.

--- a/backend/internal/adapters/fs/fileutils/dir.go
+++ b/backend/internal/adapters/fs/fileutils/dir.go
@@ -53,6 +53,10 @@ func CopyDir(source, dest string) error {
 			}
 		}
 	}
+	// Preserve directory mod times
+	if err := os.Chtimes(dest, srcinfo.ModTime(), srcinfo.ModTime()); err != nil {
+		errs = append(errs, err)
+	}
 
 	var errString string
 	for _, err := range errs {

--- a/backend/internal/adapters/fs/fileutils/file.go
+++ b/backend/internal/adapters/fs/fileutils/file.go
@@ -148,8 +148,12 @@ func copySingleFile(source, dest string) error {
 
 // copyDirectory handles copying directories recursively.
 func copyDirectory(source, dest string) error {
+	srcInfo, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
 	// Create the destination directory.
-	err := os.MkdirAll(dest, EffectiveDirPerm())
+	err = os.MkdirAll(dest, EffectiveDirPerm())
 	if err != nil {
 		return err
 	}
@@ -179,8 +183,7 @@ func copyDirectory(source, dest string) error {
 			}
 		}
 	}
-
-	return nil
+	return os.Chtimes(dest, srcInfo.ModTime(), srcInfo.ModTime())
 }
 
 // PreserveModTimes copies the mod times from src onto dst, this is used by the webdav COPY handler

--- a/backend/internal/adapters/fs/fileutils/file_test.go
+++ b/backend/internal/adapters/fs/fileutils/file_test.go
@@ -65,12 +65,13 @@ func TestCommonPrefix(t *testing.T) {
 
 func TestCopyFilePreservesModTime(t *testing.T) {
 	fileTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	dirTime := time.Date(2026, 6, 7, 8, 9, 0, 0, time.UTC)
 	testCases := map[string]struct {
 		isDir     bool
-		checkPath string
+		checkPath map[string]time.Time
 	}{
-		"file":      {checkPath: ""},
-		"directory": {isDir: true, checkPath: "nested.txt"},
+		"file":      {checkPath: map[string]time.Time{"": fileTime}},
+		"directory": {isDir: true, checkPath: map[string]time.Time{"": dirTime, "nested.txt": fileTime}},
 	}
 	for name, tt := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -85,6 +86,9 @@ func TestCopyFilePreservesModTime(t *testing.T) {
 				if err := os.Chtimes(nested, fileTime, fileTime); err != nil {
 					t.Fatal(err)
 				}
+				if err := os.Chtimes(src, dirTime, dirTime); err != nil {
+					t.Fatal(err)
+				}
 			} else {
 				srcPath = filepath.Join(src, "file.txt")
 				if err := os.WriteFile(srcPath, []byte("hi"), 0644); err != nil {
@@ -97,16 +101,18 @@ func TestCopyFilePreservesModTime(t *testing.T) {
 			if err := CopyFile(srcPath, dst); err != nil {
 				t.Fatal(err)
 			}
-			p := dst
-			if tt.checkPath != "" {
-				p = filepath.Join(dst, tt.checkPath)
-			}
-			got, err := os.Stat(p)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !got.ModTime().Equal(fileTime) {
-				t.Errorf("%s: got mtime = %v, want %v", p, got.ModTime(), fileTime)
+			for rel, want := range tt.checkPath {
+				p := dst
+				if rel != "" {
+					p = filepath.Join(dst, rel)
+				}
+				got, err := os.Stat(p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !got.ModTime().Equal(want) {
+					t.Errorf("%s: got mtime = %v, want %v", p, got.ModTime(), want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Is the same as the other PR but for dirs. I was thinking a bit, and is better to preserve them too (because of the copy fallback of move that gets triggered when moving something into a different source/disk) at least when doing it on webui :)

(tried doing it for WebDAV too, but was too complex and didn't worked well either so I gave up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copy operations now preserve source modification timestamps for both files and directories at the destination.
  * Timestamp updates are included in the operation’s reported errors if they fail.
* **Tests**
  * Expanded test coverage to assert modification times for directories and nested files.
* **Documentation**
  * Updated changelog language to clarify Web UI vs WebDAV `COPY`: both preserve file timestamps, while WebDAV `COPY` does not cover directory timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->