### PR TITLE
fix profile settings update and vite warning

### DIFF
--- a/frontend/src/components/prompts/AnalyticsDiagnostic.vue
+++ b/frontend/src/components/prompts/AnalyticsDiagnostic.vue
@@ -12,14 +12,14 @@
 </template>
 
 <script>
+import { createAsyncComponent } from "@/utils/asyncComponent.js";
 import { notify } from "@/notify";
 import * as settingsApi from "@/api/settings";
-import Editor from "@/views/files/Editor.vue";
 
 export default {
   name: "AnalyticsDiagnostic",
   components: {
-    Editor,
+    Editor: createAsyncComponent(() => import('@/views/files/Editor.vue')),
   },
   data() {
     return {

--- a/frontend/src/components/prompts/ConfigViewer.vue
+++ b/frontend/src/components/prompts/ConfigViewer.vue
@@ -27,15 +27,15 @@
 </template>
 
 <script>
+import { createAsyncComponent } from "@/utils/asyncComponent.js";
 import * as settingsApi from "@/api/settings";
 import ToggleSwitch from "@/components/settings/ToggleSwitch.vue";
-import Editor from "@/views/files/Editor.vue";
 
 export default {
   name: "ConfigViewer",
   components: {
     ToggleSwitch,
-    Editor,
+    Editor: createAsyncComponent(() => import('@/views/files/Editor.vue')),
   },
   data() {
     return {

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -29,6 +29,12 @@ import {
   applySectionsToFlatUser,
 } from "@/utils/userProfileSections.js";
 
+function cloneUser(user) {
+  return JSON.parse(
+    JSON.stringify(user ?? { preview: {}, permissions: {} })
+  );
+}
+
 export default {
   name: "settings",
   components: {
@@ -59,7 +65,7 @@ export default {
     },
   },
   mounted() {
-    this.localuser = JSON.parse(JSON.stringify(state.user));
+    this.localuser = cloneUser(state.user);
     void mutations.syncEnforcedUserDefaults();
     if (getters.eventTheme() === "halloween" && !state.disableEventThemes) {
       this.localuser.themeColor = "";
@@ -96,7 +102,7 @@ export default {
       try {
         const themeChanged = state.user.customTheme !== this.localuser.customTheme;
         await mutations.updateCurrentUser(this.localuser);
-        this.localuser = JSON.parse(JSON.stringify(state.user));
+        this.localuser = cloneUser(state.user);
         notify.showSuccessToast(this.$t("settings.settingsUpdated"));
         if (themeChanged) {
           setTimeout(() => {
@@ -104,7 +110,7 @@ export default {
           }, 1000);
         }
       } catch (e) {
-        this.localuser = JSON.parse(JSON.stringify(state.user));
+        this.localuser = cloneUser(state.user);
         if (state.user.preview) {
           this.localuser.preview = { ...state.user.preview };
         }

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -59,7 +59,7 @@ export default {
     },
   },
   mounted() {
-    this.localuser = { ...state.user };
+    this.localuser = JSON.parse(JSON.stringify(state.user));
     void mutations.syncEnforcedUserDefaults();
     if (getters.eventTheme() === "halloween" && !state.disableEventThemes) {
       this.localuser.themeColor = "";
@@ -96,6 +96,7 @@ export default {
       try {
         const themeChanged = state.user.customTheme !== this.localuser.customTheme;
         await mutations.updateCurrentUser(this.localuser);
+        this.localuser = JSON.parse(JSON.stringify(state.user));
         notify.showSuccessToast(this.$t("settings.settingsUpdated"));
         if (themeChanged) {
           setTimeout(() => {
@@ -103,7 +104,7 @@ export default {
           }, 1000);
         }
       } catch (e) {
-        this.localuser = { ...state.user };
+        this.localuser = JSON.parse(JSON.stringify(state.user));
         if (state.user.preview) {
           this.localuser.preview = { ...state.user.preview };
         }


### PR DESCRIPTION
Some settings in profile settings weren't updating (https://github.com/gtsteffaniak/filebrowser/pull/2651#issuecomment-5037734089)

and this vite warn:
```
[plugin vite:reporter]
(!) filebrowser/frontend/src/views/files/Editor.vue is dynamically imported by filebrowser/frontend/src/views/Files.vue but also statically imported by filebrowser/frontend/src/components/prompts/AnalyticsDiagnostic.vue, filebrowser/frontend/src/components/prompts/ConfigViewer.vue, dynamic import will not move module into another chunk.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile settings synchronization to keep displayed user information consistent after saving and after error handling.
  * Ensured refreshed settings are reflected immediately, including theme-related updates.

* **Performance**
  * Improved prompt/settings views by loading the embedded editor on-demand, reducing initial load work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->