### PR TITLE
port v1.5.x bugfix changes

### DIFF
--- a/backend/internal/auth/totp.go
+++ b/backend/internal/auth/totp.go
@@ -150,7 +150,7 @@ func VerifyTotpCode(user *users.User, code string) error {
 	if !found && user.TOTPSecret == "" {
 		return fmt.Errorf("OTP token not found in cache, please generate a new one")
 	}
-	useCache := found && user.TOTPSecret == ""
+	useCache := found
 	totpSecret := user.TOTPSecret // The encrypted or plaintext secret
 	totpNonce := user.TOTPNonce   // The nonce if encrypted, or empty if plaintext
 	if useCache {

--- a/backend/internal/web/onlyOffice.go
+++ b/backend/internal/web/onlyOffice.go
@@ -15,8 +15,8 @@ import (
 
 	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
-	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/gtsteffaniak/go-logger/logger"
@@ -490,7 +490,7 @@ func processOnlyOfficeCallback(w http.ResponseWriter, r *http.Request, d *Contex
 		//
 		// When the document is fully closed by all editors,
 		// the document key should no longer be re-used.
-		deleteOfficeId(source, path)
+		deleteOfficeId(source, path, user)
 
 		// Send log event for document closure and clean up log context
 		if logContext := GetOnlyOfficeLogContext(data.Key); logContext != nil {
@@ -763,14 +763,21 @@ func GetOnlyOfficeId(realpath string) (string, error) {
 	return "", fmt.Errorf("document key not found")
 }
 
-func deleteOfficeId(source, path string) {
-	idx := indexing.GetIndex(source)
-	if idx == nil {
-		logger.Errorf("deleteOfficeId: failed to find source index for user home dir creation: %s", source)
-		return
+func deleteOfficeId(source, path string, user *users.User) {
+	fi, err := files.FileInfoFaster(utils.FileOptions{
+		Path:           path,
+		Source:         source,
+		Expand:         false,
+		FollowSymlinks: true,
+	}, user)
+	key := path
+	if fi != nil && fi.RealPath != "" {
+		key = fi.RealPath
 	}
-	realpath, _, _ := idx.GetRealPath(path)
-	utils.OnlyOfficeCache.Delete(realpath)
+	if err != nil {
+		logger.Errorf("deleteOfficeId: failed to resolve realpath, source=%s, path=%s: %v", source, path, err)
+	}
+	utils.OnlyOfficeCache.Delete(key)
 }
 
 // parseOnlyOfficeJWT parses the JWT token from OnlyOffice callback

--- a/backend/internal/web/onlyOffice_test.go
+++ b/backend/internal/web/onlyOffice_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -128,6 +129,73 @@ func TestResolveOnlyOfficeDownloadURL(t *testing.T) {
 			t.Errorf("resolveOnlyOfficeDownloadURL() = %q, want empty", got)
 		}
 	})
+}
+
+func TestDeleteOfficeId(t *testing.T) {
+	const rawPath = "/docs/document.docx"
+
+	tests := []struct {
+		name      string
+		resolve   func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error)
+		deleteKey string
+		remainKey string
+	}{
+		{
+			name: "deletes resolved realpath",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return &iteminfo.ExtendedFileInfo{RealPath: "/some/path/document.docx"}, nil
+			},
+			deleteKey: "/some/path/document.docx",
+			remainKey: rawPath,
+		},
+		{
+			name: "fallback to raw path on error",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return nil, fmt.Errorf("could not resolve path")
+			},
+			deleteKey: rawPath,
+			remainKey: "/some/path/document.docx",
+		},
+		{
+			name: "also deletes realpath when partially resolved before erroring",
+			resolve: func(utils.FileOptions) (*iteminfo.ExtendedFileInfo, error) {
+				return &iteminfo.ExtendedFileInfo{RealPath: "/some/path/document.docx"}, fmt.Errorf("access check failed")
+			},
+			deleteKey: "/some/path/document.docx",
+			remainKey: rawPath,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origFunc := files.FileInfoFasterFunc
+			t.Cleanup(func() { files.FileInfoFasterFunc = origFunc })
+			files.FileInfoFasterFunc = func(opts utils.FileOptions, user *users.User) (*iteminfo.ExtendedFileInfo, error) {
+				if opts.Path != rawPath {
+					t.Errorf("expected opts.Path=%q, got %q", rawPath, opts.Path)
+				}
+				if opts.Source != "source" {
+					t.Errorf("expected opts.Source=%q, got %q", "source", opts.Source)
+				}
+				if !opts.FollowSymlinks {
+					t.Error("expected FollowSymlinks=true")
+				}
+				return tt.resolve(opts)
+			}
+			utils.OnlyOfficeCache.Set(tt.deleteKey, "document-key")
+			utils.OnlyOfficeCache.Set(tt.remainKey, "other-key")
+			t.Cleanup(func() {
+				utils.OnlyOfficeCache.Delete(tt.deleteKey)
+				utils.OnlyOfficeCache.Delete(tt.remainKey)
+			})
+			deleteOfficeId("source", rawPath, &users.User{})
+			if _, err := GetOnlyOfficeId(tt.deleteKey); err == nil {
+				t.Errorf("expected cache entry %q to be deleted", tt.deleteKey)
+			}
+			if _, err := GetOnlyOfficeId(tt.remainKey); err != nil {
+				t.Errorf("expected cache entry %q to remain, but it was deleted", tt.remainKey)
+			}
+		})
+	}
 }
 
 func TestOnlyOfficeURLHostsMatch(t *testing.T) {

--- a/backend/internal/web/totp_test.go
+++ b/backend/internal/web/totp_test.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/auth"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/state"
+	"github.com/pquerna/otp/totp"
+)
+
+func otpRequest(username, password, code, path string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path+"?username="+username, http.NoBody)
+	req.Header.Set("X-Password", password)
+	if code != "" {
+		req.Header.Set("X-Secret", code)
+	}
+	return req
+}
+
+func TestVerifyOTP_CachedSecretTakesPrecedence(t *testing.T) {
+	setupTestEnv(t)
+
+	const oldSecret = "SOMEOLDSECRET234"
+	user := &users.User{
+		FrontendUser: users.FrontendUser{Username: "test"},
+	}
+	if err := state.CreateUser(user, "testPass"); err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	user.TOTPSecret = oldSecret
+	user.OtpEnabled = true
+	if err := state.UpdateUser(user, "", "TOTPSecret", "OtpEnabled"); err != nil {
+		t.Fatalf("failed to set TOTP on user: %v", err)
+	}
+	t.Cleanup(func() { auth.TotpCache.Delete(user.Username) })
+
+	d := &Context{User: user}
+
+	rec := httptest.NewRecorder()
+	if _, err := generateOTPHandler(rec, otpRequest(user.Username, "testPass", "", "/api/auth/otp/generate"), d); err != nil {
+		t.Fatalf("generation failed: %v", err)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	u, err := url.Parse(resp["url"])
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+	newSecret := u.Query().Get("secret")
+	if newSecret == oldSecret {
+		t.Fatal("expected a fresh secret")
+	}
+	oldCode, err := totp.GenerateCode(oldSecret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate old code: %v", err)
+	}
+	if _, verifyErr := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", oldCode, "/api/auth/otp/verify"), d); verifyErr == nil {
+		t.Error("expected old secret to be rejected")
+	}
+	newCode, err := totp.GenerateCode(newSecret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate new code: %v", err)
+	}
+	if _, verifyErr := verifyOTPHandler(httptest.NewRecorder(), otpRequest(user.Username, "testPass", newCode, "/api/auth/otp/verify"), d); verifyErr != nil {
+		t.Fatalf("expected new secret to be accepted: %v", verifyErr)
+	}
+	updated, err := state.GetUserByUsername(user.Username)
+	if err != nil {
+		t.Fatalf("failed to reload user: %v", err)
+	}
+	if updated.TOTPSecret != newSecret {
+		t.Error("expected TOTPSecret to be updated to the new secret")
+	}
+	if _, found := auth.TotpCache.Get(user.Username); found {
+		t.Error("expected cache to be cleared after verification")
+	}
+}

