### PR TITLE
add default migration path behavior

### DIFF
--- a/backend/cmd/migrate.go
+++ b/backend/cmd/migrate.go
@@ -38,10 +38,10 @@ func checkMigrationNeeded() bool {
 
 // validateDatabasePaths enforces database path rules before opening or creating SQLite:
 //  1. On a fresh install, fail if server.database.path is database.db or an unrenamed
-//     legacy BoltDB file (database.db) is present in the working directory.
-//  2. On a fresh install with server.database.migrateFrom set, fail if the legacy BoltDB file is missing
+//     legacy database file (database.db) is present in the working directory.
+//  2. On a fresh install with server.database.migrateFrom set, fail if the legacy database file is missing
 //     or empty.
-//  3. When SQLite already exists and server.database.migrateFrom is set, fail if the legacy BoltDB file
+//  3. When SQLite already exists and server.database.migrateFrom is set, fail if the legacy database file
 //     is missing or empty.
 //
 // Otherwise the existing SQLite database is used, or a new one is created on first open.
@@ -96,7 +96,7 @@ func legacyBoltDatabaseError(boltPath, sqlitePath string, freshInstall bool) err
 		}
 		return migrationErrf(
 			`server.database.migrateFrom is %q but cannot be read: %v. `+
-				`Check file permissions or restore your backed-up BoltDB file.`,
+				`Check file permissions or restore your backed-up database file.`,
 			boltPath, err,
 		)
 	}
@@ -104,7 +104,7 @@ func legacyBoltDatabaseError(boltPath, sqlitePath string, freshInstall bool) err
 		if freshInstall {
 			return migrationErrf(
 				`server.database.migrateFrom is %q but that file is empty, and no SQLite database exists at server.database.path (%q). `+
-					`Restore your backed-up BoltDB file or fix the migrateFrom path.`,
+					`Restore your backed-up database file or fix the migrateFrom path.`,
 				boltPath, sqlitePath,
 			)
 		}
