### PR TITLE
fix single file stream issue

### DIFF
--- a/backend/internal/database/share/frontend.go
+++ b/backend/internal/database/share/frontend.go
@@ -60,6 +60,7 @@ func prepForFrontendOne(link *Share, viewer *users.User, r *http.Request, public
 			out.SourceURL = snap.SourceURL(viewer)
 		}
 	}
+	out.SingleFileShare = snap.IsSingleFileShare()
 	if r != nil && publicHost != "" {
 		out.DownloadURL = PublicShareURL(publicHost, publicScheme, out.Hash, true, snap.Token)
 		out.ShareURL = PublicShareURL(publicHost, publicScheme, out.Hash, false, snap.Token)

--- a/backend/internal/database/share/share.go
+++ b/backend/internal/database/share/share.go
@@ -38,6 +38,7 @@ type FrontendShareInfo struct {
 	DisableLoginOption   bool                `json:"disableLoginOption"`
 	SourceURL            string              `json:"sourceURL,omitempty"`
 	CanEditShare         bool                `json:"canEditShare,omitempty"`
+	SingleFileShare      bool                `json:"singleFileShare,omitempty"`
 }
 
 // ShareLimits are bandwidth, access, and banner settings stored in share_settings JSON.

--- a/backend/internal/web/share.go
+++ b/backend/internal/web/share.go
@@ -387,6 +387,7 @@ func sharePostHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, 
 	s.FrontendShareInfo.SourceURL = ""
 	s.FrontendShareInfo.HasPassword = false
 	s.CanEditShare = false
+	s.SingleFileShare = false
 
 	if err = state.CreateShare(s); err != nil {
 		return http.StatusInternalServerError, err
@@ -674,6 +675,7 @@ func shareInfoHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, 
 	frontendShareInfo.SidebarLinks = filtered
 	frontendShareInfo.SourceURL = shareInfo.SourceURL(d.User)
 	frontendShareInfo.CanEditShare = shareInfo.UserCanEdit(d.User)
+	frontendShareInfo.SingleFileShare = shareInfo.IsSingleFileShare()
 	if frontendShareInfo.SourceURL != "" {
 		frontendShareInfo.SidebarLinks = append(frontendShareInfo.SidebarLinks, users.SidebarLink{
 			Name:     "sourceLocation",
@@ -681,13 +683,7 @@ func shareInfoHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, 
 			Target:   frontendShareInfo.SourceURL,
 		})
 	}
-	return RenderJSON(w, r, struct {
-		share.FrontendShareInfo
-		SingleFileShare bool `json:"singleFileShare"`
-	}{
-		FrontendShareInfo: frontendShareInfo,
-		SingleFileShare:   shareInfo.IsSingleFileShare(),
-	})
+	return RenderJSON(w, r, frontendShareInfo)
 }
 
 type sharePinnedItemPatchRequest struct {

--- a/backend/internal/web/share.go
+++ b/backend/internal/web/share.go
@@ -681,7 +681,13 @@ func shareInfoHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, 
 			Target:   frontendShareInfo.SourceURL,
 		})
 	}
