### PR TITLE
fix minimal token creation bug in v2.0.0

### DIFF
--- a/backend/internal/auth/auth.go
+++ b/backend/internal/auth/auth.go
@@ -55,7 +55,13 @@ func MakeSignedTokenAPI(user *users.User, name string, duration time.Duration, p
 		claim.Permissions = users.SanitizeTokenPermissions(perms)
 		claim.BelongsTo = user.ID
 	}
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claim)
+	signedClaims := jwt.Claims(claim)
+	if minimal {
+		// Sign only standard JWT claims. The full AuthToken struct always JSON-marshals
+		// a zero Permissions object, which bloats the token past WebDAV client limits.
+		signedClaims = claim.MinimalAuthToken
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, signedClaims)
 	tokenString, err := token.SignedString([]byte(settings.Config.Auth.Key))
 	if err != nil {
 		return "", users.AuthToken{}, err

--- a/backend/internal/auth/token_length_test.go
+++ b/backend/internal/auth/token_length_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
+)
+
+const webdavPasswordLimit = 256
+
+func TestMinimalSignedTokenLengthUnder256(t *testing.T) {
+	origKey := settings.Config.Auth.Key
+	settings.Config.Auth.Key = "test-signing-key-for-length-check"
+	t.Cleanup(func() { settings.Config.Auth.Key = origKey })
+
+	user := &users.User{ID: 42, FrontendUser: users.FrontendUser{Username: "webdavuser"}}
+	tokenString, _, err := MakeSignedTokenAPI(user, "webdav", time.Hour*24*365*10, users.Permissions{}, true)
+	if err != nil {
+		t.Fatalf("MakeSignedTokenAPI: %v", err)
+	}
+	if len(tokenString) >= webdavPasswordLimit {
+		t.Fatalf("minimal token length %d must stay under %d for WebDAV clients", len(tokenString), webdavPasswordLimit)
+	}
+	assertMinimalJWTClaims(t, tokenString)
+}
+
+func TestCustomizedTokenEmbedsPermissionsAndIsLonger(t *testing.T) {
+	origKey := settings.Config.Auth.Key
+	settings.Config.Auth.Key = "test-signing-key-for-length-check"
+	t.Cleanup(func() { settings.Config.Auth.Key = origKey })
+
+	user := &users.User{ID: 42, FrontendUser: users.FrontendUser{Username: "webdavuser"}}
+	minimal, _, err := MakeSignedTokenAPI(user, "min", time.Hour*24*365, users.Permissions{}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	custom, _, err := MakeSignedTokenAPI(user, "custom", time.Hour*24*365, users.Permissions{Api: true}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(custom) <= len(minimal) {
+		t.Fatalf("custom token should be longer than minimal: custom=%d minimal=%d", len(custom), len(minimal))
+	}
+
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(custom, claims); err != nil {
+		t.Fatalf("parse custom token: %v", err)
+	}
+	if _, ok := claims["Permissions"]; !ok {
+		t.Fatal("custom token payload should include Permissions claim")
+	}
+}
+
+func assertMinimalJWTClaims(t *testing.T, tokenString string) {
+	t.Helper()
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(tokenString, claims); err != nil {
+		t.Fatalf("parse token: %v", err)
+	}
+	for _, key := range []string{"Permissions", "permissions", "belongsTo", "username", "name"} {
+		if _, ok := claims[key]; ok {
+			t.Fatalf("minimal token must not include %q claim; got %v", key, claims)
+		}
+	}
+}

--- a/backend/internal/web/api.go
+++ b/backend/internal/web/api.go
@@ -48,8 +48,8 @@ func createApiTokenHandler(w http.ResponseWriter, r *http.Request, d *Context) (
 		return http.StatusBadRequest, fmt.Errorf("api token duration must be valid")
 	}
 
-	// For full tokens (minimal=false), permissions are required in the claim
-	// For minimal tokens (minimal=true), permissions are not in the token
+	// For full tokens (minimal=false), permissions are embedded in the JWT claim.
+	// For minimal tokens (minimal=true), only standard JWT claims are included.
 	var permissions users.Permissions
 	if !minimal {
 		permissions = users.Permissions{
@@ -59,6 +59,9 @@ func createApiTokenHandler(w http.ResponseWriter, r *http.Request, d *Context) (
 			Realtime: strings.Contains(permissionsStr, "realtime") && d.User.Permissions.Realtime,
 		}
 		permissions = users.SanitizeTokenPermissions(permissions)
+		if !users.HasAnyGlobalPermission(permissions) {
+			minimal = true
+		}
 	}
 
 	// Convert the duration string to an int64

--- a/backend/internal/web/api.go
+++ b/backend/internal/web/api.go
@@ -24,7 +24,8 @@ import (
 // @Produce json
 // @Param name query string true "Name of the API token"
 // @Param days query string true "Duration of the API token in days"
-// @Param permissions query string false "Global permissions for the API token (comma-separated: admin, api, share, realtime). Omit for minimal token."
+// @Param permissions query string false "Global permissions (comma-separated: admin, api, share, realtime). Send \"minimal\" or omit with minimal=true for a WebDAV-compatible token."
+// @Param minimal query bool false "When true, create a minimal token (standard JWT claims only). When false, create a customized token using permissions (may be empty)."
 // @Success 200 {object} HttpResponse "Token created successfully, response contains json object with token"
 // @Failure 400 {object} map[string]string "Bad request"
 // @Failure 404 {object} map[string]string "Not found"
@@ -34,8 +35,7 @@ import (
 func createApiTokenHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, error) {
 	name := r.URL.Query().Get("name")
 	durationStr := r.URL.Query().Get("days")
-	permissionsStr := r.URL.Query().Get("permissions")
-	minimal := permissionsStr == ""
+	minimal, permissionsStr := apiTokenCreationMode(r)
 
 	if !d.User.Permissions.Api {
 		return http.StatusForbidden, fmt.Errorf("user does not have permission to create api tokens")
@@ -59,9 +59,6 @@ func createApiTokenHandler(w http.ResponseWriter, r *http.Request, d *Context) (
 			Realtime: strings.Contains(permissionsStr, "realtime") && d.User.Permissions.Realtime,
 		}
 		permissions = users.SanitizeTokenPermissions(permissions)
-		if !users.HasAnyGlobalPermission(permissions) {
-			minimal = true
-		}
 	}
 
 	// Convert the duration string to an int64
@@ -100,6 +97,33 @@ func createApiTokenHandler(w http.ResponseWriter, r *http.Request, d *Context) (
 	}
 	activity.RecordTokenMutation(r, toActor(d), activitydb.EventTokenCreate, name)
 	return RenderJSON(w, r, response)
+}
+
+const apiTokenPermissionsMinimal = "minimal"
+
+// apiTokenCreationMode decides whether to mint a minimal JWT or a customized token from query params.
+// minimal=true or permissions=minimal → minimal token (WebDAV-compatible).
+// minimal=false → customized token; permissions may be empty (all global caps false in the claim).
+// Legacy clients omitting both minimal and permissions still receive a minimal token.
+func apiTokenCreationMode(r *http.Request) (minimal bool, permissionsStr string) {
+	permissionsStr = r.URL.Query().Get("permissions")
+	if strings.EqualFold(permissionsStr, apiTokenPermissionsMinimal) {
+		return true, ""
+	}
+
+	if minimalValues, ok := r.URL.Query()["minimal"]; ok && len(minimalValues) > 0 {
+		switch strings.ToLower(strings.TrimSpace(minimalValues[0])) {
+		case "true", "1":
+			return true, permissionsStr
+		case "false", "0":
+			return false, permissionsStr
+		}
+	}
+
+	if permissionsStr == "" {
+		return true, ""
+	}
+	return false, permissionsStr
 }
 
 // deleteApiTokenHandler deletes an API token for the user.

--- a/backend/internal/web/api_test.go
+++ b/backend/internal/web/api_test.go
@@ -1,0 +1,151 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/auth"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/state"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
+)
+
+const webdavPasswordLimit = 256
+
+func TestCreateApiTokenUncustomizedUnder256(t *testing.T) {
+	setupTestEnv(t)
+	setTestAuthKey(t)
+
+	user := createApiTokenTestUser(t, "tokenuser", users.Permissions{Api: true})
+	rec := invokeCreateApiToken(t, user, "/auth/token?name=webdav&days=365")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	token := decodeCreatedToken(t, rec.Body.Bytes())
+	if len(token) >= webdavPasswordLimit {
+		t.Fatalf("uncustomized token length %d must stay under %d", len(token), webdavPasswordLimit)
+	}
+	assertHandlerMinimalJWTClaims(t, token)
+}
+
+func TestCreateApiTokenPermissionsParamIgnoredWhenNoEffectiveCaps(t *testing.T) {
+	setupTestEnv(t)
+	setTestAuthKey(t)
+
+	// User can create API tokens but lacks admin; requesting admin should not produce a fat JWT.
+	user := createApiTokenTestUser(t, "tokenuser2", users.Permissions{Api: true})
+	rec := invokeCreateApiToken(t, user, "/auth/token?name=webdav&days=365&permissions=admin")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	token := decodeCreatedToken(t, rec.Body.Bytes())
+	if len(token) >= webdavPasswordLimit {
+		t.Fatalf("token length %d must stay under %d when permissions resolve to none", len(token), webdavPasswordLimit)
+	}
+	assertHandlerMinimalJWTClaims(t, token)
+}
+
+func TestCreateApiTokenCustomizedWithEffectiveCaps(t *testing.T) {
+	setupTestEnv(t)
+	setTestAuthKey(t)
+
+	user := createApiTokenTestUser(t, "tokenuser3", users.Permissions{Api: true, Admin: true})
+	rec := invokeCreateApiToken(t, user, "/auth/token?name=custom&days=30&permissions=admin,api")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	token := decodeCreatedToken(t, rec.Body.Bytes())
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
+		t.Fatalf("parse token: %v", err)
+	}
+	perms, ok := claims["Permissions"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected Permissions claim in customized token, got %v", claims)
+	}
+	if perms["admin"] != true || perms["api"] != true {
+		t.Fatalf("expected admin and api true, got %v", perms)
+	}
+}
+
+func setTestAuthKey(t *testing.T) {
+	t.Helper()
+	orig := settings.Config.Auth.Key
+	settings.Config.Auth.Key = "test-signing-key-for-length-check"
+	t.Cleanup(func() { settings.Config.Auth.Key = orig })
+}
+
+func createApiTokenTestUser(t *testing.T, username string, perms users.Permissions) *users.User {
+	t.Helper()
+	user := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username:    username,
+			Permissions: perms,
+		},
+	}
+	if err := state.CreateUser(user, "password"); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	got, err := state.GetUserByUsername(username)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	got.Permissions = perms
+	if err = state.UpdateUser(&got, "", "permissions"); err != nil {
+		t.Fatalf("update permissions: %v", err)
+	}
+	got, err = state.GetUserByUsername(username)
+	if err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	return &got
+}
+
+func invokeCreateApiToken(t *testing.T, user *users.User, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := &Context{User: user, Ctx: req.Context()}
+	status, err := createApiTokenHandler(rec, req, ctx)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, status, rec.Body.String())
+	}
+	return rec
+}
+
+func decodeCreatedToken(t *testing.T, body []byte) string {
+	t.Helper()
+	var resp HttpResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Token == "" {
+		t.Fatalf("empty token in response: %s", body)
+	}
+	return resp.Token
+}
+
+func assertHandlerMinimalJWTClaims(t *testing.T, tokenString string) {
+	t.Helper()
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(tokenString, claims); err != nil {
+		t.Fatalf("parse token: %v", err)
+	}
+	for _, key := range []string{"Permissions", "permissions", "belongsTo", "username", "name"} {
+		if _, ok := claims[key]; ok {
+			t.Fatalf("minimal token must not include %q claim; got %v", key, claims)
+		}
+	}
+	if claims["iss"] != auth.FB_ISSUER {
+		t.Fatalf("expected iss %q, got %v", auth.FB_ISSUER, claims["iss"])
+	}
+}