--- a/backend/pkg/settings/config_test.go
+++ b/backend/pkg/settings/config_test.go
@@ -93,6 +93,34 @@ func TestConfigLoadEnvVars(t *testing.T) {
 	}
 }
 
+func TestConfigLoadHttpSection(t *testing.T) {
+	testDir := t.TempDir()
+	configContent := []byte(`
+server:
+  sources:
+    - path: "."
+http:
+  trustedHeaders:
+    - X-Forwarded-For
+  disableRateLimit: true
+`)
+	configFile := filepath.Join(testDir, "config.yaml")
+	if err := os.WriteFile(configFile, configContent, 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	if err := loadConfigWithDefaults(configFile, true); err != nil {
+		t.Fatalf("error loading config file: %v", err)
+	}
+
+	if len(Config.Http.TrustedHeadersArray) != 1 || Config.Http.TrustedHeadersArray[0] != "X-Forwarded-For" {
+		t.Fatalf("expected trusted headers to contain X-Forwarded-For, got %v", Config.Http.TrustedHeadersArray)
+	}
+	if !Config.Http.DisableRateLimit {
+		t.Fatal("expected http.disableRateLimit to be true")
+	}
+}
+
 func TestConfigLoadSpecificValues(t *testing.T) {
 	// Create isolated test directory
 	testDir := t.TempDir()

--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -871,24 +871,16 @@ export default {
           payload.enableOnlyOffice = false;
         }
 
-        const res = await shareApi.create(payload);
+        await shareApi.create(payload);
 
-        if (!this.isEditMode && !this.editingLink) {
-          this.links.push(res);
-          this.sort();
-        } else if (this.editingLink) {
-          // Update the link in the local list
-          const index = this.links.findIndex(l => l.hash === this.editingLink.hash);
-          if (index !== -1) {
-            this.links.splice(index, 1, res);
-          }
-          this.editingLink = null;
-          // emit event to reload shares in settings view
-          eventBus.emit('sharesChanged');
-        } else {
-          // emit event to reload shares in settings view
+        if (this.isEditMode) {
           eventBus.emit('sharesChanged');
           mutations.closeTopPrompt();
+        } else {
+          const refreshed = await this.refreshShares();
+          if (!refreshed) return;
+          this.editingLink = null;
+          eventBus.emit('sharesChanged');
         }
 
         this.time = "";
@@ -902,6 +894,21 @@ export default {
           // didn't come from api, show error to user
           notify.showError(err);
         }
+      }
+    },
+    async refreshShares() {
+      if (this.isEditMode) return true;
+      this.linksLoading = true;
+      try {
+        const links = await shareApi.get(this.item.path, this.item.source);
+        this.links = links;
+        this.sort();
+        return true;
+      } catch (err) {
+        console.error(err);
+        return false;
+      } finally {
+        this.linksLoading = false;
       }
     },
     /**

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -1116,10 +1116,17 @@ export const mutations = {
     emitStateChanged();
   },
   setShareInfo: (shareInfo) => {
-    if (state.shareInfo === shareInfo) {
+    const merged = { ...state.shareInfo, ...shareInfo };
+    if (shareInfo.token === undefined && state.shareInfo.token) {
+      merged.token = state.shareInfo.token;
+    }
+    if (shareInfo.passwordValid === undefined && state.shareInfo.passwordValid !== undefined) {
+      merged.passwordValid = state.shareInfo.passwordValid;
+    }
+    if (JSON.stringify(merged) === JSON.stringify(state.shareInfo)) {
       return;
     }
-    state.shareInfo = shareInfo;
+    state.shareInfo = merged;
     updateManifestLink();
     emitStateChanged();
   },

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -173,7 +173,7 @@
 
   <!-- Upload Share Target -->
   <!-- Only show upload interface if password is validated (or no password required) -->
-  <div v-else-if="!shareInfo.hasPassword || state.share?.passwordValid" class="upload-share-embed">
+  <div v-else-if="!shareInfo.hasPassword || shareInfo.passwordValid" class="upload-share-embed">
     <Upload :initialItems="null" />
   </div>
 </template>


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared-link updates so newly created and edited shares refresh reliably and display the latest information.
  * Preserved share access details, including tokens and password validation status, during state updates.
  * Corrected upload-share visibility when password protection is enabled.
  * Improved OnlyOffice session cleanup for files accessed through alternate paths.
  * Updated two-factor authentication verification to consistently use the most recently issued secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->