### PR TITLE
updated with kong cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This version represents the most significant change to date. It **requires** bot
  - Changed: `PUT /api/users` moved to the more appropriate `PATCH` method.
  - Changed: http related config options in `server` config key moved to `http` config key.
  - Changed: `FILEBROWSER_DATABASE` environment variable — use `FILEBROWSER_DATABASE_PATH` instead (see migration notes above).
+ - Changed: Moved stream api to `/media/stream`
+ - Changed: CLI user management — canonical commands are `user set <username> --password [value]` and `user promote <username>`; `set -u username,password` is deprecated
 
  **New Features**:
  - View grant mechanism to distinguish between UI viewing and download.
@@ -25,7 +27,6 @@ This version represents the most significant change to date. It **requires** bot
    - per-source defaults configurable in `settings > access management`
    - `view` permission is automatically set to true unless explicitly set to false.
  # - backup/restore in UI settings
- # - New CLI options and usage
  - New activity logs for user activity.
    - charts and historical data
    - activity tool to view data
@@ -52,17 +53,16 @@ This version represents the most significant change to date. It **requires** bot
    - Added configurable default file permissions per source in `settings > access management`.
    - Added a User Defaults editor for account, permission, and profile preferences in the edit/create user prompt.
  - Database env var rename: `FILEBROWSER_DATABASE` is removed (startup fails if set). Use `FILEBROWSER_DATABASE_PATH` (default `filebrowser.sqlite`) or `server.database.path` in config.
- - Bolt→SQLite sidebar migration preserves custom source link names, icons, and categories; missing scoped sources are merged into sidebar links.
+ - CLI: `user set` with `--password` (inline value, interactive prompt on TTY, or piped stdin); `user promote` for admin grant without password reset
 
  **Notes**:
