### PR TITLE
feat(files): render directory README inline

### DIFF
--- a/frontend/src/components/files/DirectoryReadme.vue
+++ b/frontend/src/components/files/DirectoryReadme.vue
@@ -1,8 +1,7 @@
 <template>
-  <details
+  <section
     class="directory-readme"
     aria-label="Directory README"
-    open
     @click.stop
     @contextmenu.stop
     @dblclick.stop
@@ -11,21 +10,35 @@
     @touchend.stop
     @touchstart.stop="handleInteraction"
   >
-    <summary class="directory-readme-header">
+    <header class="directory-readme-header">
       <span class="directory-readme-title">
         <span class="material-symbols-outlined" aria-hidden="true">{{ titleIcon }}</span>
         <span>README.md</span><!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
       </span>
-      <span class="directory-readme-chevron material-symbols-outlined" aria-hidden="true">{{ chevronIcon }}</span>
-    </summary>
-    <div class="directory-readme-body">
+    </header>
+    <div
+      ref="body"
+      class="directory-readme-body"
+      :class="{ 'is-collapsed': !expanded, 'has-overflow': isOverflowing }"
+    >
       <div
+        ref="content"
         class="directory-readme-content"
         :class="{ 'dark-mode': darkMode }"
         v-html="renderedContent"
       ></div>
     </div>
-  </details>
+    <button
+      v-if="isOverflowing"
+      type="button"
+      class="directory-readme-toggle"
+      :aria-expanded="expanded"
+      @click="toggleExpanded"
+    >
+      <span>{{ toggleLabel }}</span>
+      <span class="material-symbols-outlined" aria-hidden="true">{{ toggleIcon }}</span>
+    </button>
+  </section>
 </template>
 
 <script lang="ts">
