### PR TITLE
fix windows slash issue in v2.0.0

### DIFF
--- a/backend/internal/utils/file.go
+++ b/backend/internal/utils/file.go
@@ -10,7 +10,7 @@ import (
 	"hash"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/gtsteffaniak/filebrowser/backend/internal/errors"
@@ -68,16 +68,16 @@ type FileOptions struct {
 
 // SanitizePath cleans and validates a path or path-like filter (index paths, globs, etc.)
 // to block traversal. Rule 1: Do Not Use Untrusted Input in File Paths (without validation).
-func SanitizePath(path string) (string, error) {
-	clean := filepath.Clean(path)
+func SanitizePath(inputPath string) (string, error) {
+	clean := path.Clean(inputPath)
 
 	// Split the path into segments to check for path traversal attempts.
 	// We check if ".." appears as a complete path segment (not just in a filename).
-	segments := strings.Split(clean, string(filepath.Separator))
+	segments := strings.Split(clean, "/")
 
 	for _, segment := range segments {
 		// Check if any segment is exactly ".." (path traversal attempt).
-		// This catches any ".." that filepath.Clean couldn't resolve (i.e., escape attempts).
+		// This catches any ".." that path.Clean couldn't resolve (i.e., escape attempts).
 		if segment == ".." {
 			return "", fmt.Errorf("invalid path: path traversal detected")
 		}

--- a/backend/internal/utils/indexpath_test.go
+++ b/backend/internal/utils/indexpath_test.go
@@ -1,6 +1,9 @@
 package utils
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIndexPathFromNormalized_String(t *testing.T) {
 	tests := []struct {
@@ -35,6 +38,52 @@ func TestParseIndexPath_consecutiveSlashes(t *testing.T) {
 	}
 	if len(got.Parts) != 2 {
 		t.Errorf("Parts = %v, want [a b]", got.Parts)
+	}
+}
+
+func TestSanitizePath_indexPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"root slash", "/", "/", false},
+		{"nested", "/foo/bar", "/foo/bar", false},
+		{"traversal segment", "..", "", true},
+		{"resolved traversal", "/../secret", "/secret", false},
+		{"empty", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SanitizePath(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("SanitizePath(%q) expected error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SanitizePath(%q) unexpected error: %v", tt.input, err)
+			}
+			if strings.Contains(got, `\`) {
+				t.Errorf("SanitizePath(%q) = %q contains backslash", tt.input, got)
+			}
+			if got != tt.want {
+				t.Errorf("SanitizePath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSanitizedIndexPath_root(t *testing.T) {
+	got, err := ParseSanitizedIndexPath("/", true)
+	if err != nil {
+		t.Fatalf("ParseSanitizedIndexPath(/): %v", err)
+	}
+	if got.String() != "/" {
+		t.Errorf("got %q want /", got.String())
 	}
 }
 

--- a/backend/internal/web/middleware.go
+++ b/backend/internal/web/middleware.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -58,7 +57,6 @@ func withHashFileHelper(fn handleFunc) handleFunc {
 		if err != nil && inputPath != "" {
 			return http.StatusBadRequest, err
 		}
-		path = filepath.ToSlash(path)
 
 		link, err := state.GetShare(hash)
 		if err != nil {


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling for consistent behavior across platforms.
  * Normalized paths more reliably and rejected unsafe backslash-based traversal.
  * Added support for correctly handling empty and root paths.
* **Tests**
  * Expanded coverage for path normalization, traversal prevention, and root-path parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->