+ - CLI server start (`./filebrowser`), `setup`, `version`, and `set rule` syntax unchanged; see [CLI docs](https://filebrowserquantum.com/en/docs/reference/cli/)
  - new dropdown and input styles
  - user updates are more granular, don't include entire user payload.
  - `user.id` has been moved to a backend property and all frontend apis now query users by username. Swagger has been updated.
  - removed legacy and deprecated properties from API responses and generated config output
- - Moved stream api to `/media/stream`
  - `/api/media/stream` is audio/video only (range-based chunking). Non-media inline viewing uses `GET /api/resources/view`. Both endpoints use the same `viewToken` from file metadata.
  - removed exiftool as an optional helper, always built with the supported libraries.
- - `userDefaults` in config.yaml bootstraps SQLite on first run (initial values + lock mask for configured fields only). After seeding, manage defaults in **Settings → User management → User defaults**. Remove `userDefaults` from config when you no longer want fields re-locked on fresh installs.
 
 ## v1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This version represents the most significant change to date. It **requires** bot
  - Changed: `PUT /api/users` moved to the more appropriate `PATCH` method.
  - Changed: http related config options in `server` config key moved to `http` config key.
  - Changed: `FILEBROWSER_DATABASE` environment variable — use `FILEBROWSER_DATABASE_PATH` instead (see migration notes above).
- - Changed: Moved stream api to `/media/stream`
+ - Changed: Moved stream api to `/api/media/stream`
  - Changed: CLI user management — canonical commands are `user set <username> --password [value]` and `user promote <username>`; `set -u username,password` is deprecated
 
  **New Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v2.0.0
 
-This version represents the most significant change to date. It **requires** both a database migration and config structural changes.
+This version represents the most significant change to date. It **requires** both a database migration and config structural changes. See the [migration guide](https://filebrowserquantum.com/en/docs/getting-started/v2/migration/) for step-by-step upgrade instructions.
 
  **Breaking Changes**:
  - Removed: `GET /api/raw` and `GET /public/api/raw` download routes — use `/api/resources/download` instead.
@@ -56,6 +56,7 @@ This version represents the most significant change to date. It **requires** bot
  - CLI: `user set` with `--password` (inline value, interactive prompt on TTY, or piped stdin); `user promote` for admin grant without password reset
 
  **Notes**:
+ - v2.x.x uses a new write-through backend state management. Changes go through a fast memory layer and also write changes to database to stay in sync.
  - CLI server start (`./filebrowser`), `setup`, `version`, and `set rule` syntax unchanged; see [CLI docs](https://filebrowserquantum.com/en/docs/reference/cli/)
  - new dropdown and input styles
  - user updates are more granular, don't include entire user payload.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@
 
 :pushpin: [Read The Official Docs](https://filebrowserquantum.com/) (currently english-only)
 
+## v2.0.0 Breaking Changes
+
+This release requires database migration and config structural changes. See [CHANGELOG.md](CHANGELOG.md) and the [migration docs](https://filebrowserquantum.com/en/docs/getting-started/Migration/) for full details.
+
+**Highlights:**
+- API: removed `/api/raw`; use `/api/resources/download`
+- Config: `userDefaults` format changes; HTTP options moved from `server` to `http`
+- Env: `FILEBROWSER_DATABASE` removed — use `FILEBROWSER_DATABASE_PATH`
+- Permissions: file permissions are per-source on `scopes[].permissions`
+- CLI: use `user set <user> --password <pass>` instead of `set -u user,pass`; use `user promote <user>` for admin without password reset (`set -u` deprecated but still works with warning)
+- Unchanged: `./filebrowser`, `-c`, `setup`, `version`, `set rule …`
+
+See the [CLI reference](https://filebrowserquantum.com/en/docs/reference/cli/) for migration examples.
+
 ## About
 
 FileBrowser Quantum provides an easy way to access and manage your files from the web. It has a modern responsive interface that has many advanced features to manage users, access, sharing, and file preview and editing.

--- a/README.md
+++ b/README.md
@@ -23,17 +23,7 @@
 
 ## v2.0.0 Breaking Changes
 
-This release requires database migration and config structural changes. See [CHANGELOG.md](CHANGELOG.md) and the [migration docs](https://filebrowserquantum.com/en/docs/getting-started/Migration/) for full details.
-
-**Highlights:**
-- API: removed `/api/raw`; use `/api/resources/download`
-- Config: `userDefaults` format changes; HTTP options moved from `server` to `http`
-- Env: `FILEBROWSER_DATABASE` removed — use `FILEBROWSER_DATABASE_PATH`
-- Permissions: file permissions are per-source on `scopes[].permissions`
-- CLI: use `user set <user> --password <pass>` instead of `set -u user,pass`; use `user promote <user>` for admin without password reset (`set -u` deprecated but still works with warning)
-- Unchanged: `./filebrowser`, `-c`, `setup`, `version`, `set rule …`
-
-See the [CLI reference](https://filebrowserquantum.com/en/docs/reference/cli/) for migration examples.
+Upgrading to v2.x.x **requires** database migration and config structural changes. See the [migration docs](https://filebrowserquantum.com/en/docs/getting-started/v2/migration) for full details.
 
 ## About
 

--- a/_docker/Dockerfile.playwright-general
+++ b/_docker/Dockerfile.playwright-general
@@ -19,4 +19,4 @@ RUN dd if=/dev/zero of=/app/frontend/tests/playwright-files/1.1MB.bin bs=1024 co
 
 # Run tests
 ENV FILEBROWSER_PLAYWRIGHT_TEST=true
-RUN ./filebrowser set -u testuser1,testuser1 && ./filebrowser & sleep 2 && cd ../frontend && npx playwright test
+RUN ./filebrowser user set testuser1 --password testuser1 && ./filebrowser & sleep 2 && cd ../frontend && npx playwright test

--- a/_docker/Dockerfile.playwright-local
+++ b/_docker/Dockerfile.playwright-local
@@ -15,8 +15,8 @@ COPY [ "./backend/internal/web/embed/", "./internal/web/dist/"]
 
 ENV FILEBROWSER_PLAYWRIGHT_TEST=true
 RUN ./filebrowser user set testuser1 --password testuser1
-RUN ./filebrowser set rule -s access -p / -r user -v admin -allow -c config.yaml
-RUN ./filebrowser set rule -s access -p /excluded/showme.txt -r user -v admin -allow -c config.yaml
+RUN ./filebrowser set rule -s access -p / -r user -v admin --allow -c config.yaml
+RUN ./filebrowser set rule -s access -p /excluded/showme.txt -r user -v admin --allow -c config.yaml
 RUN ./filebrowser set rule -s access -p /denied -r user -v admin -c config.yaml
 RUN ./filebrowser set rule -s access -p /excluded -r user -v admin -c config.yaml
 ENTRYPOINT [ "./filebrowser" ]

--- a/_docker/Dockerfile.playwright-local
+++ b/_docker/Dockerfile.playwright-local
@@ -14,7 +14,7 @@ RUN mkdir -p ./internal/web/dist
 COPY [ "./backend/internal/web/embed/", "./internal/web/dist/"]
 
 ENV FILEBROWSER_PLAYWRIGHT_TEST=true
-RUN ./filebrowser set -u testuser1,testuser1
+RUN ./filebrowser user set testuser1 --password testuser1
 RUN ./filebrowser set rule -s access -p / -r user -v admin -allow -c config.yaml
 RUN ./filebrowser set rule -s access -p /excluded/showme.txt -r user -v admin -allow -c config.yaml
 RUN ./filebrowser set rule -s access -p /denied -r user -v admin -c config.yaml

--- a/_docker/Dockerfile.playwright-settings
+++ b/_docker/Dockerfile.playwright-settings
@@ -18,8 +18,8 @@ COPY [ "./backend/internal/web/embed/", "./internal/web/dist/"]
 # Run tests
 ENV FILEBROWSER_PLAYWRIGHT_TEST=true
 RUN ./filebrowser user set testuser1 --password testuser1
-RUN ./filebrowser set rule -s access -p / -r user -v admin -allow -c config.yaml
-RUN ./filebrowser set rule -s access -p /excluded/showme.txt -r user -v admin -allow -c config.yaml
+RUN ./filebrowser set rule -s access -p / -r user -v admin --allow -c config.yaml
+RUN ./filebrowser set rule -s access -p /excluded/showme.txt -r user -v admin --allow -c config.yaml
 RUN ./filebrowser set rule -s access -p /denied -r user -v admin -c config.yaml
 RUN ./filebrowser set rule -s access -p /excluded -r user -v admin -c config.yaml
 RUN ./filebrowser & sleep 2 && cd ../frontend && npx playwright test

--- a/_docker/Dockerfile.playwright-settings
+++ b/_docker/Dockerfile.playwright-settings
@@ -17,7 +17,7 @@ COPY [ "./backend/internal/web/embed/", "./internal/web/dist/"]
 
 # Run tests
 ENV FILEBROWSER_PLAYWRIGHT_TEST=true
-RUN ./filebrowser set -u testuser1,testuser1
+RUN ./filebrowser user set testuser1 --password testuser1
 RUN ./filebrowser set rule -s access -p / -r user -v admin -allow -c config.yaml
 RUN ./filebrowser set rule -s access -p /excluded/showme.txt -r user -v admin -allow -c config.yaml
 RUN ./filebrowser set rule -s access -p /denied -r user -v admin -c config.yaml

--- a/backend/cmd/cli.go
+++ b/backend/cmd/cli.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,12 +10,11 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
-	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
-	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
-	"github.com/gtsteffaniak/filebrowser/backend/internal/version"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
-	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/state"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/gtsteffaniak/go-logger/logger"
 )
 
@@ -24,149 +22,18 @@ var (
 	configPath string
 )
 
-// return bool to indicate if the program should continue running
-func runCLI() (bool, bool) {
-
-	generateYaml()
-
-	// Global flags
-	var help bool
-	// Override the default usage output to use generalUsage()
-	flag.Usage = generalUsage
-	flag.StringVar(&configPath, "c", "", "Path to the config file, default: config.yaml")
-	flag.BoolVar(&help, "h", false, "Get help about commands")
-
-	if configPath == "" {
-		configPath = os.Getenv("FILEBROWSER_CONFIG")
-		// backwards compatibility in docker, prefer config.yaml if it exists
-		if configPath != "" {
-			_, err := os.Stat(configPath)
-			if err != nil {
-				logger.Fatalf("config file %v does not exist, please create it or set the FILEBROWSER_CONFIG environment variable to a valid config file path", configPath)
-			}
-		} else {
-			configPath = "config.yaml"
-		}
-	}
-
-	// Parse global flags (before subcommands)
-	flag.Parse() // print generalUsage on error
-
-	// Show help if requested
-	if help {
-		generalUsage()
-		return false, false
-	}
-
-	// Create a new FlagSet for the 'set' subcommand
-	setCmd := flag.NewFlagSet("set", flag.ExitOnError)
-	var user, dbConfig string
-	var asAdmin bool
-	var sourceName, indexPath, ruleCategory, value string
-	var allow bool
-
-	setCmd.StringVar(&user, "u", "", "Comma-separated username and password: \"set -u <username>,<password>\"")
-	setCmd.BoolVar(&asAdmin, "a", false, "Create a user as admin user, used in combination with -u")
-	setCmd.StringVar(&dbConfig, "c", "config.yaml", "Path to the config file, default: config.yaml")
-	setCmd.StringVar(&sourceName, "s", "", "set rule: server.sources name or backend path key")
-	setCmd.StringVar(&sourceName, "sourceName", "", "same as -s")
-	setCmd.StringVar(&indexPath, "p", "", "set rule: index path within the source (e.g. / or /excluded)")
-	setCmd.StringVar(&indexPath, "sourcePath", "", "same as -p")
-	setCmd.StringVar(&ruleCategory, "r", "", "Rule category: 'user', 'group', or 'all' (for deny only)")
-	setCmd.StringVar(&value, "v", "", "Value: username or groupname (not required if ruleCategory is 'all')")
-	setCmd.BoolVar(&allow, "allow", false, "Allow access (default: false, which means deny)")
-
-	storeCfg := configPath
-	cliSubcmd := ""
-	var setKind string
-
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "version":
-			fmt.Printf(`FileBrowser Quantum - A modern web-based file manager
-	Version 	 : %v
-	Commit 		 : %v
-	Release Info 	 : https://github.com/gtsteffaniak/filebrowser/releases/tag/%v
-`, version.Version, version.CommitSHA, version.Version)
-			return false, false
-		case "setup":
-			cliSubcmd = "setup"
-		case "set":
-			cliSubcmd = "set"
-			if len(os.Args) < 3 {
-				fmt.Printf("error: missing subcommand for 'set'. Use 'set user' or 'set rule'\n")
-				os.Exit(1)
-			}
-			setKind = os.Args[2]
-			var err error
-			// Handle old syntax: "set -u user,pass -c config.yaml"
-			if setKind == "-u" {
-				err = setCmd.Parse(os.Args[2:])
-			} else {
-				// New pattern: subcommand-based (e.g., "set user" or "set rule")
-				err = setCmd.Parse(os.Args[3:])
-			}
-			if err != nil {
-				setCmd.PrintDefaults()
-				os.Exit(1)
-			}
-			storeCfg = dbConfig
-		}
-	}
-
-	switch cliSubcmd {
-	case "setup":
-		createConfig(configPath)
-		return false, false
-	case "set":
-		if setKind == "-u" {
-			dbExists := initializeDatabase(storeCfg)
-			logger.Debugf("setUser called with args: %v, config: %v, admin: %v", os.Args, dbConfig, asAdmin)
-			err := setUser(dbConfig, asAdmin)
-			if err != nil {
-				fmt.Printf("error: %v\n", err)
-				os.Exit(1)
-			}
-			return false, dbExists
-		}
-		switch setKind {
-		case "rule":
-			dbExists := initializeDatabase(storeCfg)
-			sourceInfo, ok := settings.Config.Server.NameToSource[sourceName] // backend source is path
-			if !ok {
-				fmt.Printf("error: invalid source name: %s\n", sourceName)
-				os.Exit(1)
-			}
-			err := setRule(dbConfig, sourceInfo.Path, indexPath, ruleCategory, value, allow)
-			if err != nil {
-				fmt.Printf("error: %v\n", err)
-				os.Exit(1)
-			}
-			return false, dbExists
-		default:
-			fmt.Printf("error: unknown subcommand '%s' for 'set'. Use 'set user' or 'set rule'\n", setKind)
-			os.Exit(1)
-		}
-		return false, false
-	default:
-		dbExists := initializeDatabase(storeCfg)
-		return true, dbExists
-	}
-}
-
-func setRule(dbConfig, backendSourcePath, indexPath, ruleCategory, value string, allow bool) error {
-	// Validate required parameters
+func setRule(backendSourcePath, indexPath, ruleCategory, value string, allow bool) error {
 	if backendSourcePath == "" {
-		return fmt.Errorf("backend source path is missing; check -s")
+		return fmt.Errorf("backend source path is missing; check --source / -s")
 	}
 	if indexPath == "" {
-		return fmt.Errorf("-p is required (index path within the source, e.g. /)")
+		return fmt.Errorf("--path / -p is required (index path within the source, e.g. /)")
 	}
 	if ruleCategory == "" {
-		return fmt.Errorf("ruleCategory is required: use -r <user|group|all>")
+		return fmt.Errorf("role is required: use --role / -r <user|group|all>")
 	}
 	if ruleCategory != "all" && value == "" {
-		return fmt.Errorf("value is required when ruleCategory is 'user' or 'group': use -v <username|groupname>")
+		return fmt.Errorf("value is required when role is 'user' or 'group': use --value / -v <username|groupname>")
 	}
 
 	parsedPath, err := utils.ParseSanitizedIndexPath(indexPath, true)
@@ -181,7 +48,7 @@ func setRule(dbConfig, backendSourcePath, indexPath, ruleCategory, value string,
 		case "group":
 			err = state.AllowGroup(backendSourcePath, parsedPath, value)
 		default:
-			return fmt.Errorf("invalid ruleCategory for allow: must be 'user' or 'group'")
+			return fmt.Errorf("invalid role for allow: must be 'user' or 'group'")
 		}
 	} else {
 		switch ruleCategory {
@@ -192,7 +59,7 @@ func setRule(dbConfig, backendSourcePath, indexPath, ruleCategory, value string,
 		case "all":
 			err = state.DenyAll(backendSourcePath, parsedPath)
 		default:
-			return fmt.Errorf("invalid ruleCategory: must be 'user', 'group', or 'all'")
+			return fmt.Errorf("invalid role: must be 'user', 'group', or 'all'")
 		}
 	}
 
@@ -212,16 +79,7 @@ func setRule(dbConfig, backendSourcePath, indexPath, ruleCategory, value string,
 	return nil
 }
 
-func setUser(dbConfig string, asAdmin bool) error {
-	if len(os.Args) < 4 {
-		return fmt.Errorf("missing username and password for 'set user'. Use 'set -u username,password'")
-	}
-	userInfo := strings.Split(os.Args[3], ",")
-	if len(userInfo) < 2 {
-		return fmt.Errorf("not enough info to create user: \"set -u username,password\", only provided %v", userInfo)
-	}
-	username := userInfo[0]
-	password := userInfo[1]
+func setUser(username, password string, asAdmin bool) error {
 	user, err := state.GetUserByUsername(username)
 	if err != nil {
 		newUser := users.User{
@@ -239,7 +97,6 @@ func setUser(dbConfig string, asAdmin bool) error {
 			}
 		}
 
-		// Create the user logic
 		if asAdmin {
 			logger.Infof("Creating user as admin: %s\n", username)
 		} else {
@@ -260,17 +117,15 @@ func setUser(dbConfig string, asAdmin bool) error {
 	if user.LoginMethod != users.LoginMethodPassword {
 		return fmt.Errorf("user %s is not allowed to login with password authentication, cannot set password", username)
 	}
-	user.TOTPSecret = "" // reset TOTP secret if it exists
-	user.TOTPNonce = ""  // reset TOTP nonce if it exists
+	user.TOTPSecret = ""
+	user.TOTPNonce = ""
 	user.LoginMethod = users.LoginMethodPassword
 	if asAdmin {
 		user.Permissions.Admin = true
 	}
-	// Ensure version is set for existing users being updated
 	if user.Version == 0 {
 		user.Version = users.CurrentUserMigrationVersion
 	}
-	// Pass plaintext password to UpdateUser, it will hash it
 	err = state.UpdateUser(&user, password)
 	if err != nil {
 		return fmt.Errorf("could not update user: %v", err)
@@ -279,8 +134,27 @@ func setUser(dbConfig string, asAdmin bool) error {
 	return nil
 }
 
-// askQuestion displays a prompt and reads a line of input from the user.
-// It returns the defaultValue if the user's input is empty.
+func promoteUser(username string) error {
+	user, err := state.GetUserByUsername(username)
+	if err != nil {
+		return fmt.Errorf("user %s not found", username)
+	}
+	if user.Permissions.Admin {
+		fmt.Printf("user %s is already an admin\n", username)
+		return nil
+	}
+	user.Permissions.Admin = true
+	if user.Version == 0 {
+		user.Version = users.CurrentUserMigrationVersion
+	}
+	err = state.UpdateUser(&user, "", "permissions")
+	if err != nil {
+		return fmt.Errorf("could not promote user: %v", err)
+	}
+	fmt.Printf("successfully promoted user to admin: %s\n", username)
+	return nil
+}
+
 func askQuestion(reader *bufio.Reader, prompt string, defaultValue string) string {
 	fmt.Printf("%s (default: %s): ", prompt, defaultValue)
 	input, _ := reader.ReadString('\n')
@@ -291,9 +165,6 @@ func askQuestion(reader *bufio.Reader, prompt string, defaultValue string) strin
 	return input
 }
 
-// askYesNoQuestion prompts the user with a yes/no question and returns a boolean.
-// It retries until valid input ("yes", "y", "no", "n") is received.
-// The defaultValue must be "yes" or "no".
 func askYesNoQuestion(reader *bufio.Reader, prompt string, defaultValue string) bool {
 	for {
 		answer := askQuestion(reader, prompt, defaultValue)
@@ -308,43 +179,41 @@ func askYesNoQuestion(reader *bufio.Reader, prompt string, defaultValue string) 
 	}
 }
 
-// createConfig orchestrates the configuration process by asking the user a series of questions.
 func createConfig(configpath string) {
 	reader := bufio.NewReader(os.Stdin)
 	config := settings.SetDefaults(false)
 	config.Server.Sources = []*settings.Source{{Path: "./"}}
 
+	if configpath == "" {
+		configpath = "config.yaml"
+	}
+
 	fmt.Println("--- Starting Configuration Setup ---")
 	realPath := ""
-	// 1. Ask for the source filesystem path (with validation)
 	for {
 		config.Server.Sources[0].Path = askQuestion(reader, "What is the source filesystem path?", "./")
-		// Convert relative path to absolute path
 		absolutePath, err := filepath.Abs(config.Server.Sources[0].Path)
 		if err == nil {
 			var isDir bool
-			// Resolve symlinks and get the real path
 			realPath, isDir, _ = iteminfo.ResolveSymlinks(absolutePath)
 			if realPath != "" && isDir {
-				break // Valid path found, exit loop
+				break
 			}
 		}
 		fmt.Printf("Error: The path '%s' does not exist or isn't valid. Please try again.\n", config.Server.Sources[0].Path)
 	}
-	// 2. Ask for the source name
 	defaultSourceName := filepath.Base(realPath)
 	sourceName := askQuestion(reader, "What should the first source name be?", defaultSourceName)
 	if sourceName != defaultSourceName {
 		config.Server.Sources[0].Name = sourceName
 	}
 
-	// 3. Ask for server port (with validation)
 	for {
 		portStr := askQuestion(reader, "What port should the server listen on?", "80")
 		port, err := strconv.Atoi(portStr)
 		if err == nil && (port >= 1 && port <= 65535) {
 			config.Http.Port = port
-			break // Port is valid, exit loop
+			break
 		}
 		fmt.Printf("Error: '%s' is not a valid port. Please enter a number between 1 and 65535.\n", portStr)
 	}
@@ -367,18 +236,14 @@ func createConfig(configpath string) {
 	for {
 		config.Server.DatabaseV2.Path = askQuestion(reader, "What should the file name and path be for the database?", "./database.db")
 		if strings.HasSuffix(config.Server.DatabaseV2.Path, ".db") {
-			break // Valid path found, exit loop
+			break
 		}
 		fmt.Printf("Error: '%s' is not a valid path. Please enter a path to a file ending in .db", config.Server.DatabaseV2.Path)
 	}
-	// 4. Ask for the application brand name
 	config.Frontend.Name = askQuestion(reader, "What should the application brand name be?", "FileBrowser Quantum")
-
-	// 5. Ask for admin username and password
 	config.Auth.AdminUsername = askQuestion(reader, "What should the default admin username be?", "admin")
 	config.Auth.AdminPassword = askQuestion(reader, "What should the default admin password be?", "admin")
 
-	// 6. Ask boolean (Yes/No) questions using the helper
 	modifyDefault := askYesNoQuestion(reader, "Should a new user be able to modify content by default?", "no")
 	config.Server.Sources[0].Config.DefaultPermissions = settings.NormalizeSourceFilePermissions(users.SourceFilePermissions{
 		View:     true,
@@ -391,25 +256,20 @@ func createConfig(configpath string) {
 
 	fmt.Println("--- 	Configuration Complete 	---")
 
-	// marshall yaml and write to file
-	// Marshal the struct to YAML bytes
 	yamlData, err := yaml.Marshal(&config)
 	if err != nil {
 		return
 	}
 
-	// Write the YAML data to the file
-	err = os.WriteFile("config.yaml", yamlData, 0644) // 0644 provides read/write for owner, read for others
+	err = os.WriteFile(configpath, yamlData, 0644)
 	if err != nil {
 		return
 	}
-	// cleanup database if it exists
 	if _, err := os.Stat(config.Server.DatabaseV2.Path); err == nil {
 		response := askYesNoQuestion(reader, "Database specified already exists. Move database file to backup to start fresh?", "no")
 		if !response {
 			return
 		}
-		// move database file to backup
 		backupPath := config.Server.DatabaseV2.Path + ".bak"
 		err = os.Rename(config.Server.DatabaseV2.Path, backupPath)
 		if err != nil {
@@ -418,7 +278,6 @@ func createConfig(configpath string) {
 			fmt.Printf("Database file moved to backup: %s\n", backupPath)
 		}
 	}
-
 }
 
 func generateYaml() {
@@ -431,7 +290,6 @@ func generateYaml() {
 	if generateConfig {
 		os.Exit(0)
 	}
-
 }
 
 func SplitByMultiple(str string) []string {

--- a/backend/cmd/cli.go
+++ b/backend/cmd/cli.go
@@ -179,7 +179,11 @@ func askYesNoQuestion(reader *bufio.Reader, prompt string, defaultValue string) 
 	}
 }
 
-func createConfig(configpath string) {
+func createConfig(configpath string, noInput bool) error {
+	if noInput {
+		return fmt.Errorf("'setup' requires interactive input; rerun without --no-input")
+	}
+
 	reader := bufio.NewReader(os.Stdin)
 	config := settings.SetDefaults(false)
 	config.Server.Sources = []*settings.Source{{Path: "./"}}
@@ -258,17 +262,17 @@ func createConfig(configpath string) {
 
 	yamlData, err := yaml.Marshal(&config)
 	if err != nil {
-		return
+		return fmt.Errorf("marshaling config: %w", err)
 	}
 
-	err = os.WriteFile(configpath, yamlData, 0644)
+	err = os.WriteFile(configpath, yamlData, 0600)
 	if err != nil {
-		return
+		return fmt.Errorf("writing config file: %w", err)
 	}
 	if _, err := os.Stat(config.Server.DatabaseV2.Path); err == nil {
 		response := askYesNoQuestion(reader, "Database specified already exists. Move database file to backup to start fresh?", "no")
 		if !response {
-			return
+			return nil
 		}
 		backupPath := config.Server.DatabaseV2.Path + ".bak"
 		err = os.Rename(config.Server.DatabaseV2.Path, backupPath)
@@ -278,6 +282,7 @@ func createConfig(configpath string) {
 			fmt.Printf("Database file moved to backup: %s\n", backupPath)
 		}
 	}
+	return nil
 }
 
 func generateYaml() {

--- a/backend/cmd/cli_test.go
+++ b/backend/cmd/cli_test.go
@@ -13,74 +13,85 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newCLIParser(t *testing.T) *kong.Kong {
+func freshCLI() cliRoot {
+	return cliRoot{}
+}
+
+func newCLIParser(t *testing.T, cli *cliRoot) *kong.Kong {
 	t.Helper()
-	parser, err := kong.New(&rootCLI, kong.Name("filebrowser"), kong.Bind(&rootCLI.Globals))
+	parser, err := kong.New(cli, kong.Name("filebrowser"), kong.Bind(&cli.Globals))
 	require.NoError(t, err)
 	return parser
 }
 
 func TestParseDefaultServerCommand(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	ctx, err := parser.Parse([]string{})
 	require.NoError(t, err)
 	assert.Equal(t, "run", ctx.Command())
 }
 
 func TestParseVersionCommand(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	ctx, err := parser.Parse([]string{"version"})
 	require.NoError(t, err)
 	assert.Equal(t, "version", ctx.Command())
 }
 
 func TestParseGlobalConfigFlag(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	_, err := parser.Parse([]string{"-c", "/tmp/custom.yaml", "version"})
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/custom.yaml", rootCLI.Config)
+	assert.Equal(t, "/tmp/custom.yaml", cli.Config)
 }
 
 func TestParseUserSetWithPasswordFlag(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	ctx, err := parser.Parse([]string{"user", "set", "alice", "--password", "secret", "--admin"})
 	require.NoError(t, err)
 	assert.Equal(t, "user set <username>", ctx.Command())
-	assert.Equal(t, "alice", rootCLI.User.Set.Username)
-	assert.True(t, rootCLI.User.Set.Password.Provided)
-	assert.Equal(t, "secret", rootCLI.User.Set.Password.Inline)
-	assert.True(t, rootCLI.User.Set.Admin)
+	assert.Equal(t, "alice", cli.User.Set.Username)
+	assert.True(t, cli.User.Set.Password.Provided)
+	assert.Equal(t, "secret", cli.User.Set.Password.Inline)
+	assert.True(t, cli.User.Set.Admin)
 }
 
 func TestParseUserSetConfigFlagOrder(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	_, err := parser.Parse([]string{"-c", "other.yaml", "user", "set", "bob", "--password", "x"})
 	require.NoError(t, err)
-	assert.Equal(t, "other.yaml", rootCLI.Config)
+	assert.Equal(t, "other.yaml", cli.Config)
 }
 
 func TestParseSetRuleFlags(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	ctx, err := parser.Parse([]string{
 		"set", "rule",
 		"-s", "access", "-p", "/", "-r", "user", "-v", "admin", "--allow",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "set rule", ctx.Command())
-	assert.Equal(t, "access", rootCLI.Set.Rule.Source)
-	assert.Equal(t, "/", rootCLI.Set.Rule.Path)
-	assert.Equal(t, "user", rootCLI.Set.Rule.Role)
-	assert.Equal(t, "admin", rootCLI.Set.Rule.Value)
-	assert.True(t, rootCLI.Set.Rule.Allow)
+	assert.Equal(t, "access", cli.Set.Rule.Source)
+	assert.Equal(t, "/", cli.Set.Rule.Path)
+	assert.Equal(t, "user", cli.Set.Rule.Role)
+	assert.Equal(t, "admin", cli.Set.Rule.Value)
+	assert.True(t, cli.Set.Rule.Allow)
 }
 
 func TestParseLegacySetUser(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	ctx, err := parser.Parse([]string{"set", "-u", "alice,secret", "-a"})
 	require.NoError(t, err)
 	assert.Equal(t, "set", ctx.Command())
-	assert.Equal(t, "alice,secret", rootCLI.Set.User)
-	assert.True(t, rootCLI.Set.Admin)
+	assert.Equal(t, "alice,secret", cli.Set.User)
+	assert.True(t, cli.Set.Admin)
 }
 
 func TestPasswordFlagResolveInline(t *testing.T) {
@@ -126,21 +137,21 @@ func TestSplitByMultiple(t *testing.T) {
 }
 
 func TestSetCmdRunSkipsWhenRuleSelected(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	ctx, err := parser.Parse([]string{"set", "rule", "-s", "x", "-p", "/", "-r", "all"})
 	require.NoError(t, err)
-	setCmd := &rootCLI.Set
-	setCmd.User = "should-not-run"
-	err = setCmd.Run(ctx)
+	cli.Set.User = "should-not-run"
+	err = cli.Set.Run(ctx)
 	require.NoError(t, err)
 }
 
 func TestSetCmdRunLegacyUser(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	ctx, err := parser.Parse([]string{"set", "-u", "bad"})
 	require.NoError(t, err)
-	setCmd := &rootCLI.Set
-	err = setCmd.Run(ctx)
+	err = cli.Set.Run(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not enough info")
 }
@@ -156,15 +167,16 @@ func TestPasswordReadAllFromReader(t *testing.T) {
 func TestResolveConfigPathEnvMissingFile(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
 	t.Setenv("FILEBROWSER_CONFIG", missing)
-	rootCLI.Config = ""
-	resolveConfigPath(&rootCLI.Config)
-	assert.Equal(t, missing, rootCLI.Config)
-	_, err := os.Stat(rootCLI.Config)
+	config := ""
+	resolveConfigPath(&config)
+	assert.Equal(t, missing, config)
+	_, err := os.Stat(config)
 	assert.Error(t, err)
 }
 
 func TestSetupNoInputRejected(t *testing.T) {
-	parser := newCLIParser(t)
+	cli := freshCLI()
+	parser := newCLIParser(t, &cli)
 	ctx, err := parser.Parse([]string{"setup", "--no-input"})
 	require.NoError(t, err)
 	err = ctx.Run()

--- a/backend/cmd/cli_test.go
+++ b/backend/cmd/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 
 func newCLIParser(t *testing.T) *kong.Kong {
 	t.Helper()
-	parser, err := kong.New(&rootCLI, kong.Name("filebrowser"))
+	parser, err := kong.New(&rootCLI, kong.Name("filebrowser"), kong.Bind(&rootCLI.Globals))
 	require.NoError(t, err)
 	return parser
 }
@@ -150,4 +151,23 @@ func TestPasswordReadAllFromReader(t *testing.T) {
 	data, err := io.ReadAll(&buf)
 	require.NoError(t, err)
 	assert.Equal(t, "trimmed", strings.TrimSpace(string(data)))
+}
+
+func TestResolveConfigPathEnvMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	t.Setenv("FILEBROWSER_CONFIG", missing)
+	rootCLI.Config = ""
+	resolveConfigPath(&rootCLI.Config)
+	assert.Equal(t, missing, rootCLI.Config)
+	_, err := os.Stat(rootCLI.Config)
+	assert.Error(t, err)
+}
+
+func TestSetupNoInputRejected(t *testing.T) {
+	parser := newCLIParser(t)
+	ctx, err := parser.Parse([]string{"setup", "--no-input"})
+	require.NoError(t, err)
+	err = ctx.Run()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "interactive input")
 }

--- a/backend/cmd/cli_test.go
+++ b/backend/cmd/cli_test.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCLIParser(t *testing.T) *kong.Kong {
+	t.Helper()
+	parser, err := kong.New(&rootCLI, kong.Name("filebrowser"))
+	require.NoError(t, err)
+	return parser
+}
+
+func TestParseDefaultServerCommand(t *testing.T) {
+	parser := newCLIParser(t)
+	ctx, err := parser.Parse([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, "run", ctx.Command())
+}
+
+func TestParseVersionCommand(t *testing.T) {
+	parser := newCLIParser(t)
+	ctx, err := parser.Parse([]string{"version"})
+	require.NoError(t, err)
+	assert.Equal(t, "version", ctx.Command())
+}
+
+func TestParseGlobalConfigFlag(t *testing.T) {
+	parser := newCLIParser(t)
+	_, err := parser.Parse([]string{"-c", "/tmp/custom.yaml", "version"})
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/custom.yaml", rootCLI.Config)
+}
+
+func TestParseUserSetWithPasswordFlag(t *testing.T) {
+	parser := newCLIParser(t)
+	ctx, err := parser.Parse([]string{"user", "set", "alice", "--password", "secret", "--admin"})
+	require.NoError(t, err)
+	assert.Equal(t, "user set <username>", ctx.Command())
+	assert.Equal(t, "alice", rootCLI.User.Set.Username)
+	assert.True(t, rootCLI.User.Set.Password.Provided)
+	assert.Equal(t, "secret", rootCLI.User.Set.Password.Inline)
+	assert.True(t, rootCLI.User.Set.Admin)
+}
+
+func TestParseUserSetConfigFlagOrder(t *testing.T) {
+	parser := newCLIParser(t)
+	_, err := parser.Parse([]string{"-c", "other.yaml", "user", "set", "bob", "--password", "x"})
+	require.NoError(t, err)
+	assert.Equal(t, "other.yaml", rootCLI.Config)
+}
+
+func TestParseSetRuleFlags(t *testing.T) {
+	parser := newCLIParser(t)
+	ctx, err := parser.Parse([]string{
+		"set", "rule",
+		"-s", "access", "-p", "/", "-r", "user", "-v", "admin", "--allow",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "set rule", ctx.Command())
+	assert.Equal(t, "access", rootCLI.Set.Rule.Source)
+	assert.Equal(t, "/", rootCLI.Set.Rule.Path)
+	assert.Equal(t, "user", rootCLI.Set.Rule.Role)
+	assert.Equal(t, "admin", rootCLI.Set.Rule.Value)
+	assert.True(t, rootCLI.Set.Rule.Allow)
+}
+
+func TestParseLegacySetUser(t *testing.T) {
+	parser := newCLIParser(t)
+	ctx, err := parser.Parse([]string{"set", "-u", "alice,secret", "-a"})
+	require.NoError(t, err)
+	assert.Equal(t, "set", ctx.Command())
+	assert.Equal(t, "alice,secret", rootCLI.Set.User)
+	assert.True(t, rootCLI.Set.Admin)
+}
+
+func TestPasswordFlagResolveInline(t *testing.T) {
+	p := passwordFlag{Provided: true, Inline: "inline-pass"}
+	got, err := p.resolve(true)
+	require.NoError(t, err)
+	assert.Equal(t, "inline-pass", got)
+}
+
+func TestPasswordFlagResolveStdin(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	_, err = w.WriteString("piped-secret\n")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	p := passwordFlag{Provided: true}
+	got, err := p.resolve(false)
+	require.NoError(t, err)
+	assert.Equal(t, "piped-secret", got)
+}
+
+func TestPasswordFlagMissing(t *testing.T) {
+	p := passwordFlag{}
+	_, err := p.resolve(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--password is required")
+}
+
+func TestPasswordFlagNoInputRequiresInline(t *testing.T) {
+	p := passwordFlag{Provided: true}
+	_, err := p.resolve(true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--no-input")
+}
+
+func TestSplitByMultiple(t *testing.T) {
+	assert.Equal(t, []string{"info", "warning", "error"}, SplitByMultiple("info|warning|error"))
+}
+
+func TestSetCmdRunSkipsWhenRuleSelected(t *testing.T) {
+	parser := newCLIParser(t)
+	ctx, err := parser.Parse([]string{"set", "rule", "-s", "x", "-p", "/", "-r", "all"})
+	require.NoError(t, err)
+	setCmd := &rootCLI.Set
+	setCmd.User = "should-not-run"
+	err = setCmd.Run(ctx)
+	require.NoError(t, err)
+}
+
+func TestSetCmdRunLegacyUser(t *testing.T) {
+	parser := newCLIParser(t)
+	ctx, err := parser.Parse([]string{"set", "-u", "bad"})
+	require.NoError(t, err)
+	setCmd := &rootCLI.Set
+	err = setCmd.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not enough info")
+}
+
+func TestPasswordReadAllFromReader(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteString("  trimmed  \n")
+	data, err := io.ReadAll(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, "trimmed", strings.TrimSpace(string(data)))
+}

--- a/backend/cmd/kong.go
+++ b/backend/cmd/kong.go
@@ -1,0 +1,219 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/version"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
+	"github.com/gtsteffaniak/go-logger/logger"
+	"golang.org/x/term"
+)
+
+// Globals holds flags shared across all commands (order-independent).
+type Globals struct {
+	Config  string `short:"c" name:"config" default:"config.yaml" env:"FILEBROWSER_CONFIG" help:"Path to config file"`
+	NoInput bool   `name:"no-input" help:"Disable interactive prompts (fail if input required)"`
+}
+
+type runCmd struct{}
+
+type versionCmd struct{}
+
+type setupCmd struct{}
+
+type SetCmd struct {
+	User  string     `short:"u" help:"Deprecated: comma-separated username,password. Use 'user set' instead."`
+	Admin bool       `short:"a" help:"Create user as admin (used with -u)"`
+	Rule  SetRuleCmd `cmd:"" name:"rule" help:"Add or update an access rule"`
+}
+
+type SetRuleCmd struct {
+	Source string `short:"s" name:"source" aliases:"f,sourceName" required:"" help:"Source name from config"`
+	Path   string `short:"p" name:"path" aliases:"sourcePath" required:"" help:"Index path within the source"`
+	Role   string `short:"r" name:"role" enum:"user,group,all" required:"" help:"Rule target type"`
+	Value  string `short:"v" name:"value" help:"Username or group name (required for user/group)"`
+	Allow  bool   `name:"allow" help:"Allow access (default: deny)"`
+}
+
+type UserCmd struct {
+	Set     UserSetCmd     `cmd:"" name:"set" help:"Create or update a password-authenticated user"`
+	Promote UserPromoteCmd `cmd:"" name:"promote" help:"Grant admin permissions without changing password"`
+}
+
+type UserPromoteCmd struct {
+	Username string `arg:"" help:"Username to promote"`
+}
+
+type UserSetCmd struct {
+	Username string       `arg:"" help:"Username"`
+	Password passwordFlag `name:"password" help:"Password; omit value to prompt (TTY) or read stdin (pipe)"`
+	Admin    bool         `short:"a" name:"admin" help:"Grant admin permissions"`
+}
+
+// passwordFlag accepts --password VALUE (inline) or --password alone (prompt/pipe).
+type passwordFlag struct {
+	Provided bool
+	Inline   string
+}
+
+func (p *passwordFlag) Decode(ctx *kong.DecodeContext) error {
+	p.Provided = true
+	if ctx.Scan.Peek().IsValue() {
+		return ctx.Scan.PopValueInto("password", &p.Inline)
+	}
+	return nil
+}
+
+func (p passwordFlag) resolve(noInput bool) (string, error) {
+	if !p.Provided {
+		return "", fmt.Errorf("--password is required (inline value, interactive prompt, or piped stdin)")
+	}
+	if p.Inline != "" {
+		return p.Inline, nil
+	}
+	if noInput {
+		return "", fmt.Errorf("--password requires an inline value or piped stdin when --no-input is set")
+	}
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		return promptPassword()
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read password from stdin: %w", err)
+	}
+	password := strings.TrimSpace(string(data))
+	if password == "" {
+		return "", fmt.Errorf("password must not be empty")
+	}
+	return password, nil
+}
+
+func promptPassword() (string, error) {
+	if _, err := fmt.Fprint(os.Stderr, "Password: "); err != nil {
+		return "", err
+	}
+	bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("read password: %w", err)
+	}
+	password := string(bytePassword)
+	if password == "" {
+		return "", fmt.Errorf("password must not be empty")
+	}
+	return password, nil
+}
+
+var rootCLI struct {
+	Globals `embed:""`
+
+	Run     runCmd     `cmd:"" default:"1" hidden:"" help:"Start the FileBrowser server"`
+	Version versionCmd `cmd:"" name:"version" help:"Print version information"`
+	Setup   setupCmd   `cmd:"" name:"setup" help:"Interactive configuration setup"`
+	Set     SetCmd     `cmd:"" name:"set" help:"Set configuration values (deprecated: use 'user set' for users)"`
+	User    UserCmd    `cmd:"" name:"user" help:"User management"`
+}
+
+func (versionCmd) Run() error {
+	fmt.Printf(`FileBrowser Quantum - A modern web-based file manager
+	Version 	 : %v
+	Commit 		 : %v
+	Release Info 	 : https://github.com/gtsteffaniak/filebrowser/releases/tag/%v
+`, version.Version, version.CommitSHA, version.Version)
+	return nil
+}
+
+func (setupCmd) Run(globals *Globals) error {
+	createConfig(globals.Config)
+	return nil
+}
+
+func (s *SetCmd) Run(ctx *kong.Context) error {
+	if strings.HasPrefix(ctx.Command(), "set rule") {
+		return nil
+	}
+	if s.User == "" {
+		return fmt.Errorf("missing subcommand for 'set'. Use 'set rule' or 'user set'")
+	}
+	fmt.Fprintln(os.Stderr, "warning: 'set -u' is deprecated; use 'user set' instead")
+	userInfo := strings.SplitN(s.User, ",", 2)
+	if len(userInfo) < 2 || userInfo[0] == "" || userInfo[1] == "" {
+		return fmt.Errorf("not enough info to create user: \"set -u username,password\", only provided %v", strings.Split(s.User, ","))
+	}
+	return setUser(userInfo[0], userInfo[1], s.Admin)
+}
+
+func (r *SetRuleCmd) Run() error {
+	sourceInfo, ok := settings.Config.Server.NameToSource[r.Source]
+	if !ok {
+		return fmt.Errorf("invalid source name: %s", r.Source)
+	}
+	return setRule(sourceInfo.Path, r.Path, r.Role, r.Value, r.Allow)
+}
+
+func (u *UserSetCmd) Run(globals *Globals) error {
+	password, err := u.Password.resolve(globals.NoInput)
+	if err != nil {
+		return err
+	}
+	return setUser(u.Username, password, u.Admin)
+}
+
+func (p *UserPromoteCmd) Run() error {
+	return promoteUser(p.Username)
+}
+
+func resolveConfigPath(config *string) {
+	envConfig := os.Getenv("FILEBROWSER_CONFIG")
+	if *config == "" {
+		if envConfig != "" {
+			*config = envConfig
+		} else {
+			*config = "config.yaml"
+		}
+	}
+	if envConfig != "" && *config == envConfig {
+		if _, err := os.Stat(*config); err != nil {
+			logger.Fatalf("config file %v does not exist, please create it or set the FILEBROWSER_CONFIG environment variable to a valid config file path", *config)
+		}
+	}
+}
+
+func runCLI() (keepGoing bool, dbExists bool) {
+	generateYaml()
+
+	parser, err := kong.New(&rootCLI,
+		kong.Name("filebrowser"),
+		kong.Description("FileBrowser Quantum - A modern web-based file manager"),
+	)
+	if err != nil {
+		logger.Fatalf("failed to configure CLI: %v", err)
+	}
+
+	ctx, err := parser.Parse(os.Args[1:])
+	parser.FatalIfErrorf(err)
+
+	resolveConfigPath(&rootCLI.Config)
+	configPath = rootCLI.Config
+
+	cmd := ctx.Command()
+	switch {
+	case cmd == "" || cmd == "run":
+		dbExists = initializeDatabase(configPath)
+		return true, dbExists
+	case cmd == "version" || cmd == "setup":
+		parser.FatalIfErrorf(ctx.Run(&rootCLI))
+		return false, false
+	case cmd == "set rule" || cmd == "set" || strings.HasPrefix(cmd, "user set") || strings.HasPrefix(cmd, "user promote"):
+		dbExists = initializeDatabase(configPath)
+		parser.FatalIfErrorf(ctx.Run(&rootCLI))
+		return false, dbExists
+	default:
+		parser.Fatalf("unexpected command: %q", cmd)
+		return false, false
+	}
+}

--- a/backend/cmd/kong.go
+++ b/backend/cmd/kong.go
@@ -108,7 +108,9 @@ func promptPassword() (string, error) {
 	return password, nil
 }
 
-var rootCLI struct {
+var rootCLI cliRoot
+
+type cliRoot struct {
 	Globals `embed:""`
 
 	Run     runCmd     `cmd:"" default:"1" hidden:"" help:"Start the FileBrowser server"`

--- a/backend/cmd/kong.go
+++ b/backend/cmd/kong.go
@@ -128,8 +128,7 @@ func (versionCmd) Run() error {
 }
 
 func (setupCmd) Run(globals *Globals) error {
-	createConfig(globals.Config)
-	return nil
+	return createConfig(globals.Config, globals.NoInput)
 }
 
 func (s *SetCmd) Run(ctx *kong.Context) error {
@@ -176,9 +175,13 @@ func resolveConfigPath(config *string) {
 			*config = "config.yaml"
 		}
 	}
-	if envConfig != "" && *config == envConfig {
-		if _, err := os.Stat(*config); err != nil {
-			logger.Fatalf("config file %v does not exist, please create it or set the FILEBROWSER_CONFIG environment variable to a valid config file path", *config)
+}
+
+func requireExistingConfig(config string) {
+	envConfig := os.Getenv("FILEBROWSER_CONFIG")
+	if envConfig != "" && config == envConfig {
+		if _, err := os.Stat(config); err != nil {
+			logger.Fatalf("config file %v does not exist, please create it or set the FILEBROWSER_CONFIG environment variable to a valid config file path", config)
 		}
 	}
 }
@@ -189,6 +192,7 @@ func runCLI() (keepGoing bool, dbExists bool) {
 	parser, err := kong.New(&rootCLI,
 		kong.Name("filebrowser"),
 		kong.Description("FileBrowser Quantum - A modern web-based file manager"),
+		kong.Bind(&rootCLI.Globals),
 	)
 	if err != nil {
 		logger.Fatalf("failed to configure CLI: %v", err)
@@ -203,12 +207,14 @@ func runCLI() (keepGoing bool, dbExists bool) {
 	cmd := ctx.Command()
 	switch {
 	case cmd == "" || cmd == "run":
+		requireExistingConfig(configPath)
 		dbExists = initializeDatabase(configPath)
 		return true, dbExists
 	case cmd == "version" || cmd == "setup":
 		parser.FatalIfErrorf(ctx.Run(&rootCLI))
 		return false, false
 	case cmd == "set rule" || cmd == "set" || strings.HasPrefix(cmd, "user set") || strings.HasPrefix(cmd, "user promote"):
+		requireExistingConfig(configPath)
 		dbExists = initializeDatabase(configPath)
 		parser.FatalIfErrorf(ctx.Run(&rootCLI))
 		return false, dbExists

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -55,18 +55,6 @@ func initializeDatabase(configFile string) bool {
 	return existingDb
 }
 
-func generalUsage() {
-	fmt.Printf(`usage: ./filebrowser <command> [options]
-commands:
-	-h    		Print help
-	-c    		Path to config file (global default: config.yaml)
-	version 	Print version information
-	setup   		Interactive config setup
-	set -u 		Username and password: set -u <user>,<password> [-c config.yaml]
-	set rule	Access rules: set rule -s <sourceName> -p <indexPath> -r user|group|all -v <name> [-allow] [-c config.yaml] (-sourceName/-sourcePath same as -s/-p)
-`)
-}
-
 func StartFilebrowser() {
 	keepGoing, dbExists := runCLI()
 	if !keepGoing {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/gtsteffaniak/filebrowser/backend
 go 1.25.0
 
 require (
+	github.com/alecthomas/kong v1.16.0
 	github.com/asdine/storm/v3 v3.2.1
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/coreos/go-systemd/v22 v22.7.0
@@ -33,6 +34,7 @@ require (
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.47.0
+	golang.org/x/term v0.45.0
 	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.48.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -291,7 +293,6 @@ require (
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -93,6 +93,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/go-check-sumtype v0.3.1 h1:u9aUvbGINJxLVXiFvHUlPEaD7VDULsrxJb4Aq31NLkU=
 github.com/alecthomas/go-check-sumtype v0.3.1/go.mod h1:A8TSiN3UPRw3laIgWEUOHHLPa6/r9MtoigdlP5h3K/E=
+github.com/alecthomas/kong v1.16.0 h1:g92/kUxBcdcTPOM79yE63viJgtcp5dNyrB3/O2cjYT4=
+github.com/alecthomas/kong v1.16.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Updated v2.0.0 upgrade notes for required database/config migration and structural config changes.
  * Media streaming guidance now centers on `/api/media/stream` (old guidance removed).
  * Canonical CLI user commands updated (`user set <username> --password [value]`, `user promote <username>`); legacy shorthand deprecated. `exiftool` is no longer optional.
* **New Features**
  * Enhanced CLI user and rule management, including `user promote`, stricter password input handling, and `--no-input` enforcement.
* **Documentation**
  * Expanded README/CHANGELOG with CLI and migration/streaming details.
* **Tests**
  * Added CLI parsing/password/config-path unit coverage.
* **Chores**
  * Updated Playwright Docker image commands and rule allow flag syntax to `--allow`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->