@@ -33,6 +46,13 @@ import { renderMarkdown } from "@/utils/markdown";
 
 export default {
   name: "DirectoryReadme",
+  data() {
+    return {
+      expanded: false,
+      isOverflowing: false,
+      resizeObserver: null as ResizeObserver | null,
+    };
+  },
   props: {
     content: {
       type: String,
@@ -55,16 +75,43 @@ export default {
     titleIcon() {
       return "markdown";
     },
-    chevronIcon() {
-      return "expand_more";
+    toggleIcon() {
+      return this.expanded ? "expand_less" : "expand_more";
+    },
+    toggleLabel() {
+      return this.expanded ? "Show less" : "Show full README";
     },
     renderedContent() {
       return renderMarkdown(this.content, this.filePath, this.source, true);
     },
   },
+  watch: {
+    renderedContent() {
+      this.expanded = false;
+      this.$nextTick(this.checkOverflow);
+    },
+  },
+  mounted() {
+    this.resizeObserver = new ResizeObserver(() => {
+      if (!this.expanded) this.checkOverflow();
+    });
+    this.resizeObserver.observe(this.$refs.content as Element);
+    this.$nextTick(this.checkOverflow);
+  },
+  beforeUnmount() {
+    this.resizeObserver?.disconnect();
+  },
   methods: {
     handleInteraction() {
       this.$emit("interact");
+    },
+    checkOverflow() {
+      const body = this.$refs.body as HTMLElement | undefined;
+      if (body) this.isOverflowing = body.scrollHeight > body.clientHeight + 1;
+    },
+    toggleExpanded() {
+      this.expanded = !this.expanded;
+      if (!this.expanded) this.$nextTick(this.checkOverflow);
     },
   },
 };
@@ -79,37 +126,16 @@ export default {
   user-select: text;
   background: var(--alt-background);
   border: 1px solid color-mix(in srgb, var(--textPrimary) 16%, transparent);
-  border-left: 0.2em solid var(--primaryColor);
   border-radius: 0.65em;
 }
 
 .directory-readme-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   min-height: 2.6em;
-  padding: 0.2em 0.35em 0.2em 0.8em;
-  cursor: pointer;
-  list-style: none;
+  padding: 0.2em 0.8em;
   user-select: none;
-  transition: background-color 150ms ease;
-}
-
-.directory-readme-header::-webkit-details-marker {
-  display: none;
-}
-
-.directory-readme[open] .directory-readme-header {
   border-bottom: 1px solid color-mix(in srgb, var(--textPrimary) 10%, transparent);
-}
-
-.directory-readme-header:hover {
-  background: color-mix(in srgb, var(--primaryColor) 5%, transparent);
-}
-
-.directory-readme-header:focus-visible {
-  outline: 2px solid var(--primaryColor);
-  outline-offset: -2px;
 }
 
 .directory-readme-title {
@@ -127,21 +153,25 @@ export default {
   font-size: 1.25em;
 }
 
-.directory-readme-chevron {
-  margin-left: auto;
-  color: var(--textPrimary);
-  font-size: 1.4em;
-  transition: color 150ms ease, transform 180ms ease;
-}
-
-.directory-readme[open] .directory-readme-chevron {
-  color: var(--primaryColor);
-  transform: rotate(180deg);
-}
-
 .directory-readme-body {
+  position: relative;
   min-height: 0;
+}
+
+.directory-readme-body.is-collapsed {
+  max-height: 24rem;
   overflow: hidden;
+}
+
+.directory-readme-body.is-collapsed.has-overflow::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 5rem;
+  pointer-events: none;
+  content: "";
+  background: linear-gradient(to bottom, transparent, var(--alt-background));
 }
 
 .directory-readme-content {
@@ -150,6 +180,37 @@ export default {
   padding: 1em 1.25em;
   overflow-wrap: break-word;
   word-break: break-word;
+}
+
+.directory-readme-toggle {
+  display: flex;
+  gap: 0.35em;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 2.75em;
+  padding: 0.45em 1em;
+  color: var(--primaryColor);
+  font: inherit;
+  font-size: 0.9em;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--alt-background);
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--textPrimary) 10%, transparent);
+}
+
+.directory-readme-toggle:hover {
+  background: color-mix(in srgb, var(--primaryColor) 7%, var(--alt-background));
+}
+
+.directory-readme-toggle:focus-visible {
+  outline: 2px solid var(--primaryColor);
+  outline-offset: -2px;
+}
+
+.directory-readme-toggle .material-symbols-outlined {
+  font-size: 1.3em;
 }
 
 .directory-readme-content :deep(> :first-child) {
@@ -212,10 +273,4 @@ export default {
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .directory-readme-chevron,
-  .directory-readme-header {
-    transition: none;
-  }
-}
 </style>

--- a/frontend/src/components/files/DirectoryReadme.vue
+++ b/frontend/src/components/files/DirectoryReadme.vue
@@ -1,8 +1,8 @@
 <template>
-  <section
+  <details
     class="directory-readme"
     aria-label="Directory README"
-    tabindex="0"
+    open
     @click.stop
     @contextmenu.stop
     @dblclick.stop
@@ -11,12 +11,21 @@
     @touchend.stop
     @touchstart.stop="handleInteraction"
   >
-    <div
-      class="directory-readme-content"
-      :class="{ 'dark-mode': darkMode }"
-      v-html="renderedContent"
-    ></div>
-  </section>
+    <summary class="directory-readme-header">
+      <div class="directory-readme-title">
+        <span class="material-symbols-outlined">{{ titleIcon }}</span>
+        <span>README.md</span><!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
+      </div>
+      <span class="directory-readme-chevron material-symbols-outlined">{{ chevronIcon }}</span>
+    </summary>
+    <div class="directory-readme-body">
+      <div
+        class="directory-readme-content"
+        :class="{ 'dark-mode': darkMode }"
+        v-html="renderedContent"
+      ></div>
+    </div>
+  </details>
 </template>
 
 <script lang="ts">
@@ -43,15 +52,18 @@ export default {
     },
   },
   computed: {
+    titleIcon() {
+      return "markdown";
+    },
+    chevronIcon() {
+      return "expand_more";
+    },
     renderedContent() {
       return renderMarkdown(this.content, this.filePath, this.source, true);
     },
   },
   methods: {
-    handleInteraction(event: Event) {
-      if (event.currentTarget instanceof HTMLElement) {
-        event.currentTarget.focus({ preventScroll: true });
-      }
+    handleInteraction() {
       this.$emit("interact");
     },
   },
@@ -63,7 +75,73 @@ export default {
   box-sizing: border-box;
   width: calc(100% - 2em);
   margin: 0 1em 1.25em;
+  overflow: hidden;
   user-select: text;
+  background: var(--alt-background);
+  border: 1px solid color-mix(in srgb, var(--textPrimary) 16%, transparent);
+  border-left: 0.2em solid var(--primaryColor);
+  border-radius: 0.65em;
+}
+
+.directory-readme-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 2.6em;
+  padding: 0.2em 0.35em 0.2em 0.8em;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  transition: background-color 150ms ease;
+}
+
+.directory-readme-header::-webkit-details-marker {
+  display: none;
+}
+
+.directory-readme[open] .directory-readme-header {
+  border-bottom: 1px solid color-mix(in srgb, var(--textPrimary) 10%, transparent);
+}
+
+.directory-readme-header:hover {
+  background: color-mix(in srgb, var(--primaryColor) 5%, transparent);
+}
+
+.directory-readme-header:focus-visible {
+  outline: 2px solid var(--primaryColor);
+  outline-offset: -2px;
+}
+
+.directory-readme-title {
+  display: flex;
+  gap: 0.5em;
+  align-items: center;
+  color: var(--textPrimary);
+  font-family: 'SFMono-Regular', 'Monaco', 'Inconsolata', 'Liberation Mono', monospace;
+  font-size: 0.82em;
+  font-weight: 500;
+}
+
+.directory-readme-title .material-symbols-outlined {
+  color: var(--primaryColor);
+  font-size: 1.25em;
+}
+
+.directory-readme-chevron {
+  margin-left: auto;
+  color: var(--textPrimary);
+  font-size: 1.4em;
+  transition: color 150ms ease, transform 180ms ease;
+}
+
+.directory-readme[open] .directory-readme-chevron {
+  color: var(--primaryColor);
+  transform: rotate(180deg);
+}
+
+.directory-readme-body {
+  min-height: 0;
+  overflow: hidden;
 }
 
 .directory-readme-content {
@@ -72,9 +150,6 @@ export default {
   padding: 1em 1.25em;
   overflow-wrap: break-word;
   word-break: break-word;
-  background: var(--alt-background);
-  border: 1px solid color-mix(in srgb, var(--textPrimary) 12%, transparent);
-  border-radius: 1em;
 }
 
 .directory-readme-content :deep(> :first-child) {
@@ -86,8 +161,26 @@ export default {
 }
 
 .directory-readme-content :deep(img) {
+  display: block;
   max-width: 100%;
+  max-height: 32rem;
   height: auto;
+  margin: 1em 0;
+  object-fit: contain;
+  border: 1px solid color-mix(in srgb, var(--textPrimary) 10%, transparent);
+  border-radius: 0.5em;
+}
+
+.directory-readme-content :deep(a) {
+  color: var(--primaryColor);
+  text-underline-offset: 0.15em;
+}
+
+.directory-readme-content :deep(blockquote) {
+  margin-left: 0;
+  padding-left: 1em;
+  color: color-mix(in srgb, var(--textPrimary) 72%, transparent);
+  border-left: 0.2em solid color-mix(in srgb, var(--primaryColor) 55%, transparent);
 }
 
 .directory-readme-content :deep(pre) {
@@ -112,6 +205,17 @@ export default {
 
   .directory-readme-content {
     padding: 0.8em 1em;
+  }
+
+  .directory-readme-content :deep(img) {
+    max-height: 22rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .directory-readme-chevron,
+  .directory-readme-header {
+    transition: none;
   }
 }
 </style>

--- a/frontend/src/components/files/DirectoryReadme.vue
+++ b/frontend/src/components/files/DirectoryReadme.vue
@@ -12,11 +12,11 @@
     @touchstart.stop="handleInteraction"
   >
     <summary class="directory-readme-header">
-      <div class="directory-readme-title">
-        <span class="material-symbols-outlined">{{ titleIcon }}</span>
+      <span class="directory-readme-title">
+        <span class="material-symbols-outlined" aria-hidden="true">{{ titleIcon }}</span>
         <span>README.md</span><!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
-      </div>
-      <span class="directory-readme-chevron material-symbols-outlined">{{ chevronIcon }}</span>
+      </span>
+      <span class="directory-readme-chevron material-symbols-outlined" aria-hidden="true">{{ chevronIcon }}</span>
     </summary>
     <div class="directory-readme-body">
       <div

--- a/frontend/src/components/files/DirectoryReadme.vue
+++ b/frontend/src/components/files/DirectoryReadme.vue
@@ -124,8 +124,8 @@ export default {
   margin: 0 1em 1.25em;
   overflow: hidden;
   user-select: text;
-  background: var(--alt-background);
-  border: 1px solid color-mix(in srgb, var(--textPrimary) 16%, transparent);
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--textPrimary) 10%, transparent);
   border-radius: 0.65em;
 }
 
@@ -135,7 +135,7 @@ export default {
   min-height: 2.6em;
   padding: 0.2em 0.8em;
   user-select: none;
-  border-bottom: 1px solid color-mix(in srgb, var(--textPrimary) 10%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--textPrimary) 7%, transparent);
 }
 
 .directory-readme-title {
@@ -171,7 +171,7 @@ export default {
   height: 5rem;
   pointer-events: none;
   content: "";
-  background: linear-gradient(to bottom, transparent, var(--alt-background));
+  background: linear-gradient(to bottom, transparent, var(--background));
 }
 
 .directory-readme-content {
@@ -195,13 +195,13 @@ export default {
   font-size: 0.9em;
   font-weight: 600;
   cursor: pointer;
-  background: var(--alt-background);
+  background: transparent;
   border: 0;
-  border-top: 1px solid color-mix(in srgb, var(--textPrimary) 10%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--textPrimary) 7%, transparent);
 }
 
 .directory-readme-toggle:hover {
-  background: color-mix(in srgb, var(--primaryColor) 7%, var(--alt-background));
+  background: color-mix(in srgb, var(--primaryColor) 5%, transparent);
 }
 
 .directory-readme-toggle:focus-visible {

--- a/frontend/src/components/files/DirectoryReadme.vue
+++ b/frontend/src/components/files/DirectoryReadme.vue
@@ -1,0 +1,117 @@
+<template>
+  <section
+    class="directory-readme"
+    aria-label="Directory README"
+    tabindex="0"
+    @click.stop
+    @contextmenu.stop
+    @dblclick.stop
+    @keydown.stop
+    @mousedown.stop="handleInteraction"
+    @touchend.stop
+    @touchstart.stop="handleInteraction"
+  >
+    <div
+      class="directory-readme-content"
+      :class="{ 'dark-mode': darkMode }"
+      v-html="renderedContent"
+    ></div>
+  </section>
+</template>
+
+<script lang="ts">
+import { renderMarkdown } from "@/utils/markdown";
+
+export default {
+  name: "DirectoryReadme",
+  props: {
+    content: {
+      type: String,
+      required: true,
+    },
+    filePath: {
+      type: String,
+      required: true,
+    },
+    source: {
+      type: String,
+      required: true,
+    },
+    darkMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    renderedContent() {
+      return renderMarkdown(this.content, this.filePath, this.source, true);
+    },
+  },
+  methods: {
+    handleInteraction(event: Event) {
+      if (event.currentTarget instanceof HTMLElement) {
+        event.currentTarget.focus({ preventScroll: true });
+      }
+      this.$emit("interact");
+    },
+  },
+};
+</script>
+
+<style scoped>
+.directory-readme {
+  box-sizing: border-box;
+  width: calc(100% - 2em);
+  margin: 0 1em 1.25em;
+  user-select: text;
+}
+
+.directory-readme-content {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 1em 1.25em;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  background: var(--alt-background);
+  border: 1px solid color-mix(in srgb, var(--textPrimary) 12%, transparent);
+  border-radius: 1em;
+}
+
+.directory-readme-content :deep(> :first-child) {
+  margin-top: 0;
+}
+
+.directory-readme-content :deep(> :last-child) {
+  margin-bottom: 0;
+}
+
+.directory-readme-content :deep(img) {
+  max-width: 100%;
+  height: auto;
+}
+
+.directory-readme-content :deep(pre) {
+  max-width: 100%;
+  padding: 0.8em;
+  overflow-x: auto;
+  background: color-mix(in srgb, var(--background) 85%, transparent);
+  border-radius: 0.5em;
+}
+
+.directory-readme-content :deep(code:not(pre code)) {
+  padding: 0.2em 0.35em;
+  background: color-mix(in srgb, var(--background) 85%, transparent);
+  border-radius: 0.35em;
+}
+
+@media (max-width: 768px) {
+  .directory-readme {
+    width: calc(100% - 1em);
+    margin: 0 0.5em 1em;
+  }
+
+  .directory-readme-content {
+    padding: 0.8em 1em;
+  }
+}
+</style>

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -651,6 +651,13 @@ export const mutations = {
     state.req = value;
     emitStateChanged();
   },
+  setDirectoryReadme: ({ source, path, readme }) => {
+    if (state.req?.type !== "directory" || state.req.source !== source || state.req.path !== path) {
+      return;
+    }
+    state.req = { ...state.req, readme };
+    emitStateChanged();
+  },
   /** Merge media metadata into current directory listing (state.req.items) by file name. */
   patchRequestMetadata: (metadataItems) => {
     if (!state.req?.items || !metadataItems?.length) {

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -23,6 +23,11 @@ export interface ReqObject {
 
   // Directory listing properties
   listing?: unknown[];
+  readme?: {
+    content: string;
+    path: string;
+    source: string;
+  };
 }
 
 export interface ShareInfoObject {

--- a/frontend/src/utils/markdown.test.js
+++ b/frontend/src/utils/markdown.test.js
@@ -79,15 +79,12 @@ describe("renderMarkdown", () => {
     expect(rendered).toContain('href="https://example.com"');
     expect(rendered).toContain('rel="noopener noreferrer"');
     expect(rendered).not.toContain("style=");
-    expect(rendered).toContain('src="https://tracker.example/pixel.png"');
-    expect(rendered).toContain('loading="lazy"');
-    expect(rendered).toContain('decoding="async"');
-    expect(rendered).toContain('referrerpolicy="no-referrer"');
+    expect(rendered).not.toContain("tracker.example");
     expect(rendered).not.toContain("<form");
     expect(rendered).not.toContain("<input");
   });
 
-  it("blocks insecure external images", () => {
+  it("blocks external images", () => {
     const rendered = renderMarkdown(
       "![Tracker](http://tracker.example/pixel.png)",
       "/README.md",

--- a/frontend/src/utils/markdown.test.js
+++ b/frontend/src/utils/markdown.test.js
@@ -79,9 +79,23 @@ describe("renderMarkdown", () => {
     expect(rendered).toContain('href="https://example.com"');
     expect(rendered).toContain('rel="noopener noreferrer"');
     expect(rendered).not.toContain("style=");
-    expect(rendered).not.toContain("tracker.example");
+    expect(rendered).toContain('src="https://tracker.example/pixel.png"');
+    expect(rendered).toContain('loading="lazy"');
+    expect(rendered).toContain('decoding="async"');
+    expect(rendered).toContain('referrerpolicy="no-referrer"');
     expect(rendered).not.toContain("<form");
     expect(rendered).not.toContain("<input");
+  });
+
+  it("blocks insecure external images", () => {
+    const rendered = renderMarkdown(
+      "![Tracker](http://tracker.example/pixel.png)",
+      "/README.md",
+      "shared",
+      true,
+    );
+
+    expect(rendered).not.toContain("tracker.example");
   });
 
   it("rewrites relative links to explicit file routes for inline READMEs", () => {

--- a/frontend/src/utils/markdown.test.js
+++ b/frontend/src/utils/markdown.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/constants", () => ({
+  globalVars: {
+    baseURL: "/",
+    externalUrl: "",
+  },
+}));
+
+vi.mock("@/store", () => ({
+  getters: { isShare: () => false },
+  state: { shareInfo: { subPath: "", hash: "", token: "" } },
+}));
+
+vi.mock("@/api/resources", () => ({
+  getDownloadURL: (_source, path) =>
+    `http://localhost/api/resources/download?file=${encodeURIComponent(path)}&inline=true`,
+  getDownloadURLPublic: () => "http://localhost/public/download",
+}));
+
+import {
+  DIRECTORY_README_MAX_BYTES,
+  findDirectoryReadme,
+  readTextResponseUpTo,
+  renderMarkdown,
+} from "./markdown";
+
+describe("findDirectoryReadme", () => {
+  it("finds a markdown README without case sensitivity", () => {
+    const readme = findDirectoryReadme({
+      type: "directory",
+      items: [
+        { name: "notes.md", type: "text/markdown" },
+        { name: "ReadMe.md", type: "text/markdown" },
+      ],
+    });
+
+    expect(readme?.name).toBe("ReadMe.md");
+  });
+
+  it("ignores directories named README.md", () => {
+    expect(findDirectoryReadme({
+      type: "directory",
+      items: [{ name: "README.md", type: "directory" }],
+    })).toBeNull();
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("sanitizes unsafe HTML", () => {
+    const rendered = renderMarkdown(
+      "# Welcome\n<script>alert('bad')</script><a href=\"javascript:alert(1)\">bad</a>",
+      "/README.md",
+      "shared",
+    );
+
+    expect(rendered).toContain("<h1>Welcome</h1>");
+    expect(rendered).not.toContain("<script");
+    expect(rendered).not.toContain("javascript:");
+  });
+
+  it("rewrites relative image references through the preview endpoint", () => {
+    const rendered = renderMarkdown("![Logo](images/logo.png)", "/docs/README.md", "shared");
+
+    expect(rendered).toContain(encodeURIComponent("/docs/images/logo.png"));
+  });
+
+  it("hardens automatically rendered Markdown", () => {
+    const rendered = renderMarkdown(
+      '[external](https://example.com)' +
+        '<p style="position:fixed;inset:0">overlay</p>' +
+        '![Tracker](https://tracker.example/pixel.png)' +
+        '<form><input value="phishing"></form>',
+      "/README.md",
+      "shared",
+      true,
+    );
+
+    expect(rendered).toContain('href="https://example.com"');
+    expect(rendered).toContain('rel="noopener noreferrer"');
+    expect(rendered).not.toContain("style=");
+    expect(rendered).not.toContain("tracker.example");
+    expect(rendered).not.toContain("<form");
+    expect(rendered).not.toContain("<input");
+  });
+
+  it("rewrites relative links to explicit file routes for inline READMEs", () => {
+    const rendered = renderMarkdown("[Guide](guide.md#intro)", "/docs/README.md", "shared", true);
+
+    expect(rendered).toContain('href="/files/shared/docs/guide.md#intro"');
+  });
+
+  it("defines a conservative automatic rendering limit", () => {
+    expect(DIRECTORY_README_MAX_BYTES).toBe(262144);
+  });
+});
+
+describe("readTextResponseUpTo", () => {
+  it("reads a response within the byte limit", async () => {
+    const response = new Response("# Welcome");
+
+    await expect(readTextResponseUpTo(response, 64)).resolves.toBe("# Welcome");
+  });
+
+  it("cancels a response exceeding the byte limit", async () => {
+    const response = new Response("x".repeat(65));
+
+    await expect(readTextResponseUpTo(response, 64)).resolves.toBeNull();
+  });
+});

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -68,9 +68,7 @@ function hardenInlineMarkdown(html: string): string {
       const resourceUrl = new URL(src, window.location.origin);
       const sameOriginDownload = resourceUrl.origin === window.location.origin &&
         resourceUrl.pathname.endsWith("/api/resources/download");
-      const externalHttpsImage = resourceUrl.origin !== window.location.origin &&
-        resourceUrl.protocol === "https:";
-      if (!sameOriginDownload && !externalHttpsImage) {
+      if (!sameOriginDownload) {
         image.remove();
         continue;
       }

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -39,7 +39,7 @@ const INLINE_MARKDOWN_SANITIZE_CONFIG = {
     "tr",
     "ul",
   ],
-  ALLOWED_ATTR: ["alt", "href", "loading", "referrerpolicy", "rel", "src", "title"],
+  ALLOWED_ATTR: ["alt", "decoding", "href", "loading", "referrerpolicy", "rel", "src", "title"],
   FORBID_TAGS: [
     "audio",
     "button",
@@ -66,8 +66,11 @@ function hardenInlineMarkdown(html: string): string {
     const src = image.getAttribute("src") || "";
     try {
       const resourceUrl = new URL(src, window.location.origin);
-      if (resourceUrl.origin !== window.location.origin ||
-          !resourceUrl.pathname.endsWith("/api/resources/download")) {
+      const sameOriginDownload = resourceUrl.origin === window.location.origin &&
+        resourceUrl.pathname.endsWith("/api/resources/download");
+      const externalHttpsImage = resourceUrl.origin !== window.location.origin &&
+        resourceUrl.protocol === "https:";
+      if (!sameOriginDownload && !externalHttpsImage) {
         image.remove();
         continue;
       }
@@ -75,6 +78,7 @@ function hardenInlineMarkdown(html: string): string {
       image.remove();
       continue;
     }
+    image.setAttribute("decoding", "async");
     image.setAttribute("loading", "lazy");
     image.setAttribute("referrerpolicy", "no-referrer");
   }

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -1,0 +1,162 @@
+import DOMPurify from "dompurify";
+import { Marked } from "marked";
+import {
+  buildPreviewResourceUrl,
+  isLocalResourceReference,
+} from "@/utils/htmlPreview";
+import { buildItemUrl, resolveRelativePath } from "@/utils/url";
+
+export const DIRECTORY_README_MAX_BYTES = 256 * 1024;
+
+const INLINE_MARKDOWN_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: [
+    "a",
+    "blockquote",
+    "br",
+    "code",
+    "del",
+    "details",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "img",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "strong",
+    "summary",
+    "table",
+    "tbody",
+    "td",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+  ],
+  ALLOWED_ATTR: ["alt", "href", "loading", "referrerpolicy", "rel", "src", "title"],
+  FORBID_TAGS: [
+    "audio",
+    "button",
+    "embed",
+    "form",
+    "iframe",
+    "input",
+    "math",
+    "object",
+    "select",
+    "source",
+    "svg",
+    "textarea",
+    "video",
+  ],
+  FORBID_ATTR: ["autoplay", "class", "formaction", "id", "poster", "srcset", "style"],
+};
+
+function hardenInlineMarkdown(html: string): string {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+
+  for (const image of template.content.querySelectorAll("img")) {
+    const src = image.getAttribute("src") || "";
+    try {
+      const resourceUrl = new URL(src, window.location.origin);
+      if (resourceUrl.origin !== window.location.origin ||
+          !resourceUrl.pathname.endsWith("/api/resources/download")) {
+        image.remove();
+        continue;
+      }
+    } catch {
+      image.remove();
+      continue;
+    }
+    image.setAttribute("loading", "lazy");
+    image.setAttribute("referrerpolicy", "no-referrer");
+  }
+
+  for (const link of template.content.querySelectorAll("a")) {
+    link.setAttribute("rel", "noopener noreferrer");
+  }
+
+  return template.innerHTML;
+}
+
+export function renderMarkdown(
+  content: string,
+  filePath: string,
+  source: string,
+  inline = false,
+): string {
+  const parser = new Marked({ gfm: true });
+  if (inline) {
+    parser.use({
+      renderer: {
+        html() {
+          return "";
+        },
+      },
+    });
+  }
+  parser.use({
+    walkTokens(token) {
+      if (token.type === "image" && token.href) {
+        token.href = buildPreviewResourceUrl(token.href, filePath, source);
+      }
+      if (inline && token.type === "link" && token.href && isLocalResourceReference(token.href)) {
+        const suffixIndex = token.href.search(/[?#]/);
+        const pathPart = suffixIndex === -1 ? token.href : token.href.slice(0, suffixIndex);
+        const suffix = suffixIndex === -1 ? "" : token.href.slice(suffixIndex);
+        token.href = `${buildItemUrl(source, resolveRelativePath(filePath, pathPart), true)}${suffix}`;
+      }
+    },
+  });
+
+  const result = parser.parse(content);
+  const sanitized = DOMPurify.sanitize(
+    typeof result === "string" ? result : "Loading...",
+    inline ? INLINE_MARKDOWN_SANITIZE_CONFIG : undefined,
+  );
+  return inline ? hardenInlineMarkdown(sanitized) : sanitized;
+}
+
+export async function readTextResponseUpTo(response: Response, maxBytes: number) {
+  if (!response.body) {
+    return null;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let total = 0;
+  let content = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return content + decoder.decode();
+    }
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    content += decoder.decode(value, { stream: true });
+  }
+}
+
+export function findDirectoryReadme(listing: {
+  type?: string;
+  items?: Array<{ name?: string; type?: string }>;
+}) {
+  if (listing?.type !== "directory" || !Array.isArray(listing.items)) {
+    return null;
+  }
+
+  return listing.items.find(
+    (item) => item.type !== "directory" && item.name?.toLowerCase() === "readme.md",
+  ) ?? null;
+}

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -30,6 +30,11 @@ import { extractSourceFromPath } from "@/utils/url";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import { globalVars } from "@/utils/constants";
 import { isRichTextPreviewMimeType } from "@/utils/mimetype";
+import {
+  DIRECTORY_README_MAX_BYTES,
+  findDirectoryReadme,
+  readTextResponseUpTo,
+} from "@/utils/markdown";
 
 function directoryListingHasMediaChildren(req) {
   return (
@@ -37,6 +42,8 @@ function directoryListingHasMediaChildren(req) {
     req.items?.some((i) => i.type?.startsWith("audio") || i.type?.startsWith("video"))
   );
 }
+
+let directoryReadmeRequestGeneration = 0;
 
 /** @returns {Promise<{ items?: object[], name: string, type: string, path: string, source: string, hash?: string, token?: string, parentDirItems?: object[] }>} */
 async function fetchShareItemWithParent(sharePassword) {
@@ -210,12 +217,48 @@ export default {
     window.addEventListener("keydown", this.keyEvent);
   },
   beforeUnmount() {
+    directoryReadmeRequestGeneration++;
     window.removeEventListener("keydown", this.keyEvent);
   },
   unmounted() {
     mutations.replaceRequest({}); // Use mutation
   },
   methods: {
+    async attachDirectoryReadme(listing, requestGeneration) {
+      const readmeItem = findDirectoryReadme(listing);
+      if (!readmeItem ||
+          getters.fileViewingDisabled(readmeItem.name) ||
+          Number(readmeItem.size) > DIRECTORY_README_MAX_BYTES) {
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          resourcesApi.getDownloadURL(listing.source, readmeItem.path, true, false),
+          {
+            credentials: "same-origin",
+            headers: { Range: `bytes=0-${DIRECTORY_README_MAX_BYTES}` },
+          },
+        );
+        if (!response.ok) {
+          return;
+        }
+        const content = await readTextResponseUpTo(response, DIRECTORY_README_MAX_BYTES);
+        if (content && requestGeneration === directoryReadmeRequestGeneration) {
+          mutations.setDirectoryReadme({
+            source: listing.source,
+            path: listing.path,
+            readme: {
+            content,
+            path: readmeItem.path,
+            source: readmeItem.source || listing.source,
+            },
+          });
+        }
+      } catch (error) {
+        console.warn("Unable to load directory README", error);
+      }
+    },
     scrollToHash() {
       let scrollToId = "";
       let targetName = "";
@@ -276,6 +319,7 @@ export default {
     },
 
     async fetchData() {
+      const readmeRequestGeneration = ++directoryReadmeRequestGeneration;
       const hash = getters.shareHash();
       const isShare = hash !== "";
 
@@ -478,6 +522,7 @@ export default {
           }
           document.title = `${globalVars.name} - ${this.$t("general.files")} - ${res.name}`;
           mutations.replaceRequest(res);
+          void this.attachDirectoryReadme(res, readmeRequestGeneration);
           mutations.setLoading("files", false);
           await this.patchMediaMetadataIfNeeded(res, () =>
             mediaApi.fetchDirectoryMediaMetadata(fetchSource, fetchPath)

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -237,7 +237,7 @@ export default {
           resourcesApi.getDownloadURL(listing.source, readmeItem.path, true, false),
           {
             credentials: "same-origin",
-            headers: { Range: `bytes=0-${DIRECTORY_README_MAX_BYTES}` },
+            headers: { Range: `bytes=0-${DIRECTORY_README_MAX_BYTES - 1}` },
           },
         );
         if (!response.ok) {

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -22,6 +22,15 @@
       :style="itemStyles"
       class="listing-items"
     >
+      <DirectoryReadme
+        v-if="req.readme?.content"
+        :content="req.readme.content"
+        :file-path="req.readme.path"
+        :source="req.readme.source"
+        :dark-mode="isDarkMode"
+        @interact="clearReadmeSelection"
+      />
+
       <!-- Rectangle selection overlay -->
       <div class="selection-rectangle" :style="rectangleStyle"></div>
 
@@ -188,6 +197,7 @@ import { readAllDirectoryEntries } from "@/utils/upload";
 import Item from "@/components/files/ListingItem.vue";
 import Upload from "@/components/prompts/Upload.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
+import DirectoryReadme from "@/components/files/DirectoryReadme.vue";
 
 export default {
   name: "listingView",
@@ -195,6 +205,7 @@ export default {
     Item,
     Upload,
     LoadingSpinner,
+    DirectoryReadme,
   },
   data() {
     return {
@@ -561,6 +572,9 @@ export default {
     }
   },
   methods: {
+    clearReadmeSelection() {
+      mutations.resetSelected();
+    },
     handleGlobalDragEnd() {
       // Reset drag state for all items (replaces per-item dragend listeners)
       const items = this.$el?.querySelectorAll('.listing-item.drag-hover, .listing-item.half-selected');
@@ -766,6 +780,14 @@ export default {
       }
     },
     keyEvent(event) {
+      const selection = window.getSelection();
+      const selectionElement = selection?.anchorNode instanceof Element
+        ? selection.anchorNode
+        : selection?.anchorNode?.parentElement;
+      if (event.target?.closest?.('.directory-readme') ||
+          (selection?.toString() && selectionElement?.closest?.('.directory-readme'))) {
+        return;
+      }
       const { key, ctrlKey, metaKey, altKey, which } = event;
       const isArrowKey = key === 'ArrowUp' ||
                          key === 'ArrowDown' ||
@@ -1266,7 +1288,7 @@ export default {
     },
     startRectangleSelection(event) {
       // Start rectangle selection when clicking on empty space - don't start if the click was in the status bar, an item or the header
-      if (event.target.closest('.listing-item') || event.target.closest('.header') || event.target.closest('#status-bar')) {
+      if (event.target.closest('.listing-item') || event.target.closest('.directory-readme') || event.target.closest('.header') || event.target.closest('#status-bar')) {
         return;
       }
 

--- a/frontend/src/views/files/MarkdownViewer.vue
+++ b/frontend/src/views/files/MarkdownViewer.vue
@@ -18,8 +18,6 @@
 </template>
 
 <script lang="ts">
-import { Marked } from "marked";
-import DOMPurify from 'dompurify';
 import { state, mutations, getters } from "@/store";
 import hljs from 'highlight.js';
 import { copyToClipboard } from "@/utils/clipboard";
@@ -27,8 +25,8 @@ import { globalVars } from "@/utils/constants";
 import { isHtmlMimeType } from "@/utils/mimetype";
 import {
   buildHtmlPreview,
-  buildPreviewResourceUrl,
 } from "@/utils/htmlPreview";
+import { renderMarkdown } from "@/utils/markdown";
 
 import githubLightCss from "highlight.js/styles/github.min.css?raw";
 import githubDarkCss from "highlight.js/styles/github-dark.min.css?raw";
@@ -256,21 +254,6 @@ export default {
       div.textContent = text;
       return div.innerHTML;
     },
-    parseMarkdown(content: string, filePath: string, source: string): string {
-      const parser = new Marked({ gfm: true });
-      parser.use({
-        walkTokens(token) {
-          if (token.type === "image" && token.href) {
-            token.href = buildPreviewResourceUrl(token.href, filePath, source);
-          }
-        },
-      });
-      const result = parser.parse(content);
-      if (typeof result !== "string") {
-        return DOMPurify.sanitize("Loading...");
-      }
-      return DOMPurify.sanitize(result);
-    },
     updateEditorStats() {
       const text = this.content.trim();
       const validWord = text.split(/\s+/).filter(t => /[a-zA-Z0-9]/.test(t));
@@ -332,7 +315,7 @@ export default {
       return buildHtmlPreview(this.content, state.req.path, state.req.source);
     },
     renderedContent() {
-      return this.parseMarkdown(this.content, state.req.path, state.req.source);
+      return renderMarkdown(this.content, state.req.path, state.req.source);
     },
     spaceForStatusBar() {
       return state.isMobile ? 3.1 : 3.5;


### PR DESCRIPTION
## Summary

- automatically render an accessible `README.md` preview above authenticated directory listings
- limit long previews to roughly 15 text lines with a bottom fade and explicit expand/collapse control
- omit the fade and control when the README fits within the preview
- keep the README as a normal file that can still be opened and edited
- reuse the existing sanitized Markdown pipeline with stricter rules for automatic rendering
- load asynchronously without blocking listings and discard stale navigation responses
- cap implicit reads at 256 KiB with a bounded range request

## Security and scope

Inline rendering strips raw HTML, forms, styles, external images, and embedded media. Relative images use the existing authenticated download route, and relative links resolve to FileBrowser routes. Public shares are deliberately excluded because implicit content requests can consume share download quotas.

## Validation

- `npm test` (42 tests passed)
- `npm run typecheck`
- targeted component lint
- `npm run build:docker`
- desktop and 390px mobile browser verification against the built slim image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added previews for `README.md` files within directories.
  * README content supports Markdown formatting, images, links, dark mode, and expandable/collapsible display.
  * Added secure Markdown rendering with sanitization and protected resource loading.
  * Directory README content is limited to 256 KB.

* **Bug Fixes**
  * Prevented README interactions from triggering file selection, navigation, or keyboard shortcuts.
  * Prevented outdated README requests from overwriting current directory content.

* **Tests**
  * Added coverage for README discovery, rendering, sanitization, resource handling, and size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->