--- a/backend/internal/web/api_test.go
+++ b/backend/internal/web/api_test.go
@@ -15,12 +15,50 @@ import (
 
 const webdavPasswordLimit = 256
 
+func TestApiTokenCreationMode(t *testing.T) {
+	t.Run("permissions minimal keyword", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/token?permissions=minimal", http.NoBody)
+		minimal, perms := apiTokenCreationMode(req)
+		if !minimal || perms != "" {
+			t.Fatalf("got minimal=%v perms=%q", minimal, perms)
+		}
+	})
+	t.Run("minimal true boolean", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/token?minimal=true", http.NoBody)
+		minimal, _ := apiTokenCreationMode(req)
+		if !minimal {
+			t.Fatal("expected minimal")
+		}
+	})
+	t.Run("minimal false with empty permissions", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/token?minimal=false", http.NoBody)
+		minimal, perms := apiTokenCreationMode(req)
+		if minimal || perms != "" {
+			t.Fatalf("got minimal=%v perms=%q", minimal, perms)
+		}
+	})
+	t.Run("legacy omit both", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/token", http.NoBody)
+		minimal, _ := apiTokenCreationMode(req)
+		if !minimal {
+			t.Fatal("expected legacy default minimal")
+		}
+	})
+	t.Run("legacy permissions list", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/token?permissions=api,admin", http.NoBody)
+		minimal, perms := apiTokenCreationMode(req)
+		if minimal || perms != "api,admin" {
+			t.Fatalf("got minimal=%v perms=%q", minimal, perms)
+		}
+	})
+}
+
 func TestCreateApiTokenUncustomizedUnder256(t *testing.T) {
 	setupTestEnv(t)
 	setTestAuthKey(t)
 
 	user := createApiTokenTestUser(t, "tokenuser", users.Permissions{Api: true})
-	rec := invokeCreateApiToken(t, user, "/auth/token?name=webdav&days=365")
+	rec := invokeCreateApiToken(t, user, "/auth/token?name=webdav&days=365&permissions=minimal")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
@@ -32,22 +70,41 @@ func TestCreateApiTokenUncustomizedUnder256(t *testing.T) {
 	assertHandlerMinimalJWTClaims(t, token)
 }
 
-func TestCreateApiTokenPermissionsParamIgnoredWhenNoEffectiveCaps(t *testing.T) {
+func TestCreateApiTokenLegacyOmitPermissionsStillMinimal(t *testing.T) {
 	setupTestEnv(t)
 	setTestAuthKey(t)
 
-	// User can create API tokens but lacks admin; requesting admin should not produce a fat JWT.
+	user := createApiTokenTestUser(t, "tokenuser-legacy", users.Permissions{Api: true})
+	rec := invokeCreateApiToken(t, user, "/auth/token?name=webdav&days=365")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertHandlerMinimalJWTClaims(t, decodeCreatedToken(t, rec.Body.Bytes()))
+}
+
+func TestCreateApiTokenCustomizedWithNoEffectiveCapsKeepsPermissionsClaim(t *testing.T) {
+	setupTestEnv(t)
+	setTestAuthKey(t)
+
+	// User can create API tokens but lacks admin; explicit customized token keeps Permissions in JWT.
 	user := createApiTokenTestUser(t, "tokenuser2", users.Permissions{Api: true})
-	rec := invokeCreateApiToken(t, user, "/auth/token?name=webdav&days=365&permissions=admin")
+	rec := invokeCreateApiToken(t, user, "/auth/token?name=custom&days=365&minimal=false&permissions=admin")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
 	token := decodeCreatedToken(t, rec.Body.Bytes())
-	if len(token) >= webdavPasswordLimit {
-		t.Fatalf("token length %d must stay under %d when permissions resolve to none", len(token), webdavPasswordLimit)
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
+		t.Fatalf("parse token: %v", err)
 	}
-	assertHandlerMinimalJWTClaims(t, token)
+	perms, ok := claims["Permissions"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("customized token should include Permissions claim, got %v", claims)
+	}
+	if perms["admin"] != false {
+		t.Fatalf("expected admin false in customized token, got %v", perms["admin"])
+	}
 }
 
 func TestCreateApiTokenCustomizedWithEffectiveCaps(t *testing.T) {

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -948,8 +948,14 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Global permissions for the API token (comma-separated: admin, api, share, realtime). Omit for minimal token.",
+                        "description": "Global permissions (comma-separated: admin, api, share, realtime). Send \\",
                         "name": "permissions",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "When true, create a minimal token (standard JWT claims only). When false, create a customized token using permissions (may be empty).",
+                        "name": "minimal",
                         "in": "query"
                     }
                 ],

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -937,8 +937,14 @@
                     },
                     {
                         "type": "string",
-                        "description": "Global permissions for the API token (comma-separated: admin, api, share, realtime). Omit for minimal token.",
+                        "description": "Global permissions (comma-separated: admin, api, share, realtime). Send \\",
                         "name": "permissions",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "When true, create a minimal token (standard JWT claims only). When false, create a customized token using permissions (may be empty).",
+                        "name": "minimal",
                         "in": "query"
                     }
                 ],

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -2972,11 +2972,16 @@ paths:
         name: days
         required: true
         type: string