-	return RenderJSON(w, r, frontendShareInfo)
+	return RenderJSON(w, r, struct {
+		share.FrontendShareInfo
+		SingleFileShare bool `json:"singleFileShare"`
+	}{
+		FrontendShareInfo: frontendShareInfo,
+		SingleFileShare:   shareInfo.IsSingleFileShare(),
+	})
 }
 
 type sharePinnedItemPatchRequest struct {

--- a/backend/internal/web/stream.go
+++ b/backend/internal/web/stream.go
@@ -37,6 +37,21 @@ func normalizeViewGrantPath(p string) string {
 	return filepath.ToSlash(strings.TrimSpace(p))
 }
 
+// shareRelativeDisplayName returns the client-facing filename for a path within a share.
+// Single-file shares use file=/ at the share root; the real name comes from the share path.
+func shareRelativeDisplayName(d *Context, shareRelativePath string) string {
+	name := filepath.Base(normalizeViewGrantPath(shareRelativePath))
+	if name != "" && name != "." && name != "/" {
+		return name
+	}
+	if d != nil && d.Share.Hash != "" {
+		if shareName := filepath.Base(d.Share.Path); shareName != "" && shareName != "." && shareName != "/" {
+			return shareName
+		}
+	}
+	return name
+}
+
 func mintViewGrant(d *Context, source, filePath string) (string, error) {
 	token, err := utils.RandomHex(16)
 	if err != nil {
@@ -437,7 +452,7 @@ func publicStreamHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 	if err = ValidateViewGrant(token, d, sourceInfo.Name, cleanFile); err != nil {
 		return http.StatusForbidden, err
 	}
-	if !IsMediaStreamFile(filepath.Base(cleanFile)) {
+	if !IsMediaStreamFile(shareRelativeDisplayName(d, cleanFile)) {
 		return http.StatusForbidden, fmt.Errorf("stream endpoint supports audio and video only")
 	}
 	scopedPath := utils.JoinPathAsUnix(d.Share.Path, cleanFile)

--- a/backend/internal/web/stream_test.go
+++ b/backend/internal/web/stream_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 )
 
 var streamTestResolverMu sync.Mutex
@@ -286,6 +287,54 @@ func TestStreamHandlerRejectsNonMedia(t *testing.T) {
 	status, err := streamHandler(httptest.NewRecorder(), req, d)
 	if status != http.StatusForbidden || err == nil {
 		t.Fatalf("expected 403 for non-media, got status=%d err=%v", status, err)
+	}
+}
+
+func TestShareRelativeDisplayName(t *testing.T) {
+	t.Parallel()
+	d := &requestContext{
+		Share: share.Share{
+			ShareColumns: share.ShareColumns{Hash: "abc", Path: "/users/alice/media/song.mp3"},
+		},
+	}
+	if got := shareRelativeDisplayName(d, "/"); got != "song.mp3" {
+		t.Fatalf("shareRelativeDisplayName(/) = %q, want song.mp3", got)
+	}
+	if got := shareRelativeDisplayName(d, "/nested/other.mp3"); got != "other.mp3" {
+		t.Fatalf("shareRelativeDisplayName(/nested/other.mp3) = %q, want other.mp3", got)
+	}
+}
+
+func TestPublicStreamHandlerSingleFileShareRootPath(t *testing.T) {
+	t.Parallel()
+	initStreamTestSources(t)
+	settings.Config.Server.SourceMap = map[string]*settings.Source{
+		"/srv": {Path: "/srv", Name: "srv"},
+	}
+	t.Cleanup(func() { settings.Config.Server.SourceMap = nil })
+	d := &requestContext{
+		User: testUserWithView(1, "srv"),
+		Share: share.Share{
+			ShareColumns: share.ShareColumns{
+				Hash: "abc123",
+				Path: "/scope/media/song.mp3",
+			},
+			SourcePath: "/srv",
+			ShareSettings: share.ShareSettings{
+				FrontendShareInfo: share.FrontendShareInfo{
+					DisableFileViewer: false,
+				},
+			},
+		},
+	}
+	token, err := mintViewGrant(d, "srv", "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/public/api/media/stream?hash=abc123&file=/&viewToken="+token, nil)
+	_, err = publicStreamHandler(httptest.NewRecorder(), req, d)
+	if err != nil && strings.Contains(err.Error(), "stream endpoint supports audio and video only") {
+		t.Fatalf("single-file share root path rejected as non-media: %v", err)
 	}
 }
 

--- a/backend/internal/web/stream_test.go
+++ b/backend/internal/web/stream_test.go
@@ -306,12 +306,13 @@ func TestShareRelativeDisplayName(t *testing.T) {
 }
 
 func TestPublicStreamHandlerSingleFileShareRootPath(t *testing.T) {
-	t.Parallel()
+	// SourceMap is process-global; save/restore and avoid t.Parallel (see streamTestResolverMu).
 	initStreamTestSources(t)
+	prevSourceMap := settings.Config.Server.SourceMap
 	settings.Config.Server.SourceMap = map[string]*settings.Source{
 		"/srv": {Path: "/srv", Name: "srv"},
 	}
-	t.Cleanup(func() { settings.Config.Server.SourceMap = nil })
+	t.Cleanup(func() { settings.Config.Server.SourceMap = prevSourceMap })
 	d := &requestContext{
 		User: testUserWithView(1, "srv"),
 		Share: share.Share{

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -6577,6 +6577,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/users.SidebarLink"
                     }
                 },
+                "singleFileShare": {
+                    "type": "boolean"
+                },
                 "source": {
                     "description": "source display name for API; backend path is Share.SourcePath",
                     "type": "string"
@@ -6748,6 +6751,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/users.SidebarLink"
                     }
                 },
+                "singleFileShare": {
+                    "type": "boolean"
+                },
                 "source": {
                     "description": "source display name for API; backend path is Share.SourcePath",
                     "type": "string"
@@ -6900,6 +6906,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/users.SidebarLink"
                     }
+                },
+                "singleFileShare": {
+                    "type": "boolean"
                 },
                 "source": {
                     "description": "source display name for API; backend path is Share.SourcePath",

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -6566,6 +6566,9 @@
                         "$ref": "#/definitions/users.SidebarLink"
                     }
                 },
+                "singleFileShare": {
+                    "type": "boolean"
+                },
                 "source": {
                     "description": "source display name for API; backend path is Share.SourcePath",
                     "type": "string"
@@ -6737,6 +6740,9 @@
                         "$ref": "#/definitions/users.SidebarLink"
                     }
                 },
