### PR TITLE
log specific value change for user diff

### DIFF
--- a/backend/internal/activity/diff.go
+++ b/backend/internal/activity/diff.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"time"
 
 	activitydb "github.com/gtsteffaniak/filebrowser/backend/internal/database/activity"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/share"
@@ -166,7 +165,7 @@ func valueFieldChanges(before, after reflect.Value, fieldPrefix string) []activi
 	if reflect.DeepEqual(before.Interface(), after.Interface()) {
 		return nil
 	}
-	if before.Kind() == reflect.Struct && after.Kind() == reflect.Struct && isExpandableStruct(before.Type()) {
+	if before.Kind() == reflect.Struct && after.Kind() == reflect.Struct {
 		changes := make([]activitydb.FieldChange, 0, before.Type().NumField())
 		for i := 0; i < before.Type().NumField(); i++ {
 			sf := before.Type().Field(i)
@@ -192,10 +191,6 @@ func valueFieldChanges(before, after reflect.Value, fieldPrefix string) []activi
 		From:  formatActivityValue(before),
 		To:    formatActivityValue(after),
 	}}
-}
-
-func isExpandableStruct(t reflect.Type) bool {
-	return t != reflect.TypeOf(time.Time{})
 }
 
 func fieldIndexByJSONTag(t reflect.Type, jsonTag string) ([]int, bool) {

--- a/backend/internal/activity/diff.go
+++ b/backend/internal/activity/diff.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	activitydb "github.com/gtsteffaniak/filebrowser/backend/internal/database/activity"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/share"
@@ -92,9 +93,7 @@ func UserUpdateChanges(before, after *users.User, which []string, passwordChange
 			}
 			continue
 		}
-		if change, ok := structFieldChange(reflect.ValueOf(before).Elem(), reflect.ValueOf(after).Elem(), reflect.TypeOf(users.User{}), tag); ok {
-			changes = append(changes, change)
-		}
+		changes = append(changes, structFieldChanges(reflect.ValueOf(before).Elem(), reflect.ValueOf(after).Elem(), reflect.TypeOf(users.User{}), tag)...)
 	}
 	sort.Slice(changes, func(i, j int) bool { return changes[i].Field < changes[j].Field })
 	return changes
