### PR TITLE
added source default permission behavior like userDefaults

### DIFF
--- a/_docker/src/settings/backend/config.yaml
+++ b/_docker/src/settings/backend/config.yaml
@@ -12,6 +12,8 @@ server:
       name: "playwright + files"
       config:
         defaultEnabled: true
+        defaultPermissions:
+          modify: false
     - path: "."
       name: "docker"
       config:

--- a/backend/internal/state/source_access_defaults.go
+++ b/backend/internal/state/source_access_defaults.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
@@ -36,6 +37,16 @@ func InitSourceAccessDefaults() error {
 		doc = sourceAccessSettingsDocument{DefaultPermissions: perms}
 		if saveErr := saveSourceAccessSettingsDocument(doc); saveErr != nil {
 			return saveErr
+		}
+	}
+
+	if settings.Env.ConfigSourceDefaultPermissions != nil {
+		overlaid := settings.OverlayConfigSourceDefaults(doc.DefaultPermissions)
+		if !reflect.DeepEqual(doc.DefaultPermissions, overlaid) {
+			doc.DefaultPermissions = overlaid
+			if saveErr := saveSourceAccessSettingsDocument(doc); saveErr != nil {
+				return fmt.Errorf("save config-synced source defaults: %w", saveErr)
+			}
 		}
 	}
 
@@ -113,13 +124,26 @@ func GetSourceAccessDefaults() users.SourceFilePermissions {
 
 // SourceSettings is the admin API payload for GET/PATCH /api/settings/source.
 type SourceSettings struct {
-	DefaultPermissions  users.SourceFilePermissions                `json:"defaultPermissions"`
-	EnforcedPermissions settings.SourceFilePermissionsEnforcement `json:"enforcedPermissions"`
+	DefaultPermissions    users.SourceFilePermissions                `json:"defaultPermissions"`
+	EnforcedPermissions   settings.SourceFilePermissionsEnforcement `json:"enforcedPermissions"`
+	LockedFromConfigPaths []string                                   `json:"lockedFromConfigPaths,omitempty"`
+	LockMessage           string                                     `json:"lockMessage,omitempty"`
 }
 
 // GetSourceSettings returns admin-editable source-wide settings.
 func GetSourceSettings() SourceSettings {
-	return SourceSettings(currentSourceAccessSettingsDocument())
+	doc := currentSourceAccessSettingsDocument()
+	lockedPaths := settings.ConfigSourceDefaultLockedPaths()
+	lockMessage := ""
+	if len(lockedPaths) > 0 {
+		lockMessage = settings.SourceDefaultsConfigLockMessage
+	}
+	return SourceSettings{
+		DefaultPermissions:    doc.DefaultPermissions,
+		EnforcedPermissions:   doc.EnforcedPermissions,
+		LockedFromConfigPaths: lockedPaths,
+		LockMessage:           lockMessage,
+	}
 }
 
 // GetEnforcedSourcePermissions returns universal enforced source permission flags.
@@ -127,6 +151,19 @@ func GetEnforcedSourcePermissions() settings.SourceFilePermissionsEnforcement {
 	sourceAccessMu.RLock()
 	defer sourceAccessMu.RUnlock()
 	return sourceAccessEnforcedDefault
+}
+
+// PatchSourceAccessDefaults merges a partial defaultPermissions patch and persists.
+func PatchSourceAccessDefaults(patchJSON []byte) error {
+	if err := settings.ValidateSourceDefaultsPatchNotConfigLocked(patchJSON); err != nil {
+		return err
+	}
+	current := GetSourceAccessDefaults()
+	merged, mergeErr := settings.MergeSourceDefaultsPatchJSON(current, patchJSON)
+	if mergeErr != nil {
+		return mergeErr
+	}
+	return SetSourceAccessDefaults(merged)
 }
 
 // SetSourceAccessDefaults persists and applies new global source file permission defaults.

--- a/backend/internal/state/source_defaults_config_integration_test.go
+++ b/backend/internal/state/source_defaults_config_integration_test.go
@@ -1,0 +1,53 @@
+package state
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
+)
+
+func TestInitSourceAccessDefaults_overlaysConfigOnRestart(t *testing.T) {
+	t.Setenv("FILEBROWSER_ONLYOFFICE_SECRET", "")
+	t.Setenv("FILEBROWSER_PLAYWRIGHT_TEST", "true")
+	settings.Initialize("../../../_docker/src/jwt/backend/config.yaml")
+
+	dbPath := filepath.Join(t.TempDir(), "filebrowser.sqlite")
+	_, err := Initialize(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = Close() })
+
+	access := GetSourceAccessDefaults()
+	if !access.Modify || !access.Create {
+		t.Fatalf("initial source access defaults: %+v", access)
+	}
+
+	// Simulate admin changing modify in SQLite; config should re-overlay on next init.
+	sourceAccessMu.Lock()
+	doc := sourceAccessSettingsDocument{
+		DefaultPermissions: users.SourceFilePermissions{
+			View: true, Download: true, Modify: false, Create: true, Delete: false,
+		},
+		EnforcedPermissions: sourceAccessEnforcedDefault,
+	}
+	if saveErr := saveSourceAccessSettingsDocument(doc); saveErr != nil {
+		sourceAccessMu.Unlock()
+		t.Fatal(saveErr)
+	}
+	sourceAccessMu.Unlock()
+
+	if err := InitSourceAccessDefaults(); err != nil {
+		t.Fatal(err)
+	}
+
+	access = GetSourceAccessDefaults()
+	if !access.Modify {
+		t.Fatal("expected modify re-overlaid from jwt config on restart")
+	}
+	if settings.Env.ConfigSourceDefaultPermissions == nil {
+		t.Fatal("expected config source default permissions for jwt yaml")
+	}
+}