@@ -133,18 +133,18 @@ func migrateFromBoltToSQLite() error {
 	newDBPath := settings.Config.Server.DatabaseV2.Path
 
 	logger.Info("========================================")
-	logger.Info("Starting migration from BoltDB to SQLite")
+	logger.Info("Starting migration from legacy database")
 	logger.Info("========================================")
 	// Open old BoltDB (read-only)
-	logger.Info("Opening old BoltDB...")
+	logger.Info("Opening old database...")
 	oldDB, err := storm.Open(oldDBPath)
 	if err != nil {
 		return fmt.Errorf("failed to open old database: %w", err)
 	}
 	logger.Info("✓ Old database opened")
 
-	// Initialize new SQLite database
-	logger.Info("Initializing new SQLite database...")
+	// Initialize new database
+	logger.Info("Initializing new database...")
 	sqlStore, _, err := sqldb.NewSQLStoreWithOptions(newDBPath, sqldb.NewSQLStoreOpts{SkipQuickSetup: true})
 	if err != nil {
 		oldDB.Close()

--- a/backend/cmd/migrate.go
+++ b/backend/cmd/migrate.go
@@ -58,12 +58,11 @@ func validateDatabasePaths() error {
 					`and set server.database.migrateFrom to "database.db.old".`,
 			)
 		}
-		if _, err := os.Stat(settings.LegacyDatabasePathInConfigDir()); err == nil {
+		if _, err := os.Stat("database.db"); err == nil {
 			return migrationErrf(
-				`legacy database file found next to your config (%q). `+
-					`Rename it to database.db.old, set server.database.migrateFrom to "database.db.old" `+
-					`or use migrateFrom: "default" with FILEBROWSER_DATABASE set.`,
-				settings.LegacyDatabasePathInConfigDir(),
+				`legacy database file found in the working directory. ` +
+					`Rename it to database.db.old, set server.database.migrateFrom to "database.db.old" ` +
+					`or use migrateFrom: "default".`,
 			)
 		}
 		if boltPath != "" {

--- a/backend/cmd/migrate.go
+++ b/backend/cmd/migrate.go
@@ -58,10 +58,12 @@ func validateDatabasePaths() error {
 					`and set server.database.migrateFrom to "database.db.old".`,
 			)
 		}
-		if _, err := os.Stat("database.db"); err == nil {
+		if _, err := os.Stat(settings.LegacyDatabasePathInConfigDir()); err == nil {
 			return migrationErrf(
-				`legacy database file found in the working directory. ` +
-					`Rename it to database.db.old, set server.database.migrateFrom to "database.db.old".`,
+				`legacy database file found next to your config (%q). `+
+					`Rename it to database.db.old, set server.database.migrateFrom to "database.db.old" `+
+					`or use migrateFrom: "default" with FILEBROWSER_DATABASE set.`,
+				settings.LegacyDatabasePathInConfigDir(),
 			)
 		}
 		if boltPath != "" {

--- a/backend/cmd/migrate_config_test.go
+++ b/backend/cmd/migrate_config_test.go
@@ -98,30 +98,21 @@ func TestValidateDatabasePaths_rejectsDatabaseDBAsSQLitePath(t *testing.T) {
 
 func TestValidateDatabasePaths_rejectsUnrenamedLegacyDatabaseDB(t *testing.T) {
 	dir := t.TempDir()
-	configFile := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	t.Chdir(dir)
 
 	settings.Config.Server.DatabaseV2.MigrateFrom = ""
 	settings.Config.Server.DatabaseV2.Path = filepath.Join(dir, "filebrowser.sqlite")
-	if err := os.WriteFile(filepath.Join(dir, "database.db"), []byte("legacy-bolt"), 0o600); err != nil {
+	if err := os.WriteFile("database.db", []byte("legacy-bolt"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	settings.Env.ConfigDir = dir
 
 	if err := validateDatabasePaths(); err == nil {
-		t.Fatal("expected error when unrenamed database.db exists next to config on fresh install")
+		t.Fatal("expected error when unrenamed database.db exists on fresh install")
 	}
 }
 
 func TestValidateDatabasePaths_migrateFromDefaultResolvesFromEnv(t *testing.T) {
 	dir := t.TempDir()
-	configFile := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
 	boltPath := filepath.Join(dir, "database.db.old")
 	if err := os.WriteFile(boltPath, []byte("bolt"), 0o600); err != nil {
 		t.Fatal(err)
@@ -132,8 +123,11 @@ func TestValidateDatabasePaths_migrateFromDefaultResolvesFromEnv(t *testing.T) {
 	settings.Config.Server.DatabaseV2.MigrateFrom = settings.MigrateFromDefault
 	settings.Config.Server.DatabaseV2.Path = filepath.Join(dir, "filebrowser.sqlite")
 
-	if err := settings.ResolveDatabasePaths(configFile); err != nil {
+	if err := settings.ResolveDatabasePaths(); err != nil {
 		t.Fatalf("ResolveDatabasePaths: %v", err)
+	}
+	if settings.Config.Server.DatabaseV2.MigrateFrom != boltPath {
+		t.Fatalf("migrateFrom = %q, want %q", settings.Config.Server.DatabaseV2.MigrateFrom, boltPath)
 	}
 	if err := validateDatabasePaths(); err != nil {
 		t.Fatalf("validateDatabasePaths: %v", err)

--- a/backend/cmd/migrate_config_test.go
+++ b/backend/cmd/migrate_config_test.go
@@ -98,16 +98,48 @@ func TestValidateDatabasePaths_rejectsDatabaseDBAsSQLitePath(t *testing.T) {
 
 func TestValidateDatabasePaths_rejectsUnrenamedLegacyDatabaseDB(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
-
-	settings.Config.Server.DatabaseV2.MigrateFrom = ""
-	settings.Config.Server.DatabaseV2.Path = filepath.Join(dir, "filebrowser.sqlite")
-	if err := os.WriteFile("database.db", []byte("legacy-bolt"), 0o600); err != nil {
+	configFile := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
+	settings.Config.Server.DatabaseV2.MigrateFrom = ""
+	settings.Config.Server.DatabaseV2.Path = filepath.Join(dir, "filebrowser.sqlite")
+	if err := os.WriteFile(filepath.Join(dir, "database.db"), []byte("legacy-bolt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	settings.Env.ConfigDir = dir
+
 	if err := validateDatabasePaths(); err == nil {
-		t.Fatal("expected error when unrenamed database.db exists on fresh install")
+		t.Fatal("expected error when unrenamed database.db exists next to config on fresh install")
+	}
+}
+
+func TestValidateDatabasePaths_migrateFromDefaultResolvesFromEnv(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	boltPath := filepath.Join(dir, "database.db.old")
+	if err := os.WriteFile(boltPath, []byte("bolt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("FILEBROWSER_DATABASE", boltPath)
+
+	settings.Config.Server.DatabaseV2.MigrateFrom = settings.MigrateFromDefault
+	settings.Config.Server.DatabaseV2.Path = filepath.Join(dir, "filebrowser.sqlite")
+
+	if err := settings.ResolveDatabasePaths(configFile); err != nil {
+		t.Fatalf("ResolveDatabasePaths: %v", err)
+	}
+	if err := validateDatabasePaths(); err != nil {
+		t.Fatalf("validateDatabasePaths: %v", err)
+	}
+	if !checkMigrationNeeded() {
+		t.Fatal("expected migration to be needed")
 	}
 }
 

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -37,7 +37,7 @@ func initializeDatabase(configFile string) bool {
 	}
 
 	if checkMigrationNeeded() {
-		logger.Info("Old BoltDB database detected, starting migration to SQLite...")
+		logger.Info("Old database detected, starting migration...")
 		err := migrateFromBoltToSQLite()
 		if err != nil {
 			logger.Fatalf("Migration failed: %v", err)

--- a/backend/internal/database/sqldb/sqldb.go
+++ b/backend/internal/database/sqldb/sqldb.go
@@ -19,7 +19,6 @@ type SQLStore struct {
 // NewSQLStoreOpts configures NewSQLStoreWithOptions.
 type NewSQLStoreOpts struct {
 	// SkipQuickSetup skips creating the default admin user. Use when users will be
-	// imported immediately (e.g. BoltDB → SQLite migration) to avoid UNIQUE username conflicts.
 	SkipQuickSetup bool
 }
 

--- a/backend/pkg/settings/config.go
+++ b/backend/pkg/settings/config.go
@@ -570,7 +570,7 @@ func loadConfigWithDefaults(configFile string, generate bool) error {
 			},
 		}
 		loadEnvConfig()
-		return ResolveDatabasePaths(configFile)
+		return ResolveDatabasePaths()
 	}
 
 	// Try multi-file config first (combine all YAML files in the directory)
@@ -632,7 +632,7 @@ func loadConfigWithDefaults(configFile string, generate bool) error {
 	}
 
 	loadEnvConfig()
-	return ResolveDatabasePaths(configFile)
+	return ResolveDatabasePaths()
 }
 
 func ValidateConfig(config Settings) error {

--- a/backend/pkg/settings/config.go
+++ b/backend/pkg/settings/config.go
@@ -570,7 +570,7 @@ func loadConfigWithDefaults(configFile string, generate bool) error {
 			},
 		}
 		loadEnvConfig()
-		return nil
+		return ResolveDatabasePaths(configFile)
 	}
 
 	// Try multi-file config first (combine all YAML files in the directory)
@@ -632,7 +632,7 @@ func loadConfigWithDefaults(configFile string, generate bool) error {
 	}
 
 	loadEnvConfig()
-	return nil
+	return ResolveDatabasePaths(configFile)
 }
 
 func ValidateConfig(config Settings) error {
@@ -725,11 +725,6 @@ func loadEnvConfig() {
 }
 
 func SetDefaults(generate bool) Settings {
-	database := os.Getenv("FILEBROWSER_DATABASE")
-	if database != "" {
-		logger.Fatalf("FILEBROWSER_DATABASE environment variable is deprecated, please migrate your database to SQLite.")
-	}
-
 	// New SQLite database path
 	databaseV2 := os.Getenv("FILEBROWSER_DATABASE_PATH")
 	if databaseV2 == "" {

--- a/backend/pkg/settings/database_paths.go
+++ b/backend/pkg/settings/database_paths.go
@@ -1,27 +1,19 @@
 package settings
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/gtsteffaniak/go-logger/logger"
 )
 
-// MigrateFromDefault is the config value that resolves server.database.migrateFrom from
-// the FILEBROWSER_DATABASE environment variable (legacy BoltDB path).
+// MigrateFromDefault resolves server.database.migrateFrom from FILEBROWSER_DATABASE or database.db.
 const MigrateFromDefault = "default"
 
-// ResolveDatabasePaths normalizes server.database.path and server.database.migrateFrom after
-// config load. Relative paths are resolved against the config file directory (not CWD).
-func ResolveDatabasePaths(configFile string) error {
-	configDir, err := configFileDir(configFile)
-	if err != nil {
-		return err
-	}
-	Env.ConfigDir = configDir
+const defaultLegacyDatabasePath = "database.db"
 
+// ResolveDatabasePaths applies migrateFrom "default" and fills an empty SQLite path from existing defaults.
+func ResolveDatabasePaths() error {
 	db := &Config.Server.DatabaseV2
 	if strings.TrimSpace(db.Path) == "" {
 		if v := os.Getenv("FILEBROWSER_DATABASE_PATH"); v != "" {
@@ -35,64 +27,16 @@ func ResolveDatabasePaths(configFile string) error {
 	legacyEnv := strings.TrimSpace(os.Getenv("FILEBROWSER_DATABASE"))
 
 	if migrateFrom == MigrateFromDefault {
-		if legacyEnv == "" {
-			return fmt.Errorf(
-				`server.database.migrateFrom is %q but FILEBROWSER_DATABASE is not set. `+
-					`Set FILEBROWSER_DATABASE to your legacy BoltDB path (Docker images often use `+
-					`/home/filebrowser/data/database.db) or use an explicit migrateFrom path`,
-				MigrateFromDefault,
-			)
+		if legacyEnv != "" {
+			db.MigrateFrom = legacyEnv
+		} else {
+			db.MigrateFrom = defaultLegacyDatabasePath
 		}
-		db.MigrateFrom = legacyEnv
 	} else if legacyEnv != "" {
 		logger.Fatalf(
 			"FILEBROWSER_DATABASE environment variable is deprecated. " +
 				`Remove it, or set server.database.migrateFrom to "default" to migrate from that path on first start.`,
 		)
 	}
-
-	db.Path = resolveDatabasePath(db.Path, configDir)
-	if db.MigrateFrom != "" {
-		db.MigrateFrom = resolveDatabasePath(db.MigrateFrom, configDir)
-	}
 	return nil
-}
-
-func configFileDir(configFile string) (string, error) {
-	if configFile == "" {
-		wd, err := os.Getwd()
-		if err != nil {
-			return ".", fmt.Errorf("resolve config directory: %w", err)
-		}
-		return wd, nil
-	}
-	expanded := configFile
-	if strings.HasPrefix(configFile, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("resolve home directory: %w", err)
-		}
-		expanded = filepath.Join(home, configFile[2:])
-	}
-	abs, err := filepath.Abs(expanded)
-	if err != nil {
-		return "", fmt.Errorf("resolve config file path: %w", err)
-	}
-	return filepath.Dir(abs), nil
-}
-
-func resolveDatabasePath(path, configDir string) string {
-	path = strings.TrimSpace(path)
-	if path == "" || filepath.IsAbs(path) {
-		return path
-	}
-	return filepath.Join(configDir, path)
-}
-
-// LegacyDatabasePathInConfigDir returns the path to an unrenamed legacy database.db next to the config file.
-func LegacyDatabasePathInConfigDir() string {
-	if Env.ConfigDir != "" {
-		return filepath.Join(Env.ConfigDir, "database.db")
-	}
-	return "database.db"
 }

--- a/backend/pkg/settings/database_paths.go
+++ b/backend/pkg/settings/database_paths.go
@@ -1,0 +1,98 @@
+package settings
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gtsteffaniak/go-logger/logger"
+)
+
+// MigrateFromDefault is the config value that resolves server.database.migrateFrom from
+// the FILEBROWSER_DATABASE environment variable (legacy BoltDB path).
+const MigrateFromDefault = "default"
+
+// ResolveDatabasePaths normalizes server.database.path and server.database.migrateFrom after
+// config load. Relative paths are resolved against the config file directory (not CWD).
+func ResolveDatabasePaths(configFile string) error {
+	configDir, err := configFileDir(configFile)
+	if err != nil {
+		return err
+	}
+	Env.ConfigDir = configDir
+
+	db := &Config.Server.DatabaseV2
+	if strings.TrimSpace(db.Path) == "" {
+		if v := os.Getenv("FILEBROWSER_DATABASE_PATH"); v != "" {
+			db.Path = v
+		} else {
+			db.Path = "filebrowser.sqlite"
+		}
+	}
+
+	migrateFrom := strings.TrimSpace(db.MigrateFrom)
+	legacyEnv := strings.TrimSpace(os.Getenv("FILEBROWSER_DATABASE"))
+
+	if migrateFrom == MigrateFromDefault {
+		if legacyEnv == "" {
+			return fmt.Errorf(
+				`server.database.migrateFrom is %q but FILEBROWSER_DATABASE is not set. `+
+					`Set FILEBROWSER_DATABASE to your legacy BoltDB path (Docker images often use `+
+					`/home/filebrowser/data/database.db) or use an explicit migrateFrom path`,
+				MigrateFromDefault,
+			)
+		}
+		db.MigrateFrom = legacyEnv
+	} else if legacyEnv != "" {
+		logger.Fatalf(
+			"FILEBROWSER_DATABASE environment variable is deprecated. " +
+				`Remove it, or set server.database.migrateFrom to "default" to migrate from that path on first start.`,
+		)
+	}
+
+	db.Path = resolveDatabasePath(db.Path, configDir)
+	if db.MigrateFrom != "" {
+		db.MigrateFrom = resolveDatabasePath(db.MigrateFrom, configDir)
+	}
+	return nil
+}
+
+func configFileDir(configFile string) (string, error) {
+	if configFile == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return ".", fmt.Errorf("resolve config directory: %w", err)
+		}
+		return wd, nil
+	}
+	expanded := configFile
+	if strings.HasPrefix(configFile, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		expanded = filepath.Join(home, configFile[2:])
+	}
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", fmt.Errorf("resolve config file path: %w", err)
+	}
+	return filepath.Dir(abs), nil
+}
+
+func resolveDatabasePath(path, configDir string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(configDir, path)
+}
+
+// LegacyDatabasePathInConfigDir returns the path to an unrenamed legacy database.db next to the config file.
+func LegacyDatabasePathInConfigDir() string {
+	if Env.ConfigDir != "" {
+		return filepath.Join(Env.ConfigDir, "database.db")
+	}
+	return "database.db"
+}

--- a/backend/pkg/settings/database_paths_test.go
+++ b/backend/pkg/settings/database_paths_test.go
@@ -1,0 +1,113 @@
+package settings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDatabasePaths_migrateFromDefault(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	boltPath := filepath.Join(dir, "database.db")
+	if err := os.WriteFile(boltPath, []byte("bolt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("FILEBROWSER_DATABASE", boltPath)
+	t.Setenv("FILEBROWSER_DATABASE_PATH", filepath.Join(dir, "filebrowser.sqlite"))
+
+	Config = SetDefaults(false)
+	Config.Server.DatabaseV2.MigrateFrom = MigrateFromDefault
+	Config.Server.DatabaseV2.Path = "filebrowser.sqlite"
+
+	if err := ResolveDatabasePaths(configFile); err != nil {
+		t.Fatalf("ResolveDatabasePaths: %v", err)
+	}
+
+	if Config.Server.DatabaseV2.MigrateFrom != boltPath {
+		t.Fatalf("migrateFrom = %q, want %q", Config.Server.DatabaseV2.MigrateFrom, boltPath)
+	}
+	wantSQLite := filepath.Join(dir, "filebrowser.sqlite")
+	if Config.Server.DatabaseV2.Path != wantSQLite {
+		t.Fatalf("path = %q, want %q", Config.Server.DatabaseV2.Path, wantSQLite)
+	}
+}
+
+func TestResolveDatabasePaths_migrateFromDefaultMissingEnv(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("FILEBROWSER_DATABASE", "")
+
+	Config = SetDefaults(false)
+	Config.Server.DatabaseV2.MigrateFrom = MigrateFromDefault
+
+	err := ResolveDatabasePaths(configFile)
+	if err == nil {
+		t.Fatal("expected error when migrateFrom is default but FILEBROWSER_DATABASE is unset")
+	}
+}
+
+func TestResolveDatabasePaths_onlyMigrateFromUsesEnvDefaultPath(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	boltPath := filepath.Join(dir, "legacy.db")
+	t.Setenv("FILEBROWSER_DATABASE", boltPath)
+	t.Setenv("FILEBROWSER_DATABASE_PATH", filepath.Join(dir, "data", "filebrowser.sqlite"))
+
+	Config = SetDefaults(false)
+	Config.Server.DatabaseV2.MigrateFrom = MigrateFromDefault
+	Config.Server.DatabaseV2.Path = ""
+
+	if err := ResolveDatabasePaths(configFile); err != nil {
+		t.Fatalf("ResolveDatabasePaths: %v", err)
+	}
+
+	wantSQLite := filepath.Join(dir, "data", "filebrowser.sqlite")
+	if Config.Server.DatabaseV2.Path != wantSQLite {
+		t.Fatalf("path = %q, want %q", Config.Server.DatabaseV2.Path, wantSQLite)
+	}
+}
+
+func TestResolveDatabasePaths_relativePathsAgainstConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	Config = SetDefaults(false)
+	Config.Server.DatabaseV2.Path = "data/filebrowser.sqlite"
+	Config.Server.DatabaseV2.MigrateFrom = "data/database.db.old"
+
+	if err := ResolveDatabasePaths(configFile); err != nil {
+		t.Fatalf("ResolveDatabasePaths: %v", err)
+	}
+
+	if Config.Server.DatabaseV2.Path != filepath.Join(dir, "data/filebrowser.sqlite") {
+		t.Fatalf("unexpected path: %q", Config.Server.DatabaseV2.Path)
+	}
+	if Config.Server.DatabaseV2.MigrateFrom != filepath.Join(dir, "data/database.db.old") {
+		t.Fatalf("unexpected migrateFrom: %q", Config.Server.DatabaseV2.MigrateFrom)
+	}
+}
+
+func TestLegacyDatabasePathInConfigDir(t *testing.T) {
+	Env.ConfigDir = "/home/filebrowser/data"
+	want := filepath.Join("/home/filebrowser/data", "database.db")
+	if got := LegacyDatabasePathInConfigDir(); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/backend/pkg/settings/database_paths_test.go
+++ b/backend/pkg/settings/database_paths_test.go
@@ -1,113 +1,52 @@
 package settings
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestResolveDatabasePaths_migrateFromDefault(t *testing.T) {
-	dir := t.TempDir()
-	configFile := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	boltPath := filepath.Join(dir, "database.db")
-	if err := os.WriteFile(boltPath, []byte("bolt"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
+func TestResolveDatabasePaths_migrateFromDefaultUsesEnv(t *testing.T) {
+	boltPath := filepath.Join(t.TempDir(), "database.db")
 	t.Setenv("FILEBROWSER_DATABASE", boltPath)
-	t.Setenv("FILEBROWSER_DATABASE_PATH", filepath.Join(dir, "filebrowser.sqlite"))
 
 	Config = SetDefaults(false)
 	Config.Server.DatabaseV2.MigrateFrom = MigrateFromDefault
-	Config.Server.DatabaseV2.Path = "filebrowser.sqlite"
 
-	if err := ResolveDatabasePaths(configFile); err != nil {
+	if err := ResolveDatabasePaths(); err != nil {
 		t.Fatalf("ResolveDatabasePaths: %v", err)
 	}
-
 	if Config.Server.DatabaseV2.MigrateFrom != boltPath {
 		t.Fatalf("migrateFrom = %q, want %q", Config.Server.DatabaseV2.MigrateFrom, boltPath)
 	}
-	wantSQLite := filepath.Join(dir, "filebrowser.sqlite")
-	if Config.Server.DatabaseV2.Path != wantSQLite {
-		t.Fatalf("path = %q, want %q", Config.Server.DatabaseV2.Path, wantSQLite)
-	}
 }
 
-func TestResolveDatabasePaths_migrateFromDefaultMissingEnv(t *testing.T) {
-	dir := t.TempDir()
-	configFile := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
+func TestResolveDatabasePaths_migrateFromDefaultFallsBackToDatabaseDB(t *testing.T) {
 	t.Setenv("FILEBROWSER_DATABASE", "")
 
 	Config = SetDefaults(false)
 	Config.Server.DatabaseV2.MigrateFrom = MigrateFromDefault
 
-	err := ResolveDatabasePaths(configFile)
-	if err == nil {
-		t.Fatal("expected error when migrateFrom is default but FILEBROWSER_DATABASE is unset")
+	if err := ResolveDatabasePaths(); err != nil {
+		t.Fatalf("ResolveDatabasePaths: %v", err)
+	}
+	if Config.Server.DatabaseV2.MigrateFrom != "database.db" {
+		t.Fatalf("migrateFrom = %q, want database.db", Config.Server.DatabaseV2.MigrateFrom)
 	}
 }
 
-func TestResolveDatabasePaths_onlyMigrateFromUsesEnvDefaultPath(t *testing.T) {
-	dir := t.TempDir()
-	configFile := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	boltPath := filepath.Join(dir, "legacy.db")
-	t.Setenv("FILEBROWSER_DATABASE", boltPath)
-	t.Setenv("FILEBROWSER_DATABASE_PATH", filepath.Join(dir, "data", "filebrowser.sqlite"))
+func TestResolveDatabasePaths_emptyPathUsesEnvDefault(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "custom.sqlite")
+	t.Setenv("FILEBROWSER_DATABASE_PATH", want)
+	t.Setenv("FILEBROWSER_DATABASE", "")
 
 	Config = SetDefaults(false)
-	Config.Server.DatabaseV2.MigrateFrom = MigrateFromDefault
 	Config.Server.DatabaseV2.Path = ""
+	Config.Server.DatabaseV2.MigrateFrom = ""
 
-	if err := ResolveDatabasePaths(configFile); err != nil {
+	if err := ResolveDatabasePaths(); err != nil {
 		t.Fatalf("ResolveDatabasePaths: %v", err)
 	}
-
-	wantSQLite := filepath.Join(dir, "data", "filebrowser.sqlite")
-	if Config.Server.DatabaseV2.Path != wantSQLite {
-		t.Fatalf("path = %q, want %q", Config.Server.DatabaseV2.Path, wantSQLite)
-	}
-}
-
-func TestResolveDatabasePaths_relativePathsAgainstConfigDir(t *testing.T) {
-	dir := t.TempDir()
-	configFile := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(configFile, []byte("server:\n  sources: []\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	Config = SetDefaults(false)
-	Config.Server.DatabaseV2.Path = "data/filebrowser.sqlite"
-	Config.Server.DatabaseV2.MigrateFrom = "data/database.db.old"
-
-	if err := ResolveDatabasePaths(configFile); err != nil {
-		t.Fatalf("ResolveDatabasePaths: %v", err)
-	}
-
-	if Config.Server.DatabaseV2.Path != filepath.Join(dir, "data/filebrowser.sqlite") {
-		t.Fatalf("unexpected path: %q", Config.Server.DatabaseV2.Path)
-	}
-	if Config.Server.DatabaseV2.MigrateFrom != filepath.Join(dir, "data/database.db.old") {
-		t.Fatalf("unexpected migrateFrom: %q", Config.Server.DatabaseV2.MigrateFrom)
-	}
-}
-
-func TestLegacyDatabasePathInConfigDir(t *testing.T) {
-	Env.ConfigDir = "/home/filebrowser/data"
-	want := filepath.Join("/home/filebrowser/data", "database.db")
-	if got := LegacyDatabasePathInConfigDir(); got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	if Config.Server.DatabaseV2.Path != want {
+		t.Fatalf("path = %q, want %q", Config.Server.DatabaseV2.Path, want)
 	}
 }

--- a/backend/pkg/settings/structs.go
+++ b/backend/pkg/settings/structs.go
@@ -44,6 +44,7 @@ type Environment struct {
 	IsPlaywright                bool   `json:"-"`
 	IsDevMode                   bool   `json:"-"`
 	IsFirstLoad                 bool   `json:"-"` // used internally to track if this is the first load of the application
+	ConfigDir                   string `json:"-"` // directory containing the loaded config file (for relative database paths)
 	ConfigUserDefaultsSpecified      bool     `json:"-"` // true when the config file contained a userDefaults section
 	ConfigUserDefaultsSpecifiedPaths []string `json:"-"` // dot-paths explicitly set under userDefaults in config
 	MuPdfAvailable              bool   `json:"-"` // used internally if compiled with mupdf support

--- a/backend/pkg/settings/structs.go
+++ b/backend/pkg/settings/structs.go
@@ -44,7 +44,6 @@ type Environment struct {
 	IsPlaywright                bool   `json:"-"`
 	IsDevMode                   bool   `json:"-"`
 	IsFirstLoad                 bool   `json:"-"` // used internally to track if this is the first load of the application
-	ConfigDir                   string `json:"-"` // directory containing the loaded config file (for relative database paths)
 	ConfigUserDefaultsSpecified      bool     `json:"-"` // true when the config file contained a userDefaults section
 	ConfigUserDefaultsSpecifiedPaths []string `json:"-"` // dot-paths explicitly set under userDefaults in config
 	MuPdfAvailable              bool   `json:"-"` // used internally if compiled with mupdf support

--- a/backend/pkg/settings/structs.go
+++ b/backend/pkg/settings/structs.go
@@ -41,22 +41,22 @@ type Http struct {
 }
 
 type Environment struct {
-	IsPlaywright                bool   `json:"-"`
-	IsDevMode                   bool   `json:"-"`
-	IsFirstLoad                 bool   `json:"-"` // used internally to track if this is the first load of the application
+	IsPlaywright                     bool     `json:"-"`
+	IsDevMode                        bool     `json:"-"`
+	IsFirstLoad                      bool     `json:"-"` // used internally to track if this is the first load of the application
 	ConfigUserDefaultsSpecified      bool     `json:"-"` // true when the config file contained a userDefaults section
 	ConfigUserDefaultsSpecifiedPaths []string `json:"-"` // dot-paths explicitly set under userDefaults in config
-	MuPdfAvailable              bool   `json:"-"` // used internally if compiled with mupdf support
-	EmbeddedFs                  bool   `json:"-"` // used internally if compiled with embedded fs support
-	FFmpegPath                  string `json:"-"`
-	FFprobePath                 string `json:"-"`
-	FFmpegAvailable             bool   `json:"-"`
-	LoginIconPath               string `json:"-"` // resolved login icon path (filesystem or embedded)
-	LoginIconIsCustom           bool   `json:"-"` // true if login icon is from custom filesystem path
-	LoginIconEmbeddedPath       string `json:"-"` // embedded asset path for default icon
-	FaviconPath                 string `json:"-"` // resolved favicon path (filesystem or embedded)
-	FaviconIsCustom             bool   `json:"-"` // true if favicon is from custom filesystem path
-	FaviconEmbeddedPath         string `json:"-"` // embedded asset path for default favicon
+	MuPdfAvailable                   bool     `json:"-"` // used internally if compiled with mupdf support
+	EmbeddedFs                       bool     `json:"-"` // used internally if compiled with embedded fs support
+	FFmpegPath                       string   `json:"-"`
+	FFprobePath                      string   `json:"-"`
+	FFmpegAvailable                  bool     `json:"-"`
+	LoginIconPath                    string   `json:"-"` // resolved login icon path (filesystem or embedded)
+	LoginIconIsCustom                bool     `json:"-"` // true if login icon is from custom filesystem path
+	LoginIconEmbeddedPath            string   `json:"-"` // embedded asset path for default icon
+	FaviconPath                      string   `json:"-"` // resolved favicon path (filesystem or embedded)
+	FaviconIsCustom                  bool     `json:"-"` // true if favicon is from custom filesystem path
+	FaviconEmbeddedPath              string   `json:"-"` // embedded asset path for default favicon
 }
 
 type Server struct {
@@ -88,7 +88,7 @@ type ActivityConfig struct {
 
 type Database struct {
 	Path        string         `json:"path"`        // path to SQLite database file
-	MigrateFrom string         `json:"migrateFrom"` // path to old BoltDB database file for migration (optional)
+	MigrateFrom string         `json:"migrateFrom"` // path to legacy database file for migration (optional)
 	Activity    ActivityConfig `json:"activity"`    // activity audit logging configuration
 }
 

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -5357,7 +5357,7 @@ const docTemplate = `{
                     ]
                 },
                 "migrateFrom": {
-                    "description": "path to old BoltDB database file for migration (optional)",
+                    "description": "path to legacy database file for migration (optional)",
                     "type": "string"
                 },
                 "path": {

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -5346,7 +5346,7 @@
                     ]
                 },
                 "migrateFrom": {
-                    "description": "path to old BoltDB database file for migration (optional)",
+                    "description": "path to legacy database file for migration (optional)",
                     "type": "string"
                 },
                 "path": {

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -354,7 +354,7 @@ definitions:
         - $ref: '#/definitions/settings.ActivityConfig'
         description: activity audit logging configuration
       migrateFrom:
-        description: path to old BoltDB database file for migration (optional)
+        description: path to legacy database file for migration (optional)
         type: string
       path:
         description: path to SQLite database file

--- a/frontend/public/config.generated.yaml
+++ b/frontend/public/config.generated.yaml
@@ -60,8 +60,8 @@ server:
     disableReuse: false                   # enable to always create a new indexing database on startup.
     startupIntegrityCheck: "quickCheck"   # the method used to check the integrity of the index database on startup (default: quickCheck)  validate:omitempty,oneof=quickCheck probe off
   database:                               # SQLite database configuration
-    path: "filebrowser.sqlite"            # path to SQLite database file (optional when FILEBROWSER_DATABASE_PATH is set)
-    migrateFrom: ""                       # legacy BoltDB path for one-time migration; use "default" with FILEBROWSER_DATABASE env (Docker)
+    path: "filebrowser.sqlite"            # path to SQLite database file
+    migrateFrom: ""                       # legacy BoltDB path for one-time migration; use "default" for FILEBROWSER_DATABASE or database.db
     activity:                             # activity audit logging configuration
       disabled: false                     # disable semantic activity audit logging (default: false)
       retentionDays: 30                   # purge activity rows older than this many days (default 30)

--- a/frontend/public/config.generated.yaml
+++ b/frontend/public/config.generated.yaml
@@ -61,7 +61,7 @@ server:
     startupIntegrityCheck: "quickCheck"   # the method used to check the integrity of the index database on startup (default: quickCheck)  validate:omitempty,oneof=quickCheck probe off
   database:                               # SQLite database configuration
     path: "filebrowser.sqlite"            # path to SQLite database file
-    migrateFrom: ""                       # legacy BoltDB path for one-time migration; use "default" for FILEBROWSER_DATABASE or database.db
+    migrateFrom: ""                       # path to old BoltDB database file for migration (optional)
     activity:                             # activity audit logging configuration
       disabled: false                     # disable semantic activity audit logging (default: false)
       retentionDays: 30                   # purge activity rows older than this many days (default 30)

--- a/frontend/public/config.generated.yaml
+++ b/frontend/public/config.generated.yaml
@@ -60,8 +60,8 @@ server:
     disableReuse: false                   # enable to always create a new indexing database on startup.
     startupIntegrityCheck: "quickCheck"   # the method used to check the integrity of the index database on startup (default: quickCheck)  validate:omitempty,oneof=quickCheck probe off
   database:                               # SQLite database configuration
-    path: "filebrowser.sqlite"            # path to SQLite database file
-    migrateFrom: ""                       # path to old BoltDB database file for migration (optional)
+    path: "filebrowser.sqlite"            # path to SQLite database file (optional when FILEBROWSER_DATABASE_PATH is set)
+    migrateFrom: ""                       # legacy BoltDB path for one-time migration; use "default" with FILEBROWSER_DATABASE env (Docker)
     activity:                             # activity audit logging configuration
       disabled: false                     # disable semantic activity audit logging (default: false)
       retentionDays: 30                   # purge activity rows older than this many days (default 30)

--- a/frontend/public/config.generated.yaml
+++ b/frontend/public/config.generated.yaml
@@ -61,7 +61,7 @@ server:
     startupIntegrityCheck: "quickCheck"   # the method used to check the integrity of the index database on startup (default: quickCheck)  validate:omitempty,oneof=quickCheck probe off
   database:                               # SQLite database configuration
     path: "filebrowser.sqlite"            # path to SQLite database file
-    migrateFrom: ""                       # path to old BoltDB database file for migration (optional)
+    migrateFrom: ""                       # path to legacy database file for migration (optional)
     activity:                             # activity audit logging configuration
       disabled: false                     # disable semantic activity audit logging (default: false)
       retentionDays: 30                   # purge activity rows older than this many days (default 30)


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration setup for fresh installations.
  * Automatically detects the legacy database location when using the default migration option.
  * Uses the standard SQLite database location when no path is configured.
  * Provides clearer guidance when migration is required.
* **Configuration**
  * Improved database path handling and environment-based configuration.
* **Tests**
  * Added coverage for database path resolution, legacy database detection, and migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->