@@ -107,9 +106,7 @@ func ShareUpdateChanges(before, after *share.Share) []activitydb.FieldChange {
 	tags := collectJSONTags(reflect.TypeOf(share.Share{}), shareActivitySkipJSONTags)
 	changes := make([]activitydb.FieldChange, 0, len(tags))
 	for _, tag := range tags {
-		if change, ok := structFieldChange(reflect.ValueOf(before).Elem(), reflect.ValueOf(after).Elem(), reflect.TypeOf(share.Share{}), tag); ok {
-			changes = append(changes, change)
-		}
+		changes = append(changes, structFieldChanges(reflect.ValueOf(before).Elem(), reflect.ValueOf(after).Elem(), reflect.TypeOf(share.Share{}), tag)...)
 	}
 	if before.HasPassword() != after.HasPassword() {
 		changes = append(changes, activitydb.FieldChange{
@@ -150,24 +147,55 @@ func sidebarLinksFieldChange(before, after *users.User) (activitydb.FieldChange,
 	return activitydb.FieldChange{Field: "sidebarLinks", From: from, To: to}, true
 }
 
-func structFieldChange(beforeVal, afterVal reflect.Value, rootType reflect.Type, jsonTag string) (activitydb.FieldChange, bool) {
+func structFieldChanges(beforeVal, afterVal reflect.Value, rootType reflect.Type, jsonTag string) []activitydb.FieldChange {
 	fieldIndex, ok := fieldIndexByJSONTag(rootType, jsonTag)
 	if !ok {
-		return activitydb.FieldChange{}, false
+		return nil
 	}
 	beforeField := beforeVal.FieldByIndex(fieldIndex)
 	afterField := afterVal.FieldByIndex(fieldIndex)
-	if !beforeField.IsValid() || !afterField.IsValid() {
-		return activitydb.FieldChange{}, false
+	return valueFieldChanges(beforeField, afterField, jsonTag)
+}
+
+func valueFieldChanges(before, after reflect.Value, fieldPrefix string) []activitydb.FieldChange {
+	before = reflect.Indirect(before)
+	after = reflect.Indirect(after)
+	if !before.IsValid() || !after.IsValid() {
+		return nil
 	}
-	if reflect.DeepEqual(beforeField.Interface(), afterField.Interface()) {
-		return activitydb.FieldChange{}, false
+	if reflect.DeepEqual(before.Interface(), after.Interface()) {
+		return nil
 	}
-	return activitydb.FieldChange{
-		Field: jsonTag,
-		From:  formatActivityValue(beforeField),
-		To:    formatActivityValue(afterField),
-	}, true
+	if before.Kind() == reflect.Struct && after.Kind() == reflect.Struct && isExpandableStruct(before.Type()) {
+		changes := make([]activitydb.FieldChange, 0, before.Type().NumField())
+		for i := 0; i < before.Type().NumField(); i++ {
+			sf := before.Type().Field(i)
+			if sf.PkgPath != "" {
+				continue
+			}
+			tagName := strings.Split(sf.Tag.Get("json"), ",")[0]
+			if tagName == "" || tagName == "-" {
+				continue
+			}
+			subPrefix := tagName
+			if fieldPrefix != "" {
+				subPrefix = fieldPrefix + "." + tagName
+			}
+			changes = append(changes, valueFieldChanges(before.Field(i), after.Field(i), subPrefix)...)
+		}
+		if len(changes) > 0 {
+			return changes
+		}
+	}
+	return []activitydb.FieldChange{{
+		Field: fieldPrefix,
+		From:  formatActivityValue(before),
+		To:    formatActivityValue(after),
+	}}
+}
+
+func isExpandableStruct(t reflect.Type) bool {
+	return t != reflect.TypeOf(time.Time{})
 }
 
 func fieldIndexByJSONTag(t reflect.Type, jsonTag string) ([]int, bool) {

--- a/backend/internal/activity/diff.go
+++ b/backend/internal/activity/diff.go
@@ -157,10 +157,18 @@ func structFieldChanges(beforeVal, afterVal reflect.Value, rootType reflect.Type
 }
 
 func valueFieldChanges(before, after reflect.Value, fieldPrefix string) []activitydb.FieldChange {
+	fromVal, toVal := before, after
 	before = reflect.Indirect(before)
 	after = reflect.Indirect(after)
-	if !before.IsValid() || !after.IsValid() {
+	if !before.IsValid() && !after.IsValid() {
 		return nil
+	}
+	if !before.IsValid() || !after.IsValid() {
+		return []activitydb.FieldChange{{
+			Field: fieldPrefix,
+			From:  formatActivityValue(fromVal),
+			To:    formatActivityValue(toVal),
+		}}
 	}
 	if reflect.DeepEqual(before.Interface(), after.Interface()) {
 		return nil

--- a/backend/internal/activity/diff_test.go
+++ b/backend/internal/activity/diff_test.go
@@ -1,6 +1,7 @@
 package activity
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/share"
@@ -67,6 +68,52 @@ func TestUserUpdateChangesFiltersUnchangedFields(t *testing.T) {
 	if changes[2].Field != "sorting.by" || changes[2].From != "" || changes[2].To != "name" {
 		t.Fatalf("unexpected sorting.by change: %#v", changes[2])
 	}
+}
+
+func TestValueFieldChangesPointerTransitions(t *testing.T) {
+	perms := users.MarkSourceFilePermissionsConfigured(users.SourceFilePermissions{View: true})
+
+	t.Run("nil and nil", func(t *testing.T) {
+		var before, after *users.SourceFilePermissions
+		changes := valueFieldChanges(reflect.ValueOf(before), reflect.ValueOf(after), "permissions")
+		if len(changes) != 0 {
+			t.Fatalf("expected no changes, got %#v", changes)
+		}
+	})
+
+	t.Run("nil to value", func(t *testing.T) {
+		var before *users.SourceFilePermissions
+		changes := valueFieldChanges(reflect.ValueOf(before), reflect.ValueOf(perms), "permissions")
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 change, got %#v", changes)
+		}
+		if changes[0].Field != "permissions" {
+			t.Fatalf("unexpected field: %#v", changes[0])
+		}
+		if changes[0].From != "null" {
+			t.Fatalf("expected From null, got %q", changes[0].From)
+		}
+		if changes[0].To == "" || changes[0].To == "null" {
+			t.Fatalf("expected permissions JSON in To, got %q", changes[0].To)
+		}
+	})
+
+	t.Run("value to nil", func(t *testing.T) {
+		var after *users.SourceFilePermissions
+		changes := valueFieldChanges(reflect.ValueOf(perms), reflect.ValueOf(after), "permissions")
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 change, got %#v", changes)
+		}
+		if changes[0].Field != "permissions" {
+			t.Fatalf("unexpected field: %#v", changes[0])
+		}
+		if changes[0].To != "null" {
+			t.Fatalf("expected To null, got %q", changes[0].To)
+		}
+		if changes[0].From == "" || changes[0].From == "null" {
+			t.Fatalf("expected permissions JSON in From, got %q", changes[0].From)
+		}
+	})
 }
 
 func TestUserUpdateChangesExpandsNestedStructFields(t *testing.T) {

--- a/backend/internal/activity/diff_test.go
+++ b/backend/internal/activity/diff_test.go
@@ -55,14 +55,41 @@ func TestUserUpdateChangesFiltersUnchangedFields(t *testing.T) {
 	}
 
 	changes := UserUpdateChanges(before, &after, which, false)
-	if len(changes) != 2 {
-		t.Fatalf("expected 2 changes, got %d: %#v", len(changes), changes)
+	if len(changes) != 3 {
+		t.Fatalf("expected 3 changes, got %d: %#v", len(changes), changes)
 	}
 	if changes[0].Field != "darkMode" || changes[0].From != "true" || changes[0].To != "false" {
 		t.Fatalf("unexpected darkMode change: %#v", changes[0])
 	}
-	if changes[1].Field != "sorting" {
-		t.Fatalf("unexpected second change: %#v", changes[1])
+	if changes[1].Field != "sorting.asc" || changes[1].From != "false" || changes[1].To != "true" {
+		t.Fatalf("unexpected sorting.asc change: %#v", changes[1])
+	}
+	if changes[2].Field != "sorting.by" || changes[2].From != "" || changes[2].To != "name" {
+		t.Fatalf("unexpected sorting.by change: %#v", changes[2])
+	}
+}
+
+func TestUserUpdateChangesExpandsNestedStructFields(t *testing.T) {
+	before := &users.User{
+		FrontendUser: users.FrontendUser{
+			NonAdminEditable: users.NonAdminEditable{
+				Preview: users.Preview{
+					AutoplayMedia: false,
+					Image:         true,
+					Video:         true,
+				},
+			},
+		},
+	}
+	after := *before
+	after.Preview.AutoplayMedia = true
+
+	changes := UserUpdateChanges(before, &after, []string{"preview"}, false)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %#v", len(changes), changes)
+	}
+	if changes[0].Field != "preview.autoplayMedia" || changes[0].From != "false" || changes[0].To != "true" {
+		t.Fatalf("unexpected preview.autoplayMedia change: %#v", changes[0])
 	}
 }
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -927,8 +927,7 @@
       "shareFilter": "Share filter",
       "pathGlob": "Path pattern (glob)",
       "viewActivity": "View activity",
-      "tableColumns": "Table columns",
-      "tableScrollRegion": "Activity table — scroll horizontally to see all columns"
+      "tableColumns": "Table columns"
     },
     "toolNotFound": "Tool not found",
     "backToTools": "Back to Tools"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -927,7 +927,8 @@
       "shareFilter": "Share filter",
       "pathGlob": "Path pattern (glob)",
       "viewActivity": "View activity",
-      "tableColumns": "Table columns"
+      "tableColumns": "Table columns",
+      "tableScrollRegion": "Activity table — scroll horizontally to see all columns"
     },
     "toolNotFound": "Tool not found",
     "backToTools": "Back to Tools"

--- a/frontend/src/views/tools/ActivityViewer.vue
+++ b/frontend/src/views/tools/ActivityViewer.vue
@@ -179,18 +179,19 @@
             {{ $t("tools.activityViewer.showingPage", { shown: items.length, total: totalEvents, page: currentPage, pages: totalPages }) }}
           </span>
         </div>
-        <settings-table
-          :columns="tableColumns"
-          :items="items"
-          item-key="id"
-          default-sort-key="createdAt"
-          default-sort-dir="desc"
-          :loading="loading"
-          row-clickable
-          :aria-label="$t('tools.activityViewer.name')"
-          :lonely-message-key="!loading && items.length === 0 ? 'files.lonely' : undefined"
-          @row-click="openEventDetails"
-        >
+        <div class="results-table-scroll">
+          <settings-table
+            :columns="tableColumns"
+            :items="items"
+            item-key="id"
+            default-sort-key="createdAt"
+            default-sort-dir="desc"
+            :loading="loading"
+            row-clickable
+            :aria-label="$t('tools.activityViewer.name')"
+            :lonely-message-key="!loading && items.length === 0 ? 'files.lonely' : undefined"
+            @row-click="openEventDetails"
+          >
           <template #cell-createdAt="{ row }">
             <span v-if="!isBlankTableValue(row.createdAt)">{{ formatTime(row.createdAt) }}</span>
             <span v-else class="details-muted">—</span> <!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
@@ -268,7 +269,8 @@
             </div>
             <span v-else class="details-muted">—</span> <!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
           </template>
-        </settings-table>
+          </settings-table>
+        </div>
         <div v-if="totalPages > 1" class="pagination">
           <button
             type="button"
@@ -2118,11 +2120,31 @@ export default {
 }
 
 .results-table {
-  overflow-x: auto;
+  min-width: 0;
 }
 
-.results-table :deep(.settings-table) {
+.results-table-scroll {
+  max-width: 100%;
+}
+
+.results-table-scroll :deep(.settings-table) {
+  width: 100%;
   table-layout: fixed;
+}
+
+@media (max-width: 768px) {
+  .results-table-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    width: 100%;
+  }
+
+  /* Same fixed/ellipsis layout as desktop; min-width triggers scroll when viewport is narrower */
+  .results-table-scroll :deep(.settings-table) {
+    width: 100%;
+    min-width: 1000px;
+    table-layout: fixed;
+  }
 }
 
 .table-cell-text {

--- a/frontend/src/views/tools/ActivityViewer.vue
+++ b/frontend/src/views/tools/ActivityViewer.vue
@@ -179,12 +179,7 @@
             {{ $t("tools.activityViewer.showingPage", { shown: items.length, total: totalEvents, page: currentPage, pages: totalPages }) }}
           </span>
         </div>
-        <div
-          class="results-table-scroll"
-          tabindex="0"
-          role="region"
-          :aria-label="$t('tools.activityViewer.tableScrollRegion')"
-        >
+        <div class="results-table-scroll">
           <settings-table
             :columns="tableColumns"
             :items="items"
@@ -2142,13 +2137,19 @@ export default {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     width: 100%;
+    max-width: 1000px;
   }
 
-  /* Same fixed/ellipsis layout as desktop; min-width triggers scroll when viewport is narrower */
   .results-table-scroll :deep(.settings-table) {
-    width: 100%;
-    min-width: 1000px;
-    table-layout: fixed;
+    width: max-content;
+    min-width: 100%;
+    max-width: 1000px;
+    table-layout: auto;
+  }
+
+  .results-table-scroll :deep(.settings-table thead th),
+  .results-table-scroll :deep(.settings-table tbody td) {
+    white-space: nowrap;
   }
 }
 

--- a/frontend/src/views/tools/ActivityViewer.vue
+++ b/frontend/src/views/tools/ActivityViewer.vue
@@ -179,7 +179,12 @@
             {{ $t("tools.activityViewer.showingPage", { shown: items.length, total: totalEvents, page: currentPage, pages: totalPages }) }}
           </span>
         </div>
-        <div class="results-table-scroll">
+        <div
+          class="results-table-scroll"
+          tabindex="0"
+          role="region"
+          :aria-label="$t('tools.activityViewer.tableScrollRegion')"
+        >
           <settings-table
             :columns="tableColumns"
             :items="items"


### PR DESCRIPTION
makes small changes easier to spot:

<img width="2278" height="992" alt="image" src="https://github.com/user-attachments/assets/59a31e0f-ea03-4a60-9790-d53aa5fd1c22" />

vs old:

<img width="848" height="662" alt="image" src="https://github.com/user-attachments/assets/107e25c5-9a94-4a7c-b055-170609ef5e66" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved activity change tracking for nested settings and preferences.
* Nested updates now display each changed field separately, including sorting and preview settings.
* Activity comparisons now support multiple changes within a single nested field.
* Preserved clear whole-value changes for supported values and value transitions.
* Ignored unchanged fields while recording valid missing or restored values.

## Improvements

* Activity tables now adapt to smaller screens with touch-friendly horizontal scrolling.
* Improved table readability and navigation with clearer focus and full-width desktop layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->