### PR TITLE
fix v2.0.0 totp backend user struct check

### DIFF
--- a/backend/internal/database/users/nonadmin_test.go
+++ b/backend/internal/database/users/nonadmin_test.go
@@ -5,47 +5,40 @@ import (
 	"testing"
 )
 
-func TestNonAdminEditableContainsOtpEnabled(t *testing.T) {
-	// Test that OtpEnabled is included in NonAdminEditable struct
-	structType := reflect.TypeOf(NonAdminEditable{})
+func TestFrontendUserContainsOtpEnabled(t *testing.T) {
+	structType := reflect.TypeOf(FrontendUser{})
 
-	// Check if OtpEnabled field exists
 	otpEnabledField, exists := structType.FieldByName("OtpEnabled")
 	if !exists {
-		t.Fatal("OtpEnabled field should exist in NonAdminEditable struct")
+		t.Fatal("OtpEnabled field should exist on FrontendUser")
 	}
 
-	// Check the JSON tag
 	expectedTag := "otpEnabled"
 	if otpEnabledField.Tag.Get("json") != expectedTag {
 		t.Errorf("Expected JSON tag '%s', got '%s'", expectedTag, otpEnabledField.Tag.Get("json"))
 	}
 
-	// Check the field type
 	if otpEnabledField.Type.Kind() != reflect.Bool {
 		t.Errorf("Expected OtpEnabled to be bool, got %s", otpEnabledField.Type.Kind())
 	}
 }
 
+func TestNonAdminEditableDoesNotDuplicateOtpEnabled(t *testing.T) {
+	structType := reflect.TypeOf(NonAdminEditable{})
+	if _, exists := structType.FieldByName("OtpEnabled"); exists {
+		t.Fatal("OtpEnabled should not be duplicated on NonAdminEditable")
+	}
+}
+
 func TestGetNonAdminEditableFieldNames(t *testing.T) {
-	// This is a helper function that should be tested
-	// We'll test it indirectly by checking if OtpEnabled is in the list
 	names := getNonAdminEditableFieldNames()
 
-	// Check that OtpEnabled is in the list
-	found := false
 	for _, name := range names {
 		if name == "OtpEnabled" {
-			found = true
-			break
+			t.Error("OtpEnabled should not be in NonAdminEditable field names")
 		}
 	}
 
-	if !found {
-		t.Error("OtpEnabled should be in the list of non-admin editable field names")
-	}
-
-	// Check that some other expected fields are present
 	expectedFields := []string{"DarkMode", "Locale", "ViewMode", "SingleClick"}
 	for _, expected := range expectedFields {
 		found := false
@@ -61,7 +54,6 @@ func TestGetNonAdminEditableFieldNames(t *testing.T) {
 	}
 }
 
-// Helper function to get field names (copied from bolt/users.go for testing)
 func getNonAdminEditableFieldNames() []string {
 	var names []string
 	t := reflect.TypeOf(NonAdminEditable{})

--- a/backend/internal/database/users/users.go
+++ b/backend/internal/database/users/users.go
@@ -237,7 +237,6 @@ type NonAdminEditable struct {
 	ShowCopyPath               bool                 `json:"showCopyPath"`               // show copy path action in the context menu
 	ShowToolsInSidebar         bool                 `json:"showToolsInSidebar"`         // when false, sidebar hides links with category "tool" (default: true)
 	DebugOffice                bool                 `json:"debugOffice"`                // debug onlyoffice editor
-	OtpEnabled                 bool                 `json:"otpEnabled"`                 // allow non-admin users to disable their own OTP
 	SidebarLinks               []SidebarLink        `json:"sidebarLinks"`               // customizable sidebar links
 	HideFilesInTree            bool                 `json:"hideFilesInTree"`            // hide files in the sidebar tree navigation, when true, will show only directories.
 	DeleteAfterArchive         bool                 `json:"deleteAfterArchive"`         // delete source files after successful creation/extraction of archives

--- a/backend/internal/state/users.go
+++ b/backend/internal/state/users.go
@@ -395,7 +395,8 @@ func preserveServerManagedFields(old, new *users.User) {
 	if new.BackendSourcePermissions == nil && old.BackendSourcePermissions != nil {
 		new.BackendSourcePermissions = copyBackendSourcePermissions(old.BackendSourcePermissions)
 	}
-	if new.OtpEnabled && new.TOTPSecret == "" && new.TOTPNonce == "" && old.TOTPSecret != "" {
+	// Frontend omits totpSecret/totpNonce on profile saves; preserve when OTP stays enabled or was active in DB.
+	if new.TOTPSecret == "" && new.TOTPNonce == "" && old.TOTPSecret != "" && new.OtpEnabled {
 		new.TOTPSecret = old.TOTPSecret
 		new.TOTPNonce = old.TOTPNonce
 	}

--- a/backend/internal/state/users_test.go
+++ b/backend/internal/state/users_test.go
@@ -96,6 +96,77 @@ func TestPreserveServerManagedFieldsClearsTOTPWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestPreserveServerManagedFieldsPreservesTOTPOnFullSave(t *testing.T) {
+	old := &users.User{
+		TOTPSecret: "secret",
+		TOTPNonce:  "nonce",
+	}
+	incoming := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username:   "alice",
+			OtpEnabled: true,
+		},
+	}
+
+	preserveServerManagedFields(old, incoming)
+
+	if incoming.TOTPSecret != "secret" || incoming.TOTPNonce != "nonce" {
+		t.Fatalf("expected TOTP preserved on full save, got secret=%q nonce=%q", incoming.TOTPSecret, incoming.TOTPNonce)
+	}
+}
+
+func TestUpdateUserFullPatchPreservesTOTPSecret(t *testing.T) {
+	t.Setenv("FILEBROWSER_ONLYOFFICE_SECRET", "")
+	settings.Initialize("../../../_docker/src/noauth/backend/config.yaml")
+	settings.Env.IsPlaywright = true
+
+	dbPath := filepath.Join(t.TempDir(), "filebrowser.sqlite")
+	_, err := Initialize(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = Close() })
+
+	u := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username: "alice",
+			Locale:   "en",
+		},
+	}
+	if err = CreateUser(u, "password"); err != nil {
+		t.Fatal(err)
+	}
+	u.TOTPSecret = "persisted-secret"
+	u.TOTPNonce = "persisted-nonce"
+	u.OtpEnabled = true
+	if err = UpdateUser(u, "", "TOTPSecret", "TOTPNonce", "OtpEnabled"); err != nil {
+		t.Fatal(err)
+	}
+
+	patch := &users.User{
+		ID: u.ID,
+		FrontendUser: users.FrontendUser{
+			Username:   "alice",
+			Locale:   "de",
+			OtpEnabled: true,
+		},
+	}
+	if err = UpdateUser(patch, "", "all"); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := GetUserByUsername("alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.TOTPSecret != "persisted-secret" || loaded.TOTPNonce != "persisted-nonce" {
+		t.Fatalf("expected TOTP preserved after full patch, got secret=%q nonce=%q", loaded.TOTPSecret, loaded.TOTPNonce)
+	}
+	if !loaded.OtpEnabled {
+		t.Fatal("expected OtpEnabled to remain true after full patch")
+	}
+}
+
 func TestUpdateUserPatchPreservesBackendSourcePermissions(t *testing.T) {
 	t.Setenv("FILEBROWSER_ONLYOFFICE_SECRET", "")
 	settings.Initialize("../../../_docker/src/noauth/backend/config.yaml")

--- a/backend/internal/state/users_test.go
+++ b/backend/internal/state/users_test.go
@@ -130,7 +130,9 @@ func TestUpdateUserFullPatchPreservesTOTPSecret(t *testing.T) {
 	u := &users.User{
 		FrontendUser: users.FrontendUser{
 			Username: "alice",
-			Locale:   "en",
+			NonAdminEditable: users.NonAdminEditable{
+				Locale: "en",
+			},
 		},
 	}
 	if err = CreateUser(u, "password"); err != nil {
@@ -147,8 +149,10 @@ func TestUpdateUserFullPatchPreservesTOTPSecret(t *testing.T) {
 		ID: u.ID,
 		FrontendUser: users.FrontendUser{
 			Username:   "alice",
-			Locale:   "de",
 			OtpEnabled: true,
+			NonAdminEditable: users.NonAdminEditable{
+				Locale: "de",
+			},
 		},
 	}
 	if err = UpdateUser(patch, "", "all"); err != nil {

--- a/backend/internal/web/middleware.go
+++ b/backend/internal/web/middleware.go
@@ -331,7 +331,7 @@ func withoutUserHelper(fn handleFunc) handleFunc {
 	}
 }
 
-// allow user without OTP to pass
+// LoginHelper authenticates login/signup requests. When disableOtp is false, users with TOTPSecret must supply X-Secret.
 func LoginHelper(disableOtp bool, fn handleFunc) handleFunc {
 	return func(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
 		if settings.Config.Auth.Methods.ProxyAuth.Enabled {
@@ -378,7 +378,7 @@ func LoginHelper(disableOtp bool, fn handleFunc) handleFunc {
 			logger.Debug("ldap auth failed, calling password auth", err)
 		}
 		if settings.Config.Auth.Methods.PasswordAuth.Enabled {
-			user, err := auth.AuthenticatePassword(r, true)
+			user, err := auth.AuthenticatePassword(r, disableOtp)
 			if err != nil {
 				logger.Debug("password auth failed, calling handler:", err)
 				if err == errors.ErrNoTotpProvided {

--- a/backend/internal/web/totp_test.go
+++ b/backend/internal/web/totp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gtsteffaniak/filebrowser/backend/internal/auth"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/state"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/pquerna/otp/totp"
 )
 
@@ -81,5 +82,54 @@ func TestVerifyOTP_CachedSecretTakesPrecedence(t *testing.T) {
 	}
 	if _, found := auth.TotpCache.Get(user.Username); found {
 		t.Error("expected cache to be cleared after verification")
+	}
+}
+
+func TestLogin_RequiresOTPWhenTOTPSecretSet(t *testing.T) {
+	setupTestEnv(t)
+
+	origPasswordAuth := settings.Config.Auth.Methods.PasswordAuth.Enabled
+	settings.Config.Auth.Methods.PasswordAuth.Enabled = true
+	t.Cleanup(func() { settings.Config.Auth.Methods.PasswordAuth.Enabled = origPasswordAuth })
+
+	const secret = "SOMEOLDSECRET234"
+	user := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username:    "test",
+			LoginMethod: users.LoginMethodPassword,
+		},
+	}
+	if err := state.CreateUser(user, "testPass"); err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	user.TOTPSecret = secret
+	user.OtpEnabled = true
+	if err := state.UpdateUser(user, "", "TOTPSecret", "TOTPNonce", "OtpEnabled", "LoginMethod"); err != nil {
+		t.Fatalf("failed to set TOTP on user: %v", err)
+	}
+
+	handler := wrapHandler(loginHelper(loginHandler))
+
+	rec := httptest.NewRecorder()
+	handler(rec, otpRequest(user.Username, "testPass", "", "/api/auth/login"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without OTP, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var errResp HttpResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Message != "OTP code is required for user" {
+		t.Fatalf("expected OTP required message, got %q", errResp.Message)
+	}
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate TOTP code: %v", err)
+	}
+	rec2 := httptest.NewRecorder()
+	handler(rec2, otpRequest(user.Username, "testPass", code, "/api/auth/login"))
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected 200 with valid OTP, got %d body=%s", rec2.Code, rec2.Body.String())
 	}
 }

--- a/frontend/src/components/sidebar/Settings.vue
+++ b/frontend/src/components/sidebar/Settings.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isMobile" class="card item clickable settings-card" @click="closeSettings">
-    <span>
-      <span class="material-symbols-outlined">close</span> <!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
+    <span class="settings-item-content">
+      <span class="material-symbols-outlined settings-icon">close</span> <!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
       {{ $t("general.exit") }}
     </span>
   </div>


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OTP-enabled accounts now correctly require a valid one-time password during password login.
  * User updates preserve existing TOTP settings when OTP remains enabled.
  * Non-administrative user edits can no longer directly modify OTP status.

* **Style**
  * Updated the mobile Settings close control for a more consistent appearance.

* **Tests**
  * Added coverage for OTP-required login flows and TOTP configuration preservation during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->