### PR TITLE
updated with small changes before preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,33 +4,32 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v2.0.0
 
-This version represents the most significant change to date. It **requires** both a database migration and config structural changes. See the [migration guide](https://filebrowserquantum.com/en/docs/getting-started/v2/migration/) for step-by-step upgrade instructions.
+This version represents the most significant change to date. It **requires** both a database migration and config structural changes. See the [migration guide](https://filebrowserquantum.com/en/docs/getting-started/v2/migration/) for step-by-step upgrade instructions, [About v2.0.0](https://filebrowserquantum.com/en/docs/getting-started/v2/about/) for a full summary, and the [config migration tool](https://filebrowserquantum.com/en/docs/getting-started/v2/config-migration/) to convert legacy config.
 
  **Breaking Changes**:
- - Removed: `GET /api/raw` and `GET /public/api/raw` download routes — use `/api/resources/download` instead.
- - Removed: `/share/…` URL redirect to `/public/share/…` — use `/public/share/…` directly.
- - Removed: singular `source` search api param (use `sources`), bare `scope` paths without `sourceName:` prefix, and `glob` / `useGlob` aliases (use `useWildcard`).
- - Removed `config.conditionals`, source-level `indexingIntervalMinutes` (indexing always uses adaptive scheduling), and deprecated rule fields `fileNames` / `folderNames` / top-level `hidden` — use `config.rules` with `fileName`, `folderName`, and `ignoreHidden` on rules.
- - Removed: support for deprecated userDefaults config format, users must use config migration tool to update userDefaults.
+ - Removed: `GET /api/raw` and `GET /public/api/raw` download routes — use `/api/resources/download` instead. See [API reference](https://filebrowserquantum.com/en/docs/reference/api/).
+ - Removed: `/share/…` URL redirect to `/public/share/…` — use `/public/share/…` directly. See [Share options](https://filebrowserquantum.com/en/docs/shares/options/).
+ - Removed: singular `source` search api param (use `sources`), bare `scope` paths without `sourceName:` prefix, and `glob` / `useGlob` aliases (use `useWildcard`). See [API reference](https://filebrowserquantum.com/en/docs/reference/api/).
+ - Removed `config.conditionals`, source-level `indexingIntervalMinutes` (indexing always uses adaptive scheduling), and deprecated rule fields `fileNames` / `folderNames` / top-level `hidden` — use `config.rules` with `fileName`, `folderName`, and `ignoreHidden` on rules. See [Exclusion rules](https://filebrowserquantum.com/en/docs/user-guides/general-configuration/exclusion-rules/).
+ - Removed: support for deprecated userDefaults config format, users must use [config migration tool](https://filebrowserquantum.com/en/docs/getting-started/v2/config-migration/) to update userDefaults.
  - Removed: support for deprecated flat `userDefaults` config format.
- - Changed: `PUT /api/users` moved to the more appropriate `PATCH` method.
- - Changed: http related config options in `server` config key moved to `http` config key.
- - Changed: `FILEBROWSER_DATABASE` environment variable — use `FILEBROWSER_DATABASE_PATH` instead (see migration notes above).
- - Changed: Moved stream api to `/api/media/stream`
- - Changed: CLI user management — canonical commands are `user set <username> --password [value]` and `user promote <username>`; `set -u username,password` is deprecated
+ - Changed: `PUT /api/users` moved to the more appropriate `PATCH` method. See [API reference](https://filebrowserquantum.com/en/docs/reference/api/).
+ - Changed: http related config options in `server` config key moved to `http` config key. See [HTTP settings](https://filebrowserquantum.com/en/docs/configuration/http/).
+ - Changed: `FILEBROWSER_DATABASE` environment variable — use `FILEBROWSER_DATABASE_PATH` instead. See [Environment variables](https://filebrowserquantum.com/en/docs/reference/environment-variables/) and [Server settings](https://filebrowserquantum.com/en/docs/configuration/server/).
+ - Changed: Moved stream api to `/api/media/stream`. See [API reference](https://filebrowserquantum.com/en/docs/reference/api/).
+ - Changed: CLI user management — canonical commands are `user set <username> --password [value]` and `user promote <username>`; `set -u username,password` is deprecated. See [CLI reference](https://filebrowserquantum.com/en/docs/reference/cli/).
 
  **New Features**:
- - View grant mechanism to distinguish between UI viewing and download.
+ - View grant mechanism to distinguish between UI viewing and download. See [Access control overview](https://filebrowserquantum.com/en/docs/access-control/access-control-overview/).
  - ffmpeg hardware acceleration detection and support via go-ffmpeg
-  - video streaming is limited to viewing only.
+  - video streaming is limited to viewing only. See [Media integration](https://filebrowserquantum.com/en/docs/integrations/media/about/).
  - granular per-source file permissions (view, download, modify, create, delete) with automatic migration from global permissions
    - per-source defaults configurable in `settings > access management`
-   - `view` permission is automatically set to true unless explicitly set to false.
- # - backup/restore in UI settings
+   - `view` permission is automatically set to true unless explicitly set to false. See [Access control overview](https://filebrowserquantum.com/en/docs/access-control/access-control-overview/).
  - New activity logs for user activity.
    - charts and historical data
    - activity tool to view data
-   - reports
+   - reports. See [Activity feature docs](https://filebrowserquantum.com/en/docs/features/activity/).
  - Media player improvements:
    - Refreshed playback queue UI: Supports thumbnails, stored into session storage, and has a "clear queue" button (#2575) (#2600).
    - Loop now has 3 states (off/single/all) and neither of them will clear the existing queue (#2600).
@@ -43,7 +42,7 @@ This version represents the most significant change to date. It **requires** bot
    - anonymized with a viewer so users can see what info would be sent.
    - if opt-in, every month a snapshot of your deployment config would be sent to developer servers
    - this will help me know what features are being used and what versions everyone is on over time. I will also provide a public dashboard with this information in the future. 
- - WebDAV now supports set modification time via the `X-OC-Mtime` header for clients that support it (#2626).
+ - WebDAV now supports set modification time via the `X-OC-Mtime` header for clients that support it (#2626). See [WebDAV docs](https://filebrowserquantum.com/en/docs/features/webdav/).
  - Copy operations now preserve their original modification times (#2642) (#2647):
    - WebUI preserves both, files and directories.
    - WebDAV `COPY` preserves modification times only for files, is limitation we have with webdav.
@@ -51,20 +50,37 @@ This version represents the most significant change to date. It **requires** bot
    - Config `userDefaults` seeds SQLite on first run; only fields explicitly set in config stay locked in **Settings → User defaults** (other defaults remain editable)
    - Added administrator controls for universal user defaults and enforced preferences in `settings > user management > user defaults`.
    - Added configurable default file permissions per source in `settings > access management`.
-   - Added a User Defaults editor for account, permission, and profile preferences in the edit/create user prompt.
- - Database env var rename: `FILEBROWSER_DATABASE` is removed (startup fails if set). Use `FILEBROWSER_DATABASE_PATH` (default `filebrowser.sqlite`) or `server.database.path` in config.
- - CLI: `user set` with `--password` (inline value, interactive prompt on TTY, or piped stdin); `user promote` for admin grant without password reset
+   - Added a User Defaults editor for account, permission, and profile preferences in the edit/create user prompt. See [User management](https://filebrowserquantum.com/en/docs/configuration/users/).
+ - Database env var rename: `FILEBROWSER_DATABASE` is removed (startup fails if set). Use `FILEBROWSER_DATABASE_PATH` (default `filebrowser.sqlite`) or `server.database.path` in config. See [Environment variables](https://filebrowserquantum.com/en/docs/reference/environment-variables/) and [Server settings](https://filebrowserquantum.com/en/docs/configuration/server/).
+ - CLI: `user set` with `--password` (inline value, interactive prompt on TTY, or piped stdin); `user promote` for admin grant without password reset. See [CLI reference](https://filebrowserquantum.com/en/docs/reference/cli/).
 
  **Notes**:
- - v2.x.x uses a new write-through backend state management. Changes go through a fast memory layer and also write changes to database to stay in sync.
+ - v2.x.x uses a new write-through backend state management. Changes go through a fast memory layer and also write changes to database to stay in sync. See [About v2.0.0](https://filebrowserquantum.com/en/docs/getting-started/v2/about/).
  - CLI server start (`./filebrowser`), `setup`, `version`, and `set rule` syntax unchanged; see [CLI docs](https://filebrowserquantum.com/en/docs/reference/cli/)
  - new dropdown and input styles
  - user updates are more granular, don't include entire user payload.
- - `user.id` has been moved to a backend property and all frontend apis now query users by username. Swagger has been updated.
+ - `user.id` has been moved to a backend property and all frontend apis now query users by username. Swagger has been updated. See [API reference](https://filebrowserquantum.com/en/docs/reference/api/).
  - removed legacy and deprecated properties from API responses and generated config output
- - `/api/media/stream` is audio/video only (range-based chunking). Non-media inline viewing uses `GET /api/resources/view`. Both endpoints use the same `viewToken` from file metadata.
+ - `/api/media/stream` is audio/video only (range-based chunking). Non-media inline viewing uses `GET /api/resources/view`. Both endpoints use the same `viewToken` from file metadata. See [API reference](https://filebrowserquantum.com/en/docs/reference/api/).
  - removed exiftool as an optional helper, always built with the supported libraries.
+ - If migration issues arise, see [Migration troubleshooting](https://filebrowserquantum.com/en/docs/getting-started/Migration/troubleshooting/).
 
+## v1.5.2
+
+ **Notes**:
+ - [docker] upgraded ffmpeg version 8.1.1 to 8.1.2
+
+ **BugFixes**:
+ - Fixed OnlyOffice reopening an older editor state after a document is modified (#2633) (#2578).
+ - Cannot "Reset and generate new two-factor code" to reset the TOTP for a user (#2399) (#2641).
+
+## v1.5.1
+
+ **BugFixes**:
+ - fix http config section being dropped so trustedHeaders and disableRateLimit apply (#2602) (#2560)
+ - fix upload shares with password (#2589) (#2573)
+ - fix token when returning from preview on shares with pass (#2588) (#2465)
+ - fix share undefined url after editing (#2567) (#2523)
 ## v1.5.0
 
  **New Features**:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@
 
 :pushpin: [Read The Official Docs](https://filebrowserquantum.com/) (currently english-only)
 
-## v2.0.0 Breaking Changes
+## v2.0.0
 
-Upgrading to v2.x.x **requires** database migration and config structural changes. See the [migration docs](https://filebrowserquantum.com/en/docs/getting-started/v2/migration) for full details.
+This release is the largest upgrade to date. It **requires** both a database migration and config structural changes.
+
+**Start here:** [Migration guide](https://filebrowserquantum.com/en/docs/getting-started/v2/migration/) · [About v2.0.0](https://filebrowserquantum.com/en/docs/getting-started/v2/about/) · [Config migration tool](https://filebrowserquantum.com/en/docs/getting-started/v2/config-migration/) · [Migration troubleshooting](https://filebrowserquantum.com/en/docs/getting-started/Migration/troubleshooting/)
 
 ## About
 
@@ -129,7 +131,7 @@ Office file support           | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
 Office file previews          | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
 Themes                        | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 Branding support              | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
-activity log                  | :construction: | ❌ | ✅ | ✅ | ✅ | ✅ |
+activity log                  | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
 Comments support              | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
 trash support                 | :construction: | ❌ | ✅ | ✅ | ✅ | ✅ |
 Starred/pinned files          | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ |

--- a/backend/cmd/migrate.go
+++ b/backend/cmd/migrate.go
@@ -7,18 +7,24 @@ import (
 	"path/filepath"
 
 	storm "github.com/asdine/storm/v3"
-	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/access"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/dbindex"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/share"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/sqldb"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/usersidebar"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/gtsteffaniak/go-logger/logger"
 )
 
-// checkMigrationNeeded is true when database.migrateFrom points at a BoltDB file to import and
-// database.path (SQLite) does not exist yet or is empty.
+const migrationGuideURL = "https://filebrowserquantum.com/en/docs/getting-started/v2/migration"
+
+func migrationErrf(format string, args ...any) error {
+	return fmt.Errorf(format+" See the v2 migration guide: "+migrationGuideURL, args...)
+}
+
+// checkMigrationNeeded is true when server.database.migrateFrom points at a BoltDB file to import and
+// server.database.path (SQLite) does not exist yet or is empty.
 func checkMigrationNeeded() bool {
 	boltPath := settings.Config.Server.DatabaseV2.MigrateFrom
 	if boltPath == "" {
@@ -31,11 +37,11 @@ func checkMigrationNeeded() bool {
 }
 
 // validateDatabasePaths enforces database path rules before opening or creating SQLite:
-//  1. On a fresh install, fail if the configured SQLite path is database.db or an unrenamed
-//     legacy Bolt file (database.db) is present in the working directory.
-//  2. On a fresh install with database.migrateFrom set, fail if the legacy Bolt file is missing
+//  1. On a fresh install, fail if server.database.path is database.db or an unrenamed
+//     legacy BoltDB file (database.db) is present in the working directory.
+//  2. On a fresh install with server.database.migrateFrom set, fail if the legacy BoltDB file is missing
 //     or empty.
-//  3. When SQLite already exists and database.migrateFrom is set, fail if the legacy Bolt file
+//  3. When SQLite already exists and server.database.migrateFrom is set, fail if the legacy BoltDB file
 //     is missing or empty.
 //
 // Otherwise the existing SQLite database is used, or a new one is created on first open.
@@ -46,14 +52,16 @@ func validateDatabasePaths() error {
 
 	if !sqliteExists {
 		if filepath.Base(sqlitePath) == "database.db" {
-			return fmt.Errorf(
-				"server.database path cannot be %q; use a different filename for the SQLite database (e.g. filebrowser.sqlite)",
-				sqlitePath,
+			return migrationErrf(
+				`server.database.path cannot be "database.db": that name is reserved for the legacy database file. ` +
+					`Rename database.db to database.db.old, set server.database.path to a new SQLite filename ` +
+					`and set server.database.migrateFrom to "database.db.old".`,
 			)
 		}
 		if _, err := os.Stat("database.db"); err == nil {
-			return fmt.Errorf(
-				"old version of database file found at database.db, please rename it to database.db.old and set database.migrateFrom",
+			return migrationErrf(
+				`legacy database file found in the working directory. ` +
+					`Rename it to database.db.old, set server.database.migrateFrom to "database.db.old".`,
 			)
 		}
 		if boltPath != "" {
@@ -73,29 +81,31 @@ func legacyBoltDatabaseError(boltPath, sqlitePath string, freshInstall bool) err
 	if err != nil {
 		if os.IsNotExist(err) {
 			if freshInstall {
-				return fmt.Errorf(
-					"database.migrateFrom is %q but that file does not exist and no SQLite database exists at %q",
-					boltPath,
-					sqlitePath,
+				return migrationErrf(
+					`server.database.migrateFrom is %q but that file does not exist, and no SQLite database exists at server.database.path (%q). `+
+						`Check the migrateFrom path or restore your renamed legacy database backup.`,
+					boltPath, sqlitePath,
 				)
 			}
-			return fmt.Errorf(
-				"database.migrateFrom is %q but that file does not exist; remove migrateFrom from config or restore the legacy database file",
+			return migrationErrf(
+				`server.database.migrateFrom is %q but that file does not exist. `+
+					`Migration appears complete — remove server.database.migrateFrom from your config.`,
 				boltPath,
 			)
 		}
-		return fmt.Errorf("database.migrateFrom is %q but cannot be read: %w", boltPath, err)
+		return fmt.Errorf("server.database.migrateFrom is %q but cannot be read: %w", boltPath, err)
 	}
 	if stat.Size() == 0 {
 		if freshInstall {
-			return fmt.Errorf(
-				"database.migrateFrom is %q but that file is empty and no SQLite database exists at %q",
-				boltPath,
-				sqlitePath,
+			return migrationErrf(
+				`server.database.migrateFrom is %q but that file is empty, and no SQLite database exists at server.database.path (%q). `+
+					`Restore your backed-up BoltDB file or fix the migrateFrom path.`,
+				boltPath, sqlitePath,
 			)
 		}
-		return fmt.Errorf(
-			"database.migrateFrom is %q but that file is empty; remove migrateFrom from config or restore the legacy database file",
+		return migrationErrf(
+			`server.database.migrateFrom is %q but that file is empty. `+
+				`Remove server.database.migrateFrom from your config, or restore the legacy database backup if migration is not complete.`,
 			boltPath,
 		)
 	}
@@ -184,7 +194,7 @@ func migrateFromBoltToSQLite() error {
 	logger.Info("========================================")
 	logger.Info("Migration completed successfully!")
 	logger.Info("========================================")
-	logger.Infof("Your old BoltDB file is unchanged at: %s", oldDBPath)
+	logger.Infof("Your legacy database file is unchanged at: %s", oldDBPath)
 	logger.Infof("New SQLite database created at: %s", newDBPath)
 
 	return nil
@@ -257,7 +267,7 @@ func migrateUsers(oldDB *storm.DB, sqlStore *sqldb.SQLStore) error {
 		user.Version = users.ProfileStorageVersion
 		if newScopesCount > oldScopesCount {
 			promoted++
-			logger.Infof("  user %q: Bolt had %d scopes, SQLite now has %d",
+			logger.Infof("  user %q: legacy database had %d scopes, SQLite now has %d",
 				user.Username, oldScopesCount, newScopesCount)
 		}
 		boltID := user.ID
@@ -318,7 +328,7 @@ func migrateShares(oldDB *storm.DB, sqlStore *sqldb.SQLStore) error {
 		var batch []*share.LegacyShare
 		err := oldDB.Select().Bucket(bucket).Find(&batch)
 		if err != nil && err != storm.ErrNotFound {
-			return fmt.Errorf("failed to read shares from old DB bucket %q: %w", bucket, err)
+			return fmt.Errorf("failed to read shares from legacy DB bucket %q: %w", bucket, err)
 		}
 		if len(batch) > 0 {
 			sharesList = append(sharesList, batch...)

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -207,7 +207,6 @@ func rootCMD(ctx context.Context, serverConfig *settings.Server, a *app.App, shu
 		logger.Fatalf("Error starting preview service: %v", err)
 	}
 	logger.Debugf("MuPDF Enabled            : %v", settings.Env.MuPdfAvailable)
-	logger.Debugf("Media Enabled            : %v", settings.MediaEnabled())
 
 	// Generate PWA icons after preview service is initialized
 	if err := icons.GeneratePWAIcons(); err != nil {

--- a/backend/internal/ffmpeg/service.go
+++ b/backend/internal/ffmpeg/service.go
@@ -158,7 +158,7 @@ func logCapabilities(svc *goffmpeg.Service, detectHardware bool) {
 		return
 	}
 
-	logger.Infof("Media Enabled: version %s @ %s", caps.FFmpegVersion, caps.FFmpegPath)
+	logger.Debugf("Media Enabled: version %s @ %s", caps.FFmpegVersion, caps.FFmpegPath)
 
 	if !detectHardware {
 		return
@@ -169,7 +169,7 @@ func logCapabilities(svc *goffmpeg.Service, detectHardware bool) {
 		logger.Warning("no ffmpeg hardware codec support found")
 		return
 	}
-	logger.Infof("supported ffmpeg hardware codecs: %s", hw)
+	logger.Debugf("supported ffmpeg hardware codecs: %s", hw)
 }
 
 func hardwareCodecSummary(svc *goffmpeg.Service) string {

--- a/backend/internal/ffmpeg/service.go
+++ b/backend/internal/ffmpeg/service.go
@@ -158,7 +158,7 @@ func logCapabilities(svc *goffmpeg.Service, detectHardware bool) {
 		return
 	}
 
-	logger.Infof("ffmpeg enabled: version %s @ %s", caps.FFmpegVersion, caps.FFmpegPath)
+	logger.Infof("Media Enabled: version %s @ %s", caps.FFmpegVersion, caps.FFmpegPath)
 
 	if !detectHardware {
 		return


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy database migration readiness and failure messages with clearer, consistent wording and direct links to the v2 migration guide.
  * Updated legacy database migration status and share-migration error text for more accurate troubleshooting.

* **Logging**
  * Startup logs now report MuPDF availability and media support more accurately.
  * Refined media/ffmpeg capability log wording and reduced verbosity for detailed codec hardware output.

* **Documentation**
  * Updated v2.0.0 release notes, adding and refining documentation links and rewording several guidance items (including README comparison status).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->