+                "singleFileShare": {
+                    "type": "boolean"
+                },
                 "source": {
                     "description": "source display name for API; backend path is Share.SourcePath",
                     "type": "string"
@@ -6889,6 +6895,9 @@
                     "items": {
                         "$ref": "#/definitions/users.SidebarLink"
                     }
+                },
+                "singleFileShare": {
+                    "type": "boolean"
                 },
                 "source": {
                     "description": "source display name for API; backend path is Share.SourcePath",

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -1268,6 +1268,8 @@ definitions:
         items:
           $ref: '#/definitions/users.SidebarLink'
         type: array
+      singleFileShare:
+        type: boolean
       source:
         description: source display name for API; backend path is Share.SourcePath
         type: string
@@ -1383,6 +1385,8 @@ definitions:
         items:
           $ref: '#/definitions/users.SidebarLink'
         type: array
+      singleFileShare:
+        type: boolean
       source:
         description: source display name for API; backend path is Share.SourcePath
         type: string
@@ -1486,6 +1490,8 @@ definitions:
         items:
           $ref: '#/definitions/users.SidebarLink'
         type: array
+      singleFileShare:
+        type: boolean
       source:
         description: source display name for API; backend path is Share.SourcePath
         type: string


### PR DESCRIPTION
fixes https://github.com/gtsteffaniak/filebrowser/issues/2680
## Summary by CodeRabbit

- **New Features**
  - Share information now indicates whether a share contains a single file.
  - Single-file shares display the appropriate filename when accessed or streamed.

- **Bug Fixes**
  - Fixed public single-file shares being incorrectly rejected as unsupported media during streaming.
  - Improved filename handling for shared files with nested or root-level paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Share information now indicates whether a share contains a single file.
  - Single-file shares display the appropriate filename when accessed or streamed.

- **Bug Fixes**
  - Fixed public single-file shares being incorrectly rejected as unsupported media during streaming.
  - Improved filename handling for shared files with nested or root-level paths.
  - Corrected share details so single-file status is consistently shown across views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->