### PR TITLE
Fix 32bit build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ This version represents the most significant change to date. It **requires** bot
  - `user.id` has been moved to a backend property and all frontend apis now query users by username. Swagger has been updated. See [API reference](https://filebrowserquantum.com/en/docs/reference/api/).
  - removed legacy and deprecated properties from API responses and generated config output
  - `/api/media/stream` is audio/video only (range-based chunking). Non-media inline viewing uses `GET /api/resources/view`. Both endpoints use the same `viewToken` from file metadata. See [API reference](https://filebrowserquantum.com/en/docs/reference/api/).
- - removed exiftool as an optional helper, always built with the supported libraries.
+ - removed exiftool as an optional helper, always built with the supported libraries (requires 64 bit os)
  - If migration issues arise, see [Migration troubleshooting](https://filebrowserquantum.com/en/docs/getting-started/migration/troubleshooting/).
 
 ## v1.5.2

--- a/backend/internal/imagemeta/common.go
+++ b/backend/internal/imagemeta/common.go
@@ -1,0 +1,6 @@
+package imagemeta
+
+// IsJPEG reports whether data begins with a JPEG SOI marker.
+func IsJPEG(data []byte) bool {
+	return len(data) >= 2 && data[0] == 0xff && data[1] == 0xd8
+}

--- a/backend/internal/imagemeta/embedded.go
+++ b/backend/internal/imagemeta/embedded.go
@@ -1,3 +1,5 @@
+//go:build !386 && !arm
+
 package imagemeta
 
 import (
@@ -153,9 +155,4 @@ func readFileRange(f *os.File, offset, length uint32) ([]byte, error) {
 		return nil, err
 	}
 	return data[:n], nil
-}
-
-// IsJPEG reports whether data begins with a JPEG SOI marker.
-func IsJPEG(data []byte) bool {
-	return len(data) >= 2 && data[0] == 0xff && data[1] == 0xd8
 }

--- a/backend/internal/imagemeta/imagemeta_test.go
+++ b/backend/internal/imagemeta/imagemeta_test.go
@@ -1,3 +1,5 @@
+//go:build !386 && !arm
+
 package imagemeta
 
 import (

--- a/backend/internal/imagemeta/orientation.go
+++ b/backend/internal/imagemeta/orientation.go
@@ -1,3 +1,5 @@
+//go:build !386 && !arm
+
 package imagemeta
 
 import (

--- a/backend/internal/imagemeta/stub.go
+++ b/backend/internal/imagemeta/stub.go
@@ -1,0 +1,15 @@
+//go:build 386 || arm
+
+package imagemeta
+
+import "context"
+
+// ExtractEmbeddedPreview is unavailable on 32-bit platforms (imagemeta dependency omitted).
+func ExtractEmbeddedPreview(ctx context.Context, path string) ([]byte, error) {
+	return nil, nil
+}
+
+// GetOrientation is unavailable on 32-bit platforms (imagemeta dependency omitted).
+func GetOrientation(ctx context.Context, path string) string {
+	return ""
+}

--- a/backend/internal/imagemeta/stub_test.go
+++ b/backend/internal/imagemeta/stub_test.go
@@ -1,0 +1,33 @@
+//go:build 386 || arm
+
+package imagemeta
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIsJPEG(t *testing.T) {
+	if !IsJPEG([]byte{0xff, 0xd8, 0xff, 0xe0}) {
+		t.Fatal("expected JPEG SOI")
+	}
+	if IsJPEG([]byte{0x89, 0x50}) {
+		t.Fatal("expected non-JPEG")
+	}
+}
+
+func TestExtractEmbeddedPreviewUnavailable(t *testing.T) {
+	data, err := ExtractEmbeddedPreview(context.Background(), "/any/file.cr2")
+	if err != nil {
+		t.Fatalf("ExtractEmbeddedPreview() err = %v", err)
+	}
+	if data != nil {
+		t.Fatalf("ExtractEmbeddedPreview() = %v, want nil on 32-bit", data)
+	}
+}
+
+func TestGetOrientationUnavailable(t *testing.T) {
+	if got := GetOrientation(context.Background(), "/any/file.cr2"); got != "" {
+		t.Fatalf("GetOrientation() = %q, want empty on 32-bit", got)
+	}
+}


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added image orientation detection for supported image formats.
  - Added embedded preview extraction support for compatible images.
  - JPEG detection is now handled consistently across supported platforms.

- **Bug Fixes**
  - Image metadata features now degrade gracefully on 32-bit ARM and 386 systems when unavailable.

- **Documentation**
  - Clarified that exiftool is always built with supported libraries and requires a 64-bit operating system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->