### PR TITLE
fixed webdav api token creation bug (#2740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. For commit guidelines, please refer to [Standard Version](https://github.com/conventional-changelog/standard-version).
 
+## v1.5.5
+
+ **BugFixes**:
+ - fix uncustomized (minimal) API tokens creation needed by webdav clients (#2503)
+
 ## v1.5.4
 
  **Notes**:

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -55,7 +55,13 @@ func MakeSignedTokenAPI(user *users.User, name string, duration time.Duration, p
 		claim.Permissions = perms
 		claim.BelongsTo = user.ID
 	}
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claim)
+	signedClaims := jwt.Claims(claim)
+	if minimal {
+		// Sign only standard JWT claims. The full AuthToken struct always JSON-marshals
+		// a zero Permissions object, which bloats the token past WebDAV client limits.
+		signedClaims = claim.MinimalAuthToken
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, signedClaims)
 	tokenString, err := token.SignedString([]byte(settings.Config.Auth.Key))
 	if err != nil {
 		return "", users.AuthToken{}, err

--- a/backend/http/api.go
+++ b/backend/http/api.go
@@ -45,8 +45,8 @@ func createApiTokenHandler(w http.ResponseWriter, r *http.Request, d *requestCon
 		return http.StatusBadRequest, fmt.Errorf("api token duration must be valid")
 	}
 
-	// For full tokens (minimal=false), permissions are required in the claim
-	// For minimal tokens (minimal=true), permissions are not in the token
+	// For full tokens (minimal=false), permissions are embedded in the JWT claim.
+	// For minimal tokens (minimal=true), only standard JWT claims are included.
 	var permissions users.Permissions
 	if !minimal {
 		// Parse permissions from the query parameter
@@ -59,6 +59,10 @@ func createApiTokenHandler(w http.ResponseWriter, r *http.Request, d *requestCon
 			Share:    strings.Contains(permissionsStr, "share") && d.user.Permissions.Share,
 			Realtime: strings.Contains(permissionsStr, "realtime") && d.user.Permissions.Realtime,
 			Download: strings.Contains(permissionsStr, "download") && d.user.Permissions.Download,
+		}
+		if !permissions.Api && !permissions.Admin && !permissions.Modify && !permissions.Delete &&
+			!permissions.Create && !permissions.Share && !permissions.Realtime && !permissions.Download {
+			minimal = true
 		}
 	}
 


### PR DESCRIPTION
## v1.5.5

 **BugFixes**:
 - fix uncustomized (minimal) API tokens creation needed by webdav clients (#2503)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed creation of minimal API tokens for WebDAV clients and other compatible integrations.
  - Minimal tokens now contain only standard authentication information, improving compatibility.
  - API token creation automatically uses minimal-token mode when no permissions are granted.
  - Full tokens continue to include the permissions needed for authorized access.

- **Documentation**
  - Updated release notes and token-related guidance to clarify the difference between full and minimal API tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->