-      - description: 'Global permissions for the API token (comma-separated: admin,
-          api, share, realtime). Omit for minimal token.'
+      - description: 'Global permissions (comma-separated: admin, api, share, realtime).
+          Send \'
         in: query
         name: permissions
         type: string
+      - description: When true, create a minimal token (standard JWT claims only).
+          When false, create a customized token using permissions (may be empty).
+        in: query
+        name: minimal
+        type: boolean
       produces:
       - application/json
       responses:

--- a/frontend/src/components/prompts/CreateApi.vue
+++ b/frontend/src/components/prompts/CreateApi.vue
@@ -125,17 +125,18 @@ export default {
         const params = {
           name: this.apiName,
           days: this.durationInDays,
-          minimal: !this.customizeToken, // minimal = true when NOT customizing
         };
 
-        // Only include permissions when customizing token
+        // Only send permissions when customizing and at least one cap is selected.
+        // Omitting permissions tells the backend to create a minimal (WebDAV-compatible) token.
         if (this.customizeToken) {
-          // Filter to get keys of permissions set to true and join them as a comma-separated string
           const permissionsString = Object.entries(this.localPerms)
             .filter(([, value]) => value)
             .map(([key]) => key)
             .join(",");
-          params.permissions = permissionsString;
+          if (permissionsString) {
+            params.permissions = permissionsString;
+          }
         }
 
         await authApi.createApiKey(params);

--- a/frontend/src/components/prompts/CreateApi.vue
+++ b/frontend/src/components/prompts/CreateApi.vue
@@ -127,9 +127,8 @@ export default {
           days: this.durationInDays,
         };
 
-        // Only send permissions when customizing and at least one cap is selected.
-        // Omitting permissions tells the backend to create a minimal (WebDAV-compatible) token.
         if (this.customizeToken) {
+          params.minimal = false;
           const permissionsString = Object.entries(this.localPerms)
             .filter(([, value]) => value)
             .map(([key]) => key)
@@ -137,6 +136,8 @@ export default {
           if (permissionsString) {
             params.permissions = permissionsString;
           }
+        } else {
+          params.permissions = "minimal";
         }
 
         await authApi.createApiKey(params);

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -311,10 +311,13 @@ export default {
         // Valid share - add the hash and other required fields, then store in state
         shareInfo.hash = hash;
 
-        if (this.lastShareHash !== hash) {
+        const sameShare =
+          this.lastShareHash.length === hash.length &&
+          this.lastShareHash.indexOf(hash) === 0;
+        if (this.lastShareHash && !sameShare) {
           this.sharePassword = "";
-          this.lastShareHash = hash;
         }
+        this.lastShareHash = hash;
 
         // Parse share route to get subPath
         const urlPath = getters.routePath('public/share')


### PR DESCRIPTION
Fixes https://github.com/gtsteffaniak/filebrowser/issues/2503 in v2.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API tokens now support explicit minimal or customized modes.
  * Minimal tokens use shorter claims, while customized tokens include granted permissions.
  * Legacy token creation behavior remains supported when options are omitted.
* **Bug Fixes**
  * Prevented ineffective permission requests from unnecessarily customizing tokens.
  * Preserved share passwords when navigating to compatible share links.
  * Share passwords are cleared when the share link changes incompatibly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->