### PR TITLE
remove trusted header warning on devmode

### DIFF
--- a/backend/pkg/settings/config.go
+++ b/backend/pkg/settings/config.go
@@ -89,10 +89,6 @@ func setupHttp() {
 	}
 }
 
-func needsSubpathTrustProxyHeadersWarning(baseURL string, trustProxyHeaders bool) bool {
-	return baseURL != "/" && !trustProxyHeaders && !Env.IsDevMode
-}
-
 func warnHttpProxyConfig() {
 	if Env.IsDevMode || Env.IsPlaywright {
 		return

--- a/backend/pkg/settings/config.go
+++ b/backend/pkg/settings/config.go
@@ -90,11 +90,14 @@ func setupHttp() {
 }
 
 func needsSubpathTrustProxyHeadersWarning(baseURL string, trustProxyHeaders bool) bool {
-	return baseURL != "/" && !trustProxyHeaders
+	return baseURL != "/" && !trustProxyHeaders && !Env.IsDevMode
 }
 
 func warnHttpProxyConfig() {
-	if needsSubpathTrustProxyHeadersWarning(Config.Http.BaseURL, Config.Http.TrustProxyHeaders) {
+	if Env.IsDevMode || Env.IsPlaywright {
+		return
+	}
+	if Config.Http.BaseURL != "/" && !Config.Http.TrustProxyHeaders {
 		logger.Warning(`http.baseURL is not "/" but http.trustProxyHeaders is false. Behind a reverse proxy on a subpath, set trustProxyHeaders: true so cookies, client IP, OIDC redirects, and URLs resolve correctly. See https://filebrowserquantum.com/en/docs/configuration/http/#trustproxyheaders`)
 	}
 	if !Env.IsDevMode {

--- a/backend/pkg/settings/config_test.go
+++ b/backend/pkg/settings/config_test.go
@@ -118,18 +118,6 @@ func TestConfigLoadSpecificValues(t *testing.T) {
 	}
 }
 
-func TestNeedsSubpathTrustProxyHeadersWarning(t *testing.T) {
-	if !needsSubpathTrustProxyHeadersWarning("/files/", false) {
-		t.Fatal("expected warning for subpath without trustProxyHeaders")
-	}
-	if needsSubpathTrustProxyHeadersWarning("/", false) {
-		t.Fatal("expected no warning for root baseURL")
-	}
-	if needsSubpathTrustProxyHeadersWarning("/files/", true) {
-		t.Fatal("expected no warning when trustProxyHeaders is true")
-	}
-}
-
 func TestInvalidConfig(t *testing.T) {
 	// Create isolated test directory
 	testDir := t.TempDir()


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary proxy configuration warnings during development and Playwright testing.
  * Production-only external URL warnings remain appropriately restricted to production scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->