### PR TITLE
port v1.5.4 changes to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,13 +53,6 @@ This version represents the most significant change to date. It **requires** bot
  - Database env var rename: `FILEBROWSER_DATABASE` is removed (startup fails if set). Use `FILEBROWSER_DATABASE_PATH` (default `filebrowser.sqlite`) or `server.database.path` in config. See [Environment variables](https://filebrowserquantum.com/en/docs/reference/environment-variables/) and [Server settings](https://filebrowserquantum.com/en/docs/configuration/server/).
  - CLI: `user set` with `--password` (inline value, interactive prompt on TTY, or piped stdin); `user promote` for admin grant without password reset. See [CLI reference](https://filebrowserquantum.com/en/docs/reference/cli/).
 
- **BugFixes** (ported from v1.5.3 / v1.5.4):
- - fix probe canShare with the real file, not a fixed text/plain stand-in (#2664)
- - When the logout button is pressed on a share, redirect honors baseURL / externalUrl (#2657)
- - fix redirect to login when an authenticated request returns 401 (expired session) (#2679)
- - fix forward slash blocked in text fields when the search shortcut listener intercepts `/` (#2696)
- - PWA installation name now capped at 30 characters instead of 12; removed separate short_name (#2701)
-
  **Notes**:
  - v2.x.x uses a new write-through backend state management. Changes go through a fast memory layer and also write changes to database to stay in sync. See [About v2.0.0](https://filebrowserquantum.com/en/docs/getting-started/v2/about/).
  - CLI server start (`./filebrowser`), `setup`, `version`, and `set rule` syntax unchanged; see [CLI docs](https://filebrowserquantum.com/en/docs/reference/cli/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ This version represents the most significant change to date. It **requires** bot
  - Database env var rename: `FILEBROWSER_DATABASE` is removed (startup fails if set). Use `FILEBROWSER_DATABASE_PATH` (default `filebrowser.sqlite`) or `server.database.path` in config. See [Environment variables](https://filebrowserquantum.com/en/docs/reference/environment-variables/) and [Server settings](https://filebrowserquantum.com/en/docs/configuration/server/).
  - CLI: `user set` with `--password` (inline value, interactive prompt on TTY, or piped stdin); `user promote` for admin grant without password reset. See [CLI reference](https://filebrowserquantum.com/en/docs/reference/cli/).
 
+ **BugFixes** (ported from v1.5.3 / v1.5.4):
+ - fix probe canShare with the real file, not a fixed text/plain stand-in (#2664)
+ - When the logout button is pressed on a share, redirect honors baseURL / externalUrl (#2657)
+ - fix redirect to login when an authenticated request returns 401 (expired session) (#2679)
+ - fix forward slash blocked in text fields when the search shortcut listener intercepts `/` (#2696)
+ - PWA installation name now capped at 30 characters instead of 12; removed separate short_name (#2701)
+
  **Notes**:
  - v2.x.x uses a new write-through backend state management. Changes go through a fast memory layer and also write changes to database to stay in sync. See [About v2.0.0](https://filebrowserquantum.com/en/docs/getting-started/v2/about/).
  - CLI server start (`./filebrowser`), `setup`, `version`, and `set rule` syntax unchanged; see [CLI docs](https://filebrowserquantum.com/en/docs/reference/cli/)

--- a/backend/internal/icons/manifest.go
+++ b/backend/internal/icons/manifest.go
@@ -1,13 +1,14 @@
 package icons
 
 import (
+	"strings"
+
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 )
 
 // PWAManifest represents the web app manifest structure
 type PWAManifest struct {
 	Name            string    `json:"name"`
-	ShortName       string    `json:"short_name"`
 	ID              string    `json:"id"`
 	Scope           string    `json:"scope"`
 	Icons           []PWAIcon `json:"icons"`
@@ -29,19 +30,23 @@ type PWAIcon struct {
 // CachedManifest holds the generated PWA manifest at startup
 var CachedManifest PWAManifest
 
+const pwaManifestNameMaxLen = 30
+
+// pwaManifestName returns the app title for the web app manifest.
+// Names longer than 30 characters are truncated to fit common mobile launcher limits.
+func pwaManifestName(name string) string {
+	name = strings.TrimSpace(name)
+	runes := []rune(name)
+	if len(runes) > pwaManifestNameMaxLen {
+		return string(runes[:pwaManifestNameMaxLen])
+	}
+	return name
+}
+
 // generatePWAManifest creates the PWA manifest structure
 func generatePWAManifest(name, description, baseURL, themeColor, pwaIcon192, pwaIcon256, pwaIcon512 string) PWAManifest {
-	shortName := name
-	if len(name) > 12 {
-		shortName = name[:12]
-	}
-	if name == "FileBrowser Quantum" {
-		shortName = "FBQ"
-	}
-
 	return PWAManifest{
-		Name:            name,
-		ShortName:       shortName,
+		Name:            pwaManifestName(name),
 		ID:              baseURL,
 		Scope:           baseURL,
 		StartURL:        baseURL,

--- a/backend/internal/icons/manifest_share.go
+++ b/backend/internal/icons/manifest_share.go
@@ -92,12 +92,7 @@ func ManifestForShare(baseURL, startURL, name, description string) (PWAManifest,
 	manifest.ID = shareRoot
 
 	if name = sanitizeManifestText(strings.TrimSpace(name)); name != "" {
-		manifest.Name = name
-		shortName := name
-		if len(shortName) > 12 {
-			shortName = shortName[:12]
-		}
-		manifest.ShortName = shortName
+		manifest.Name = pwaManifestName(name)
 	}
 	if description = sanitizeManifestText(strings.TrimSpace(description)); description != "" {
 		manifest.Description = description

--- a/backend/internal/icons/manifest_share_test.go
+++ b/backend/internal/icons/manifest_share_test.go
@@ -51,11 +51,10 @@ func TestShareHashFromHTTPPathRejectsEmbeddedPrefix(t *testing.T) {
 
 func TestManifestForShare(t *testing.T) {
 	CachedManifest = PWAManifest{
-		Name:      "FileBrowser Quantum",
-		ShortName: "FBQ",
-		StartURL:  "/testing/",
-		Scope:     "/testing/",
-		ID:        "/testing/",
+		Name:     "FileBrowser Quantum",
+		StartURL: "/testing/",
+		Scope:    "/testing/",
+		ID:       "/testing/",
 	}
 
 	manifest, ok := ManifestForShare(
@@ -75,5 +74,29 @@ func TestManifestForShare(t *testing.T) {
 	}
 	if manifest.Name != "My Share" {
 		t.Fatalf("unexpected name: %q", manifest.Name)
+	}
+}
+
+func TestManifestForShareTruncatesLongName(t *testing.T) {
+	CachedManifest = PWAManifest{
+		Name:     "FileBrowser Quantum",
+		StartURL: "/testing/",
+		Scope:    "/testing/",
+		ID:       "/testing/",
+	}
+
+	longName := "Shared files - quarterly backup archive 2026"
+	want := "Shared files - quarterly backu"
+	manifest, ok := ManifestForShare(
+		"/testing/",
+		"/testing/public/share/hash1234567890abcdef/",
+		longName,
+		"",
+	)
+	if !ok {
+		t.Fatal("expected share manifest")
+	}
+	if manifest.Name != want {
+		t.Fatalf("expected name %q, got %q", want, manifest.Name)
 	}
 }

--- a/backend/pkg/settings/structs.go
+++ b/backend/pkg/settings/structs.go
@@ -288,7 +288,7 @@ type ResolvedRulesConfig struct {
 }
 
 type Frontend struct {
-	Name                  string         `json:"name"`                  // display name
+	Name                  string         `json:"name"`                  // display name, PWA installation name is capped at 30 characters
 	DisableDefaultLinks   bool           `json:"disableDefaultLinks"`   // disable default links in the sidebar
 	DisableUsedPercentage bool           `json:"disableUsedPercentage"` // disable used percentage for the sources in the sidebar
 	ExternalLinks         []ExternalLink `json:"externalLinks"`

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -5565,7 +5565,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "name": {
-                    "description": "display name",
+                    "description": "display name, PWA installation name is capped at 30 characters",
                     "type": "string"
                 },
                 "oidcLoginButtonText": {

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -5554,7 +5554,7 @@
                     "type": "string"
                 },
                 "name": {
-                    "description": "display name",
+                    "description": "display name, PWA installation name is capped at 30 characters",
                     "type": "string"
                 },
                 "oidcLoginButtonText": {

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -430,7 +430,7 @@ definitions:
         description: path to an image file for the login page icon
         type: string
       name:
-        description: display name
+        description: display name, PWA installation name is capped at 30 characters
         type: string
       oidcLoginButtonText:
         description: text to display on the OIDC login button

--- a/frontend/public/config.generated.yaml
+++ b/frontend/public/config.generated.yaml
@@ -136,7 +136,7 @@ auth:
   adminPassword: "admin"                  # secret: the password of the admin user. If not set, the default is "admin".
   totpSecret: ""                          # secret: secret used to encrypt TOTP secrets
 frontend:
-  name: "FileBrowser Quantum"             # display name
+  name: "FileBrowser Quantum"             # display name, PWA installation name is capped at 30 characters
   disableDefaultLinks: false              # disable default links in the sidebar
   disableUsedPercentage: false            # disable used percentage for the sources in the sidebar
   externalLinks:

--- a/frontend/src/components/Search.vue
+++ b/frontend/src/components/Search.vue
@@ -266,7 +266,7 @@ export default {
 
     // Add keyboard event listener for "/" to activate search
     this.handleKeydown = (event) => {
-      if (event.key === '/' || event.key === ' ' && !state.isSearchActive && getters.currentPrompt() === null) {
+      if ((event.key === '/' || event.key === ' ') && !state.isSearchActive && !getters.currentPrompt()) {
         event.preventDefault();
         this.open();
       }

--- a/frontend/src/components/sidebar/General.vue
+++ b/frontend/src/components/sidebar/General.vue
@@ -191,14 +191,13 @@ export default {
       let sharePath;
 
       if (isShare && state.shareInfo?.hash) {
-        const shareBase = `/public/share/${state.shareInfo.hash}`;
+        const shareBase = `${globalVars.baseURL}public/share/${state.shareInfo.hash}`;
         const subPath = state.req?.path && state.req.path !== '/'
           ? url.removeLeadingSlash(state.req.path)
           : '';
         sharePath = subPath ? `${shareBase}/${url.encodedPath(subPath)}` : shareBase;
       }
-      await auth.logout();
-      window.location.href = sharePath || '/login';
+      await auth.logout(sharePath);
     },
     beforeEnter(el) {
       el.style.maxHeight = '0';

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -328,7 +328,7 @@
     "shareDurationDescription": "Duration before the share expires. Leave blank for a permanent share.",
     "passwordDescription": "Optional password required to access this share, including authenticated users.",
     "shareThemeColorDescription": "CSS color value applied to the share's theme (e.g., red, #0ea5e9, rgb(14,165,233)).",
-    "shareTitleDescription": "Custom page title shown on the share page.",
+    "shareTitleDescription": "Custom page title shown on the share page. If this share is installed as a PWA, the app name is limited to 30 characters.",
     "shareDescriptionHelp": "Short description shown on the share page (may be used in meta tags).",
     "shareBannerDescription": "Banner image URL or path accessible by the client -- either abosolute or index path are accepted: eg 'https://domain.com/banner.png' or '/path/to/banner.png'",
     "shareFaviconDescription": "Favicon URL or path accessible by the client -- either abosolute or index path are accepted: eg 'https://domain.com/favicon.png' or '/path/to/favicon.png'",

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -14,6 +14,21 @@ export async function validateLogin(isPublicRoute = false) {
   });
 
   if (res.status !== 200) {
+    // A 401 from the non-public self check means our session cookie (JWT) is no
+    // longer valid — typically it expired. Clear it and redirect to login so the
+    // user can re-authenticate, instead of leaving the stale cookie in place
+    // (which otherwise leaves the app stuck on reload). Only do this for a real,
+    // non-public session: public routes legitimately 401 for anonymous share
+    // visitors, and we skip it when there is no session cookie to clear.
+    if (
+      res.status === 401 &&
+      !isPublicRoute &&
+      document.cookie
+        .split(";")
+        .some((c) => c.trim().startsWith("filebrowser_quantum_jwt="))
+    ) {
+      sessionExpired();
+    }
     throw new Error(`{"status":${res.status},"message":"${await res.text()}"}`);
   }
   const userInfo = await res.json();
@@ -63,7 +78,7 @@ export function generateRandomCode(length) {
   return code;
 }
 
-export async function logout() {
+export async function logout(redirectUrl) {
   try {
     const res = await fetch(getApiPath("auth/logout"), {
       method: "POST",
@@ -71,17 +86,17 @@ export async function logout() {
     });
     if (res.ok) {
       const data = await res.json();
-      let logoutUrl = data.logoutUrl;
+      let destination = data.logoutUrl || `${globalVars.baseURL}login`;
+      if (redirectUrl) {
+        destination = redirectUrl;
+      }
       // Backend clears the cookie, but frontend does it as fail-safe cleanup
       document.cookie = "filebrowser_quantum_jwt=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/";
       void mutations.setCurrentUser(null);
       // No need to clear state.jwt - cookie is the source of truth
-      if (!logoutUrl) {
-        logoutUrl = `${globalVars.baseURL}login`;
-      }
       // Add a small delay to ensure cookie deletion completes before redirect
       setTimeout(() => {
-        window.location.href = logoutUrl;
+        window.location.href = destination;
       }, 100);
       return; // Stop execution
     } else {
@@ -91,6 +106,24 @@ export async function logout() {
   } catch (e) {
     console.error("An error occurred during logout:", e);
   }
+}
+
+// Handle an authenticated request that came back 401 because the session cookie
+// (JWT) is no longer valid — typically it expired while the tab was idle. Unlike
+// logout(), this does NOT call the server (which would itself 401 on an expired
+// token and leave the stale cookie in place); it clears the cookie locally and
+// redirects to the login page so the user can re-authenticate, instead of being
+// stuck on a raw "token is expired" error.
+export function sessionExpired() {
+  document.cookie =
+    "filebrowser_quantum_jwt=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/";
+  void mutations.setCurrentUser(null);
+  // Avoid a redirect loop if we're already on the login page.
+  if (window.location.pathname.endsWith("/login")) {
+    return;
+  }
+  const current = window.location.pathname + window.location.search;
+  window.location.href = `${globalVars.baseURL}login?redirect=${encodeURIComponent(current)}`;
 }
 
 // Helper function to retrieve the value of a specific cookie

--- a/frontend/src/utils/auth.test.js
+++ b/frontend/src/utils/auth.test.js
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks referenced by the vi.mock factories below.
+const { storeMock } = vi.hoisted(() => ({
+  storeMock: {
+    state: { sessionId: 'sess', user: null },
+    getters: { isLoggedIn: vi.fn(() => true) },
+    mutations: { setCurrentUser: vi.fn(), setSession: vi.fn(), syncEnforcedUserDefaults: vi.fn() },
+  },
+}));
+
+vi.mock('@/store', () => storeMock);
+vi.mock('@/utils/constants', () => ({ globalVars: { baseURL: '/', recaptcha: false } }));
+vi.mock('@/utils/url.js', () => ({
+  getApiPath: (p, params = {}) =>
+    `/api/${p}${params.username ? `?username=${params.username}` : ''}`,
+}));
+
+import { validateLogin } from './auth.js';
+
+const COOKIE = 'filebrowser_quantum_jwt';
+
+function respond(status, body = '') {
+  global.fetch = vi.fn().mockResolvedValue({
+    status,
+    text: async () => body,
+    json: async () => ({}),
+  });
+}
+
+describe('validateLogin session-expiry handling', () => {
+  beforeEach(() => {
+    storeMock.mutations.setCurrentUser.mockClear();
+    document.cookie = `${COOKIE}=stale; path=/`;
+    // Stub navigation via Vitest's global-stub API (jsdom doesn't implement
+    // real navigation). pathname+search feed the redirect; href captures it.
+    vi.stubGlobal('location', { pathname: '/files/', search: '?a=1', href: '' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('clears the cookie + user and redirects (with encoded return path) on a non-public 401 with a session cookie', async () => {
+    respond(401, 'token is expired');
+    await expect(validateLogin(false)).rejects.toThrow();
+    expect(storeMock.mutations.setCurrentUser).toHaveBeenCalledWith(null);
+    expect(document.cookie.includes(`${COOKIE}=stale`)).toBe(false);
+    // Full redirect contract: login route + correctly encoded current path+query.
+    expect(window.location.href).toBe(
+      `/login?redirect=${encodeURIComponent('/files/?a=1')}`
+    );
+  });
+
+  it('does NOT log out or redirect on a PUBLIC 401 (anonymous share visitor)', async () => {
+    respond(401, 'unauthorized');
+    await expect(validateLogin(true)).rejects.toThrow();
+    expect(storeMock.mutations.setCurrentUser).not.toHaveBeenCalledWith(null);
+    expect(document.cookie.includes(`${COOKIE}=stale`)).toBe(true);
+    expect(window.location.href).toBe('');
+  });
+
+  it('does NOT log out or redirect on a non-public 401 when there is NO session cookie', async () => {
+    document.cookie = `${COOKIE}=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/`;
+    respond(401, 'unauthorized');
+    await expect(validateLogin(false)).rejects.toThrow();
+    expect(storeMock.mutations.setCurrentUser).not.toHaveBeenCalledWith(null);
+    expect(window.location.href).toBe('');
+  });
+
+  it('does NOT log out or redirect on a non-401 error (e.g. 500)', async () => {
+    respond(500, 'server error');
+    await expect(validateLogin(false)).rejects.toThrow();
+    expect(storeMock.mutations.setCurrentUser).not.toHaveBeenCalledWith(null);
+    expect(document.cookie.includes(`${COOKIE}=stale`)).toBe(true);
+    expect(window.location.href).toBe('');
+  });
+});

--- a/frontend/src/utils/nativeShare.js
+++ b/frontend/src/utils/nativeShare.js
@@ -10,13 +10,18 @@ export function canNativeShare() {
   );
 }
 
-function canShareFiles() {
+/**
+ * Checks whether the OS/browser share sheet can accept the given File.
+ * navigator.canShare({ files }) validates the specific file being shared
+ * (name, MIME type, size) — many platforms only allow a safe subset
+ * (images, audio, video, plain text, PDF) and reject everything else.
+ */
+function canShareFile(file) {
   if (typeof navigator.canShare !== "function") {
     return false;
   }
   try {
-    const probe = new File(["x"], "share-probe.txt", { type: "text/plain" });
-    return navigator.canShare({ files: [probe] });
+    return navigator.canShare({ files: [file] });
   } catch {
     return false;
   }
@@ -43,7 +48,14 @@ export async function nativeShareFile(item) {
   const url = buildDownloadUrl(item);
 
   try {
-    if (canShareFiles()) {
+    // Only attempt to share the file's actual bytes if navigator.canShare
+    // exists at all. We must check the real file (fetched below), not a
+    // synthetic stand-in: this previously probed with a fixed text/plain
+    // file, which always reported success even for file types (e.g.
+    // .xlsx, .docx, .zip) that the OS share sheet then silently rejected
+    // once navigator.share() was actually called, surfacing as an opaque
+    // "permission denied" error to the user (see #2659).
+    if (typeof navigator.canShare === "function") {
       const response = await fetch(url, { credentials: "same-origin" });
       if (!response.ok) {
         const detail = response.statusText ? ` (${response.statusText})` : "";
@@ -53,10 +65,15 @@ export async function nativeShareFile(item) {
       const blob = await response.blob();
       const type = blob.type || item.type || "application/octet-stream";
       const file = new File([blob], filename, { type });
-      await navigator.share({ files: [file], title: filename });
-      return;
+
+      if (canShareFile(file)) {
+        await navigator.share({ files: [file], title: filename });
+        return;
+      }
     }
 
+    // Fall back to sharing a link when the platform can't share the file's
+    // actual bytes/type (or doesn't support file sharing at all).
     await navigator.share({ url, title: filename });
   } catch (e) {
     if (e?.name === "AbortError") {

--- a/frontend/src/utils/nativeShare.test.js
+++ b/frontend/src/utils/nativeShare.test.js
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const showErrorMock = vi.fn();
+
+vi.mock("@/api", () => ({
+  resourcesApi: {
+    getDownloadURL: vi.fn(() => "https://example.com/api/raw/report.xlsx"),
+    getDownloadURLPublic: vi.fn(() => "https://example.com/api/public/dl/report.xlsx"),
+  },
+}));
+
+vi.mock("@/notify", () => ({
+  notify: {
+    showError: (...args) => showErrorMock(...args),
+  },
+}));
+
+vi.mock("@/store", () => ({
+  getters: {
+    isShare: () => false,
+  },
+  state: {
+    req: { source: "default" },
+  },
+}));
+
+import { canNativeShare, nativeShareFile } from "./nativeShare";
+
+function mockShare(implementation) {
+  Object.defineProperty(window, "isSecureContext", {
+    configurable: true,
+    value: true,
+  });
+  navigator.share = vi.fn(implementation ?? (() => Promise.resolve()));
+}
+
+function stubFetch(blobType) {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      statusText: "OK",
+      status: 200,
+      blob: () =>
+        Promise.resolve({
+          type: blobType,
+        }),
+    })
+  );
+}
+
+beforeEach(() => {
+  showErrorMock.mockClear();
+  delete navigator.canShare;
+  delete navigator.share;
+  global.fetch = undefined;
+});
+
+describe("canNativeShare", () => {
+  it("returns false when navigator.share is unavailable", () => {
+    expect(canNativeShare()).toBe(false);
+  });
+
+  it("returns true when navigator.share exists and context is secure", () => {
+    mockShare();
+    expect(canNativeShare()).toBe(true);
+  });
+});
+
+describe("nativeShareFile", () => {
+  it("shows an error when sharing isn't supported at all", async () => {
+    await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+    expect(showErrorMock).toHaveBeenCalledWith("Sharing is not supported on this device");
+  });
+
+  it(
+    "falls back to sharing a link (not the file) when the platform rejects the file's real MIME type " +
+      "-- regression test for #2659, where a hardcoded text/plain probe file made canShareFiles() always " +
+      "return true, so navigator.share() was called with an .xlsx/.docx/.zip file the platform then " +
+      "silently rejected, surfacing as 'permission denied'",
+    async () => {
+      mockShare();
+      stubFetch("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+      // Platform can share files in general, but rejects this specific
+      // (non-safelisted) MIME type -- exactly what real browsers do for
+      // office/archive formats.
+      navigator.canShare = vi.fn(({ files }) => {
+        const file = files?.[0];
+        return file ? file.type === "text/plain" : false;
+      });
+
+      await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+
+      expect(navigator.share).toHaveBeenCalledTimes(1);
+      const sharedPayload = navigator.share.mock.calls[0][0];
+      // Must NOT have attempted to share the actual xlsx file bytes.
+      expect(sharedPayload.files).toBeUndefined();
+      expect(sharedPayload.url).toBe("https://example.com/api/raw/report.xlsx");
+      expect(showErrorMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("shares the real file when the platform's canShare accepts its actual type", async () => {
+    mockShare();
+    stubFetch("application/pdf");
+    navigator.canShare = vi.fn(({ files }) => files?.[0]?.type === "application/pdf");
+
+    await nativeShareFile({ name: "doc.pdf", path: "/doc.pdf" });
+
+    expect(navigator.share).toHaveBeenCalledTimes(1);
+    const sharedPayload = navigator.share.mock.calls[0][0];
+    expect(sharedPayload.files).toHaveLength(1);
+    expect(sharedPayload.files[0].name).toBe("doc.pdf");
+    expect(sharedPayload.files[0].type).toBe("application/pdf");
+  });
+
+  it("shares a link directly when the platform has no canShare at all", async () => {
+    mockShare();
+    // No navigator.canShare defined -- older/limited platforms.
+
+    await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+
+    expect(global.fetch).toBeUndefined();
+    expect(navigator.share).toHaveBeenCalledWith({
+      url: "https://example.com/api/raw/report.xlsx",
+      title: "report.xlsx",
+    });
+  });
+
+  it("surfaces a download failure instead of silently sharing nothing", async () => {
+    mockShare();
+    navigator.canShare = vi.fn(() => true);
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 403, statusText: "Forbidden" })
+    );
+
+    await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+
+    expect(navigator.share).not.toHaveBeenCalled();
+    expect(showErrorMock).toHaveBeenCalledWith("Download failed (403 (Forbidden))");
+  });
+
+  it("silently ignores the user cancelling the OS share sheet", async () => {
+    mockShare(() => {
+      const err = new Error("cancelled");
+      err.name = "AbortError";
+      return Promise.reject(err);
+    });
+
+    await nativeShareFile({ name: "report.xlsx", path: "/report.xlsx" });
+
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PWA installation names now support up to 30 characters with improved whitespace handling.
  - File sharing now verifies device support and falls back to sharing the download link when needed.
  - Session-expiry handling now clears expired sessions and redirects securely to login.

- **Bug Fixes**
  - Corrected keyboard shortcuts for opening search while prompts are displayed.
  - Improved logout redirects, including shared-page destinations.
  - Fixed handling of unsupported file types and expired private sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->