--- a/backend/internal/web/settings.go
+++ b/backend/internal/web/settings.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/state"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
@@ -214,11 +213,6 @@ func settingsUserDefaultsPatchHandler(w http.ResponseWriter, r *http.Request, d 
 	return http.StatusNoContent, nil
 }
 
-type sourceSettingsPatch struct {
-	DefaultPermissions  *users.SourceFilePermissions                `json:"defaultPermissions,omitempty"`
-	EnforcedPermissions *settings.SourceFilePermissionsEnforcement `json:"enforcedPermissions,omitempty"`
-}
-
 func settingsSourceGetHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, error) {
 	// Read-only global source file permission defaults (used by user edit/create UI).
 	return RenderJSON(w, r, state.GetSourceSettings())
@@ -258,14 +252,13 @@ func settingsSourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Conte
 	}
 
 	if hasValues {
-		var body sourceSettingsPatch
-		if err := json.Unmarshal(valuesPatch, &body); err != nil {
-			return http.StatusBadRequest, fmt.Errorf("invalid source settings patch JSON: %w", err)
+		if err := settings.ValidateSinglePropertyUserDefaultsPatch(valuesPatch); err != nil {
+			return http.StatusBadRequest, err
 		}
-		if body.DefaultPermissions == nil {
-			return http.StatusBadRequest, fmt.Errorf("source settings patch must include defaultPermissions")
+		if err := settings.ValidateSourceDefaultsPatchNotConfigLocked(valuesPatch); err != nil {
+			return http.StatusBadRequest, err
 		}
-		if err := state.SetSourceAccessDefaults(*body.DefaultPermissions); err != nil {
+		if err := state.PatchSourceAccessDefaults(valuesPatch); err != nil {
 			logger.Errorf("failed to update source settings: %v", err)
 			return http.StatusInternalServerError, fmt.Errorf("failed to update source settings")
 		}

--- a/backend/pkg/settings/config.go
+++ b/backend/pkg/settings/config.go
@@ -468,6 +468,23 @@ func setupSources(generate bool) {
 	}
 	Config.UserDefaults.DefaultScopes = defaultScopes
 	Config.Server.Sources = sourceList
+	finalizeConfigSourceDefaultPermissions()
+}
+
+func finalizeConfigSourceDefaultPermissions() {
+	Env.ConfigSourceDefaultPermissions = nil
+	for _, source := range Config.Server.Sources {
+		if source == nil || len(source.Config.DefaultPermissionsFromConfig) == 0 {
+			continue
+		}
+		Env.ConfigSourceDefaultPermissions = source.Config.DefaultPermissionsFromConfig
+		perms := NormalizeSourceFilePermissions(source.Config.DefaultPermissions)
+		for flag, val := range source.Config.DefaultPermissionsFromConfig {
+			setSourcePermissionFlag(&perms, flag, val)
+		}
+		source.Config.DefaultPermissions = users.MarkSourceFilePermissionsConfigured(perms)
+		return
+	}
 }
 
 func setupUrls() {
@@ -661,6 +678,8 @@ func loadConfigWithDefaults(configFile string, generate bool) error {
 		return err
 	}
 
+	attachSourceDefaultPermissionsFromConfig(filteredConfig)
+
 	loadEnvConfig()
 	return ResolveDatabasePaths()
 }
@@ -679,6 +698,41 @@ func applyLoadedUserDefaultsFromConfig(generate bool) error {
 	}
 	Config.UserDefaults = merged
 	return nil
+}
+
+func attachSourceDefaultPermissionsFromConfig(raw map[string]interface{}) {
+	server, ok := raw["server"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	sources, ok := server["sources"].([]interface{})
+	if !ok {
+		return
+	}
+	for i, srcRaw := range sources {
+		if i >= len(Config.Server.Sources) || Config.Server.Sources[i] == nil {
+			continue
+		}
+		src, ok := srcRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		config, ok := src["config"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		dp, ok := config["defaultPermissions"].(map[string]interface{})
+		if !ok || len(dp) == 0 {
+			continue
+		}
+		fromConfig := make(map[string]bool, len(dp))
+		for key, val := range dp {
+			if b, ok := val.(bool); ok {
+				fromConfig[key] = b
+			}
+		}
+		Config.Server.Sources[i].Config.DefaultPermissionsFromConfig = fromConfig
+	}
 }
 
 func ValidateConfig(config Settings) error {

--- a/backend/pkg/settings/source_access.go
+++ b/backend/pkg/settings/source_access.go
@@ -1,8 +1,15 @@
 package settings
 
 import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 )
+
+const SourceDefaultsConfigLockMessage = "some source access defaults were set in the config file and cannot be changed here until an admin removes them from the config file"
 
 // BuiltinDefaultSourceFilePermissions is used when no source access defaults are configured.
 func BuiltinDefaultSourceFilePermissions() users.SourceFilePermissions {
@@ -45,4 +52,77 @@ func DefaultSourceFilePermissions() users.SourceFilePermissions {
 		}
 	}
 	return BuiltinDefaultSourceFilePermissions()
+}
+
+// ConfigSourceDefaultLockedPaths returns API lock paths for config-specified defaultPermissions flags.
+func ConfigSourceDefaultLockedPaths() []string {
+	if len(Env.ConfigSourceDefaultPermissions) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(Env.ConfigSourceDefaultPermissions))
+	for flag := range Env.ConfigSourceDefaultPermissions {
+		paths = append(paths, "defaultPermissions."+flag)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// OverlayConfigSourceDefaults applies config-locked permission flags onto stored defaults.
+func OverlayConfigSourceDefaults(stored users.SourceFilePermissions) users.SourceFilePermissions {
+	if len(Env.ConfigSourceDefaultPermissions) == 0 {
+		return stored
+	}
+	for flag, val := range Env.ConfigSourceDefaultPermissions {
+		setSourcePermissionFlag(&stored, flag, val)
+	}
+	return NormalizeSourceFilePermissions(users.MarkSourceFilePermissionsConfigured(stored))
+}
+
+func sourcePermissionsPatchWrapper(p users.SourceFilePermissions) map[string]interface{} {
+	return map[string]interface{}{
+		"defaultPermissions": map[string]interface{}{
+			"view":     p.View,
+			"download": p.Download,
+			"modify":   p.Modify,
+			"create":   p.Create,
+			"delete":   p.Delete,
+		},
+	}
+}
+
+// MergeSourceDefaultsPatchJSON merges a partial defaultPermissions patch into base permissions.
+func MergeSourceDefaultsPatchJSON(base users.SourceFilePermissions, patchJSON []byte) (users.SourceFilePermissions, error) {
+	baseBytes, err := json.Marshal(sourcePermissionsPatchWrapper(base))
+	if err != nil {
+		return users.SourceFilePermissions{}, fmt.Errorf("marshal base source defaults: %w", err)
+	}
+	mergedBytes, err := mergeUserDefaultsJSON(baseBytes, patchJSON)
+	if err != nil {
+		return users.SourceFilePermissions{}, err
+	}
+	var wrapper struct {
+		DefaultPermissions users.SourceFilePermissions `json:"defaultPermissions"`
+	}
+	if err := json.Unmarshal(mergedBytes, &wrapper); err != nil {
+		return users.SourceFilePermissions{}, fmt.Errorf("unmarshal merged source defaults: %w", err)
+	}
+	return NormalizeSourceFilePermissions(wrapper.DefaultPermissions), nil
+}
+
+// ValidateSourceDefaultsPatchNotConfigLocked rejects patches touching config-locked permission flags.
+func ValidateSourceDefaultsPatchNotConfigLocked(patchJSON []byte) error {
+	if len(Env.ConfigSourceDefaultPermissions) == 0 {
+		return nil
+	}
+	paths, err := CollectJSONPatchLeafPaths(patchJSON)
+	if err != nil {
+		return err
+	}
+	for _, path := range paths {
+		flag := strings.TrimPrefix(path, "defaultPermissions.")
+		if _, locked := Env.ConfigSourceDefaultPermissions[flag]; locked {
+			return fmt.Errorf("source default %q is locked from config file", path)
+		}
+	}
+	return nil
 }

--- a/backend/pkg/settings/source_access.go
+++ b/backend/pkg/settings/source_access.go
@@ -72,10 +72,11 @@ func OverlayConfigSourceDefaults(stored users.SourceFilePermissions) users.Sourc
 	if len(Env.ConfigSourceDefaultPermissions) == 0 {
 		return stored
 	}
+	stored = NormalizeSourceFilePermissions(stored)
 	for flag, val := range Env.ConfigSourceDefaultPermissions {
 		setSourcePermissionFlag(&stored, flag, val)
 	}
-	return NormalizeSourceFilePermissions(users.MarkSourceFilePermissionsConfigured(stored))
+	return users.MarkSourceFilePermissionsConfigured(stored)
 }
 
 func sourcePermissionsPatchWrapper(p users.SourceFilePermissions) map[string]interface{} {

--- a/backend/pkg/settings/source_access_config_test.go
+++ b/backend/pkg/settings/source_access_config_test.go
@@ -1,0 +1,69 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+)
+
+func TestOverlayConfigSourceDefaults(t *testing.T) {
+	prev := Env.ConfigSourceDefaultPermissions
+	t.Cleanup(func() { Env.ConfigSourceDefaultPermissions = prev })
+
+	Env.ConfigSourceDefaultPermissions = map[string]bool{"modify": false}
+	stored := users.SourceFilePermissions{View: true, Download: true, Modify: true, Create: true}
+	merged := OverlayConfigSourceDefaults(stored)
+	if merged.Modify {
+		t.Fatal("expected modify overlaid from config")
+	}
+	if !merged.Create {
+		t.Fatal("expected create unchanged")
+	}
+}
+
+func TestValidateSourceDefaultsPatchNotConfigLocked(t *testing.T) {
+	prev := Env.ConfigSourceDefaultPermissions
+	t.Cleanup(func() { Env.ConfigSourceDefaultPermissions = prev })
+
+	Env.ConfigSourceDefaultPermissions = map[string]bool{"modify": false}
+	if err := ValidateSourceDefaultsPatchNotConfigLocked([]byte(`{"defaultPermissions":{"view":false}}`)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateSourceDefaultsPatchNotConfigLocked([]byte(`{"defaultPermissions":{"modify":true}}`)); err == nil {
+		t.Fatal("expected config lock error")
+	}
+}
+
+func TestConfigSourceDefaultLockedPaths(t *testing.T) {
+	prev := Env.ConfigSourceDefaultPermissions
+	t.Cleanup(func() { Env.ConfigSourceDefaultPermissions = prev })
+
+	Env.ConfigSourceDefaultPermissions = map[string]bool{"modify": false, "view": true}
+	paths := ConfigSourceDefaultLockedPaths()
+	if len(paths) != 2 {
+		t.Fatalf("paths=%v", paths)
+	}
+}
+
+func TestAttachSourceDefaultPermissionsFromConfig(t *testing.T) {
+	Config.Server.Sources = []*Source{{Path: "/data", Config: SourceConfig{}}}
+	raw := map[string]interface{}{
+		"server": map[string]interface{}{
+			"sources": []interface{}{
+				map[string]interface{}{
+					"path": "/data",
+					"config": map[string]interface{}{
+						"defaultPermissions": map[string]interface{}{
+							"modify": false,
+						},
+					},
+				},
+			},
+		},
+	}
+	attachSourceDefaultPermissionsFromConfig(raw)
+	got := Config.Server.Sources[0].Config.DefaultPermissionsFromConfig
+	if got["modify"] != false || len(got) != 1 {
+		t.Fatalf("DefaultPermissionsFromConfig: %+v", got)
+	}
+}

--- a/backend/pkg/settings/source_access_config_test.go
+++ b/backend/pkg/settings/source_access_config_test.go
@@ -21,6 +21,23 @@ func TestOverlayConfigSourceDefaults(t *testing.T) {
 	}
 }
 
+func TestOverlayConfigSourceDefaults_unsetStoredPartialConfig(t *testing.T) {
+	prev := Env.ConfigSourceDefaultPermissions
+	t.Cleanup(func() { Env.ConfigSourceDefaultPermissions = prev })
+
+	Env.ConfigSourceDefaultPermissions = map[string]bool{"modify": false}
+	merged := OverlayConfigSourceDefaults(users.SourceFilePermissions{})
+	if !merged.View || !merged.Download {
+		t.Fatalf("expected built-in view/download preserved: %+v", merged)
+	}
+	if merged.Modify {
+		t.Fatal("expected modify false from config overlay")
+	}
+	if !merged.Configured {
+		t.Fatal("expected result marked configured")
+	}
+}
+
 func TestValidateSourceDefaultsPatchNotConfigLocked(t *testing.T) {
 	prev := Env.ConfigSourceDefaultPermissions
 	t.Cleanup(func() { Env.ConfigSourceDefaultPermissions = prev })

--- a/backend/pkg/settings/source_permission_enforcement.go
+++ b/backend/pkg/settings/source_permission_enforcement.go
@@ -60,6 +60,15 @@ func applyEnforcedSourcePermissionFlag(perms *users.SourceFilePermissions, flag 
 	}
 }
 
+func setSourcePermissionFlag(perms *users.SourceFilePermissions, flag string, value bool) {
+	for _, f := range sourcePermissionFields {
+		if f.name == flag {
+			*f.field(perms) = value
+			return
+		}
+	}
+}
+
 // MergeSourceEnforcedPatchJSON merges a partial JSON patch into base source permission enforcement.
 func MergeSourceEnforcedPatchJSON(base SourceFilePermissionsEnforcement, patchJSON []byte) (SourceFilePermissionsEnforcement, error) {
 	baseBytes, err := json.Marshal(base)

--- a/backend/pkg/settings/structs.go
+++ b/backend/pkg/settings/structs.go
@@ -43,6 +43,8 @@ type Environment struct {
 	IsFirstLoad                      bool     `json:"-"` // used internally to track if this is the first load of the application
 	ConfigUserDefaultsSpecified      bool     `json:"-"` // true when the config file contained a userDefaults section
 	ConfigUserDefaultsSpecifiedPaths []string `json:"-"` // dot-paths explicitly set under userDefaults in config
+	// ConfigSourceDefaultPermissions maps permission flags explicitly set in config defaultPermissions (e.g. view -> true).
+	ConfigSourceDefaultPermissions map[string]bool `json:"-"`
 	MuPdfAvailable                   bool     `json:"-"` // used internally if compiled with mupdf support
 	EmbeddedFs                       bool     `json:"-"` // used internally if compiled with embedded fs support
 	FFmpegPath                       string   `json:"-"`
@@ -234,6 +236,8 @@ type SourceConfig struct {
 	UseLogicalSize   bool              `json:"useLogicalSize"`          // calculate sizes based on logical size instead of disk utilization (du -sh), folders will be 0 bytes when empty.
 	// DefaultPermissions is the template for new user scopes on this source (also synced globally via Access settings).
 	DefaultPermissions users.SourceFilePermissions `json:"defaultPermissions,omitempty" yaml:"defaultPermissions,omitempty"`
+	// DefaultPermissionsFromConfig holds permission flags explicitly set under defaultPermissions in config YAML.
+	DefaultPermissionsFromConfig map[string]bool `json:"-"`
 	// hidden but used internally - optimized map lookups for conditional rules
 	ResolvedRules ResolvedRulesConfig `json:"-"`
 }

--- a/frontend/src/components/settings/SourceFilePermissions.vue
+++ b/frontend/src/components/settings/SourceFilePermissions.vue
@@ -7,7 +7,8 @@
       :enforceable="enforceable"
       :enforced="!!enforcedPermissions.view"
       @update:enforced="(v) => $emit('enforced-change', 'view', v)"
-      :disabled="!!enforcedPermissions.view"
+      :disabled="isValueDisabled('view')"
+      :value-tooltip="configLockTooltip('view')"
       :name="viewPermissionName"
     />
     <ToggleSwitch
@@ -17,7 +18,8 @@
       :enforceable="enforceable"
       :enforced="!!enforcedPermissions.download"
       @update:enforced="(v) => $emit('enforced-change', 'download', v)"
-      :disabled="!!enforcedPermissions.download"
+      :disabled="isValueDisabled('download')"
+      :value-tooltip="configLockTooltip('download')"
       :name="downloadPermissionName"
     />
     <ToggleSwitch
@@ -27,7 +29,8 @@
       :enforceable="enforceable"
       :enforced="!!enforcedPermissions.modify"
       @update:enforced="(v) => $emit('enforced-change', 'modify', v)"
-      :disabled="!!enforcedPermissions.modify"
+      :disabled="isValueDisabled('modify')"
+      :value-tooltip="configLockTooltip('modify')"
       :name="modifyPermissionName"
     />
     <ToggleSwitch
@@ -37,7 +40,8 @@
       :enforceable="enforceable"
       :enforced="!!enforcedPermissions.create"
       @update:enforced="(v) => $emit('enforced-change', 'create', v)"
-      :disabled="!!enforcedPermissions.create"
+      :disabled="isValueDisabled('create')"
+      :value-tooltip="configLockTooltip('create')"
       :name="createPermissionName"
     />
     <ToggleSwitch
@@ -47,7 +51,8 @@
       :enforceable="enforceable"
       :enforced="!!enforcedPermissions.delete"
       @update:enforced="(v) => $emit('enforced-change', 'delete', v)"
-      :disabled="!!enforcedPermissions.delete"
+      :disabled="isValueDisabled('delete')"
+      :value-tooltip="configLockTooltip('delete')"
       :name="deletePermissionName"
     />
   </div>
@@ -72,6 +77,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    configLockedPaths: {
+      type: Array,
+      default: () => [],
+    },
   },
   components: {
     ToggleSwitch,
@@ -87,6 +96,34 @@ export default {
     });
   },
   methods: {
+    isConfigLocked(flag) {
+      return this.configLockedPaths.includes(`defaultPermissions.${flag}`);
+    },
+    isEnforced(flag) {
+      switch (flag) {
+        case "view":
+          return !!this.enforcedPermissions.view;
+        case "download":
+          return !!this.enforcedPermissions.download;
+        case "modify":
+          return !!this.enforcedPermissions.modify;
+        case "create":
+          return !!this.enforcedPermissions.create;
+        case "delete":
+          return !!this.enforcedPermissions.delete;
+        default:
+          return false;
+      }
+    },
+    isValueDisabled(flag) {
+      return this.isEnforced(flag) || this.isConfigLocked(flag);
+    },
+    configLockTooltip(flag) {
+      if (this.isConfigLocked(flag)) {
+        return this.$t("settings.userDefaultFieldLockedFromConfig");
+      }
+      return "";
+    },
     setPermission(key, value) {
       const current = this.permissionValue(key);
       if (current === undefined || current === value) {
@@ -112,7 +149,7 @@ export default {
           return;
       }
       if (this.emitChanges) {
-        this.$emit("changed");
+        this.$emit("changed", key);
       }
     },
     permissionValue(key) {

--- a/frontend/src/views/settings/Access.vue
+++ b/frontend/src/views/settings/Access.vue
@@ -34,6 +34,7 @@
         enforceable
         :permissions="sourceAccessDefaults"
         :enforced-permissions="sourceAccessEnforced"
+        :config-locked-paths="lockedFromConfigPaths"
         @changed="onSourceAccessDefaultsChange"
         @enforced-change="onSourceAccessEnforcedChange"
       />
@@ -116,6 +117,7 @@ export default {
       create: false,
       delete: false,
     },
+    lockedFromConfigPaths: [],
   }),
   async mounted() {
     this.selectedSource = state.sources.current;
@@ -180,22 +182,7 @@ export default {
       this.hydratingDefaults = true;
       try {
         const settings = await getSourceSettings();
-        const perms = settings?.defaultPermissions ?? {};
-        const enforced = settings?.enforcedPermissions ?? {};
-        this.sourceAccessDefaults = {
-          view: perms.view !== false,
-          download: perms.download !== false,
-          modify: !!perms.modify,
-          create: !!perms.create,
-          delete: !!perms.delete,
-        };
-        this.sourceAccessEnforced = {
-          view: !!enforced.view,
-          download: !!enforced.download,
-          modify: !!enforced.modify,
-          create: !!enforced.create,
-          delete: !!enforced.delete,
-        };
+        this.applySourceSettingsResponse(settings);
       } catch (e) {
         console.error(e);
         if (e?.message) {
@@ -218,6 +205,9 @@ export default {
     applySourceSettingsResponse(settings) {
       const perms = settings?.defaultPermissions ?? {};
       const enforced = settings?.enforcedPermissions ?? {};
+      this.lockedFromConfigPaths = Array.isArray(settings?.lockedFromConfigPaths)
+        ? settings.lockedFromConfigPaths
+        : [];
       this.sourceAccessDefaults = {
         view: perms.view !== false,
         download: perms.download !== false,
@@ -258,15 +248,40 @@ export default {
         });
       }
     },
-    async onSourceAccessDefaultsChange() {
-      if (!this.canSaveSourceDefaults()) {
+    isConfigLockedPermission(flag) {
+      return this.lockedFromConfigPaths.includes(`defaultPermissions.${flag}`);
+    },
+    sourceDefaultPermissionsPatch(flag) {
+      const perms = this.sourceAccessDefaults;
+      switch (flag) {
+        case "view":
+          return { defaultPermissions: { view: perms.view } };
+        case "download":
+          return { defaultPermissions: { download: perms.download } };
+        case "modify":
+          return { defaultPermissions: { modify: perms.modify } };
+        case "create":
+          return { defaultPermissions: { create: perms.create } };
+        case "delete":
+          return { defaultPermissions: { delete: perms.delete } };
+        default:
+          return null;
+      }
+    },
+    async onSourceAccessDefaultsChange(flag) {
+      if (!this.canSaveSourceDefaults() || !flag) {
+        return;
+      }
+      if (this.isConfigLockedPermission(flag)) {
+        return;
+      }
+      const patch = this.sourceDefaultPermissionsPatch(flag);
+      if (!patch) {
         return;
       }
       this.savingDefaults = true;
       try {
-        const settings = await patchSourceSettings({
-          defaultPermissions: this.sourceAccessDefaults,
-        });
+        const settings = await patchSourceSettings(patch);
         this.hydratingDefaults = true;
         this.applySourceSettingsResponse(settings);
         notify.showSuccessToast(this.$t("settings.settingsUpdated"));

--- a/frontend/tests/playwright/settings/source-defaults-lock.spec.ts
+++ b/frontend/tests/playwright/settings/source-defaults-lock.spec.ts
@@ -3,7 +3,6 @@ import { expect, test } from "../test-setup";
 async function openAccessSettings(page: import("@playwright/test").Page) {
   await page.goto("/settings");
   await expect(page).toHaveTitle("Graham's Filebrowser - Settings");
-  await page.locator("#access-sidebar").click();
 
   const defaultsResponse = page.waitForResponse(
     (response) =>
@@ -11,6 +10,7 @@ async function openAccessSettings(page: import("@playwright/test").Page) {
       response.request().method() === "GET" &&
       response.ok(),
   );
+  await page.locator("#access-sidebar").click();
 
   const permissionsGroup = page
     .locator(".settings-group")

--- a/frontend/tests/playwright/settings/source-defaults-lock.spec.ts
+++ b/frontend/tests/playwright/settings/source-defaults-lock.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "../test-setup";
+
+async function openAccessSettings(page: import("@playwright/test").Page) {
+  await page.goto("/settings");
+  await expect(page).toHaveTitle("Graham's Filebrowser - Settings");
+  await page.locator("#access-sidebar").click();
+
+  const defaultsResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/settings/source") &&
+      response.request().method() === "GET" &&
+      response.ok(),
+  );
+
+  const permissionsGroup = page
+    .locator(".settings-group")
+    .filter({ hasText: "Permissions" });
+  const content = permissionsGroup.locator(".settings-content");
+  if (!(await content.isVisible())) {
+    await permissionsGroup.locator(".settings-group-title.button").click();
+    await expect(content).toBeVisible();
+  }
+
+  const response = await defaultsResponse;
+  return response;
+}
+
+test("config-locked source defaults show lock help and skip patch", async ({ page, checkForErrors }) => {
+  try {
+    const defaultsResponse = await openAccessSettings(page);
+    const data = await defaultsResponse.json();
+    expect(data.lockedFromConfigPaths).toContain("defaultPermissions.modify");
+
+    const modifyRow = page
+      .locator(".source-file-permissions .item")
+      .filter({ hasText: "Edit files" });
+    await expect(modifyRow).toBeVisible();
+    await modifyRow.locator(".toggle-row--value").hover();
+    const lockTooltip = page.locator(".floating-tooltip");
+    await expect(lockTooltip).toBeVisible();
+    await expect(lockTooltip).toHaveText(
+      "This default is set in the config file and cannot be changed here.",
+    );
+
+    let patchCount = 0;
+    await page.route("**/api/settings/source", (route) => {
+      if (route.request().method() === "PATCH") {
+        patchCount += 1;
+      }
+      return route.continue();
+    });
+
+    const valueInput = modifyRow.locator(".toggle-row--value input[type='checkbox']");
+    const valueSwitch = modifyRow.locator(".toggle-row--value label.switch");
+    expect(await valueInput.isChecked()).toBe(false);
+    await expect(valueInput).toBeDisabled();
+    await valueSwitch.click({ force: true });
+    await expect.poll(() => patchCount).toBe(0);
+    expect(await valueInput.isChecked()).toBe(false);
+
+    const enforceInput = modifyRow.locator(".toggle-row--enforced input[type='checkbox']");
+    const enforceSwitch = modifyRow.locator(".toggle-row--enforced label.switch");
+    await expect(enforceInput).toBeEnabled();
+    const initialEnforced = await enforceInput.isChecked();
+    const enforcePatch = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/settings/source") &&
+        resp.request().method() === "PATCH" &&
+        resp.ok(),
+    );
+    await enforceSwitch.click();
+    await enforcePatch;
+    expect(patchCount).toBe(1);
+    expect(await enforceInput.isChecked()).toBe(!initialEnforced);
+  } finally {
+    checkForErrors();
+  }
+});


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration-controlled default permissions for sources, including Playwright files.
  * Permission settings can now be locked by configuration and clearly identify options that cannot be changed.
  * Access settings now apply permission changes individually.

* **Bug Fixes**
  * Configured permission defaults are restored after application restart.
  * Locked permissions remain protected while other controls stay editable.

* **Tests**
  * Added coverage for configuration overlays, persistence, locked settings, and the settings interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->