### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The goal for this repo is to become the best open-source self-hosted file browsi
 
 Ready to try it out? See [Getting Started Docs](https://filebrowserquantum.com/en/docs/getting-started/).
 
+If you would rather not run a server yourself, [Zenith Hosting](https://zenith.hosting/host/filebrowser-quantum) offers one-click managed FileBrowser Quantum: storage, backups, email and a free subdomain included. A share of every subscription goes back to the projects it hosts.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/filebrowser-quantum)
+
 ## How its different
 
 FileBrowser Quantum is a massive fork of the file browser open-source project with the following changes:


### PR DESCRIPTION
**Description**

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added FileBrowser Quantum to our marketplace, so this PR adds a small "Deploy with Zenith" badge in the About section, right under the "Ready to try it out?" line (links to https://zenith.hosting/host/filebrowser-quantum).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR. (n/a, README only, no backend or frontend code touched)
- [x] Any additional details for functionality not covered by tests.

**Additional Details**

one file, four lines added, no code. i know Quantum is deliberately easy to run as a single binary, so this is not meant to imply otherwise. it is for the people who want the app but do not want to own a box, a domain or backups.

happy to move it further down, shorten the blurb, or drop the prose and keep just the badge if you would rather it stayed out of the About section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about managed FileBrowser Quantum hosting through Zenith Hosting.
  * Included a deployment badge and link for streamlined access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->