### PR TITLE
fix(share): probe canShare with the real file, not a fixed text/plain stand-in

### DIFF
--- a/frontend/src/utils/nativeShare.js
+++ b/frontend/src/utils/nativeShare.js
@@ -10,13 +10,18 @@ export function canNativeShare() {
   );
 }
 
-function canShareFiles() {
+/**
+ * Checks whether the OS/browser share sheet can accept the given File.
+ * navigator.canShare({ files }) validates the specific file being shared
+ * (name, MIME type, size) — many platforms only allow a safe subset
+ * (images, audio, video, plain text, PDF) and reject everything else.
+ */
+function canShareFile(file) {
   if (typeof navigator.canShare !== "function") {
     return false;
   }
   try {
-    const probe = new File(["x"], "share-probe.txt", { type: "text/plain" });
-    return navigator.canShare({ files: [probe] });
+    return navigator.canShare({ files: [file] });
   } catch {
     return false;
   }
@@ -43,7 +48,14 @@ export async function nativeShareFile(item) {
   const url = buildDownloadUrl(item);
 
   try {
-    if (canShareFiles()) {
+    // Only attempt to share the file's actual bytes if navigator.canShare
+    // exists at all. We must check the real file (fetched below), not a
+    // synthetic stand-in: this previously probed with a fixed text/plain
+    // file, which always reported success even for file types (e.g.
+    // .xlsx, .docx, .zip) that the OS share sheet then silently rejected
+    // once navigator.share() was actually called, surfacing as an opaque
+    // "permission denied" error to the user (see #2659).
+    if (typeof navigator.canShare === "function") {
       const response = await fetch(url, { credentials: "same-origin" });
       if (!response.ok) {
         const detail = response.statusText ? ` (${response.statusText})` : "";
@@ -53,10 +65,15 @@ export async function nativeShareFile(item) {
       const blob = await response.blob();
       const type = blob.type || item.type || "application/octet-stream";
       const file = new File([blob], filename, { type });
-      await navigator.share({ files: [file], title: filename });
-      return;
+
+      if (canShareFile(file)) {
+        await navigator.share({ files: [file], title: filename });
+        return;
+      }
     }
 
+    // Fall back to sharing a link when the platform can't share the file's
+    // actual bytes/type (or doesn't support file sharing at all).
     await navigator.share({ url, title: filename });
   } catch (e) {
     if (e?.name === "AbortError") {

--- a/frontend/src/utils/nativeShare.test.js
+++ b/frontend/src/utils/nativeShare.test.js
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const showErrorMock = vi.fn();
+
+vi.mock("@/api", () => ({
+  resourcesApi: {
+    getDownloadURL: vi.fn(() => "https://example.com/api/raw/report.xlsx"),
+    getDownloadURLPublic: vi.fn(() => "https://example.com/api/public/dl/report.xlsx"),
+  },
+}));
+
+vi.mock("@/notify", () => ({
+  notify: {
+    showError: (...args) => showErrorMock(...args),
+  },
+}));
+
+vi.mock("@/store", () => ({
+  getters: {
+    isShare: () => false,
+  },
+  state: {
+    req: { source: "default" },
+  },
+}));
+
+import { canNativeShare, nativeShareFile } from "./nativeShare";
+
+function mockShare(implementation) {
+  Object.defineProperty(window, "isSecureContext", {
+    configurable: true,
+    value: true,
+  });
+  navigator.share = vi.fn(implementation ?? (() => Promise.resolve()));
+}
+
+function stubFetch(blobType) {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      statusText: "OK",
+      status: 200,
+      blob: () =>
+        Promise.resolve({
+          type: blobType,
+        }),
+    })
+  );
+}
+
+beforeEach(() => {
+  showErrorMock.mockClear();
+  delete navigator.canShare;
+  delete navigator.share;
+  global.fetch = undefined;
+});
+
+describe("canNativeShare", () => {
+  it("returns false when navigator.share is unavailable", () => {
+    expect(canNativeShare()).toBe(false);
+  });
+
+  it("returns true when navigator.share exists and context is secure", () => {
+    mockShare();
+    expect(canNativeShare()).toBe(true);
+  });
+});
+
+describe("nativeShareFile", () => {
+  it("shows an error when sharing isn't supported at all", async () => {
+    await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+    expect(showErrorMock).toHaveBeenCalledWith("Sharing is not supported on this device");
+  });
+
+  it(
+    "falls back to sharing a link (not the file) when the platform rejects the file's real MIME type " +
+      "-- regression test for #2659, where a hardcoded text/plain probe file made canShareFiles() always " +
+      "return true, so navigator.share() was called with an .xlsx/.docx/.zip file the platform then " +
+      "silently rejected, surfacing as 'permission denied'",
+    async () => {
+      mockShare();
+      stubFetch("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+      // Platform can share files in general, but rejects this specific
+      // (non-safelisted) MIME type -- exactly what real browsers do for
+      // office/archive formats.
+      navigator.canShare = vi.fn(({ files }) => {
+        const file = files?.[0];
+        return file ? file.type === "text/plain" : false;
+      });
+
+      await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+
+      expect(navigator.share).toHaveBeenCalledTimes(1);
+      const sharedPayload = navigator.share.mock.calls[0][0];
+      // Must NOT have attempted to share the actual xlsx file bytes.
+      expect(sharedPayload.files).toBeUndefined();
+      expect(sharedPayload.url).toBe("https://example.com/api/raw/report.xlsx");
+      expect(showErrorMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("shares the real file when the platform's canShare accepts its actual type", async () => {
+    mockShare();
+    stubFetch("application/pdf");
+    navigator.canShare = vi.fn(({ files }) => files?.[0]?.type === "application/pdf");
+
+    await nativeShareFile({ name: "doc.pdf", path: "/doc.pdf" });
+
+    expect(navigator.share).toHaveBeenCalledTimes(1);
+    const sharedPayload = navigator.share.mock.calls[0][0];
+    expect(sharedPayload.files).toHaveLength(1);
+    expect(sharedPayload.files[0].name).toBe("doc.pdf");
+    expect(sharedPayload.files[0].type).toBe("application/pdf");
+  });
+
+  it("shares a link directly when the platform has no canShare at all", async () => {
+    mockShare();
+    // No navigator.canShare defined -- older/limited platforms.
+
+    await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+
+    expect(global.fetch).toBeUndefined();
+    expect(navigator.share).toHaveBeenCalledWith({
+      url: "https://example.com/api/raw/report.xlsx",
+      title: "report.xlsx",
+    });
+  });
+
+  it("surfaces a download failure instead of silently sharing nothing", async () => {
+    mockShare();
+    navigator.canShare = vi.fn(() => true);
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 403, statusText: "Forbidden" })
+    );
+
+    await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+
+    expect(navigator.share).not.toHaveBeenCalled();
+    expect(showErrorMock).toHaveBeenCalledWith("Download failed (403 (Forbidden))");
+  });
+
+  it("silently ignores the user cancelling the OS share sheet", async () => {
+    mockShare(() => {
+      const err = new Error("cancelled");
+      err.name = "AbortError";
+      return Promise.reject(err);
+    });
+
+    await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What / Why

Fixes #2659: "Send to App" throws a "permission denied" style error for `.xlsx`, `.docx`, `.zip`, `.pptx` files, while `.txt`, images and PDFs work fine.

`nativeShareFile()` checks `navigator.canShare({ files })` before attempting to share a file's actual bytes via the Web Share API. That check was being probed with a hardcoded synthetic file:

```js
const probe = new File(["x"], "share-probe.txt", { type: "text/plain" });
return navigator.canShare({ files: [probe] });
```

`navigator.canShare({ files })` validates the *specific* file being shared (name/type/size) — most platforms only allow a safe subset of MIME types through the file-sharing path (images, audio, video, plain text, PDF) and reject everything else. Since the probe was always `text/plain`, this check always reported success no matter what the user actually wanted to send. `navigator.share()` was then called with the *real* file — an `.xlsx`/`.docx`/`.zip`/etc — which the OS/browser share sheet silently rejected, and that rejection surfaced to the user as an opaque error.

## Fix

- The `canShare` probe now runs against the real `File` object — fetched from the download URL and given its actual MIME type from the response — the same object that would be passed to `navigator.share()` if the check passes.
- If the platform's `canShare` rejects that specific file (or `navigator.canShare` doesn't exist at all), `nativeShareFile` now falls back to sharing a **link** instead of erroring out or blindly calling `navigator.share({files})` anyway. So "Send to App" stays usable for every file type: files the platform can actually receive are shared as files, everything else is shared as a link the receiving app can fetch.

## Testing

```
npm ci
npx vitest run                                  # 7 files / 40 tests, all pass
npx eslint --ext .js,.vue,.ts src/utils/nativeShare.js src/utils/nativeShare.test.js
npx vue-tsc -p ./tsconfig.json --noEmit          # typecheck clean
```

This util had no test coverage before. Added `frontend/src/utils/nativeShare.test.js` with 8 cases, including a direct regression test for #2659: it stubs `navigator.canShare` to accept only `text/plain` (mirroring real platform behavior for an `.xlsx` file) and asserts `nativeShareFile` falls back to sharing a link instead of attempting — and failing — to share the office-document bytes. Other cases cover: sharing unsupported entirely, the platform accepting the real file type, no `canShare` at all, a download-fetch failure, and the user cancelling the OS share sheet.

Fixes #2659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native file sharing compatibility by checking whether the downloaded file type is supported before sharing.
  * Automatically falls back to sharing the download link when file sharing isn’t supported.
  * Preserved clearer handling for download failures and user-cancelled shares.

* **Tests**
  * Added coverage for secure contexts, unsupported sharing environments, file-type compatibility, link sharing, download errors, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->