### PR TITLE
fix download button show on gallery view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file. For commit 
  - PDF preview generation prevents file uploads from completing (#2752)
  - Brings back double-tap to zoom images that was mistakenly removed.
  - multiple embedded subtitles with same language bug (#2756)
+ - gallery view download button missing (#2767)
 
 ## v2.0.0
 

--- a/frontend/src/components/files/Icon.vue
+++ b/frontend/src/components/files/Icon.vue
@@ -512,6 +512,28 @@ export default {
   opacity: 0.7;
 }
 
+.overlay-icon--bottom {
+  top: auto;
+  left: auto;
+  bottom: 0;
+  right: 0;
+  width: auto !important;
+  height: auto !important;
+  pointer-events: auto;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: none;
+  line-height: 1;
+}
+
+.overlay-icon--bottom.clickable:hover {
+  transform: none;
+  box-shadow: none !important;
+  opacity: 1;
+}
+
 .file-icons [aria-label^="."] {
   opacity: 0.33;
 }

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -52,7 +52,7 @@
         class="material-symbols overlay-icon overlay-icon--bottom clickable"
         aria-label="Download"
         @click.stop.prevent="downloadFile"
-      >file_download</button>
+      >file_download</button> <!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
     </div>
 
     <div class="text">
@@ -133,7 +133,7 @@
         class="material-symbols overlay-icon overlay-icon--bottom clickable"
         aria-label="Download"
         @click.stop.prevent="downloadFile"
-      >file_download</button>
+      >file_download</button> <!-- eslint-disable-line @intlify/vue-i18n/no-raw-text -->
     </div>
 
     <div class="text">

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -46,6 +46,13 @@
         :isShared="isShared"
         :viewToken="viewToken"
       />
+      <button
+        v-if="quickDownloadEnabled && galleryView"
+        type="button"
+        class="material-symbols overlay-icon overlay-icon--bottom clickable"
+        aria-label="Download"
+        @click.stop.prevent="downloadFile"
+      >file_download</button>
     </div>
 
     <div class="text">
@@ -68,7 +75,7 @@
 
     <Icon
       @click.stop="downloadFile"
-      v-if="quickDownloadEnabled"
+      v-if="quickDownloadEnabled && !galleryView"
       :filename="name"
       :hasPreview="hasPreview"
       mimetype="file_download"
@@ -120,6 +127,13 @@
         :isShared="isShared"
         :viewToken="viewToken"
       />
+      <button
+        v-if="quickDownloadEnabled && galleryView"
+        type="button"
+        class="material-symbols overlay-icon overlay-icon--bottom clickable"
+        aria-label="Download"
+        @click.stop.prevent="downloadFile"
+      >file_download</button>
     </div>
 
     <div class="text">
@@ -241,9 +255,9 @@ export default {
     },
     quickDownloadEnabled() {
       if (getters.isShare()) {
-        return state.shareInfo?.quickDownload && !this.galleryView;
+        return state.shareInfo?.quickDownload;
       }
-      return state.user?.quickDownload && !this.galleryView;
+      return state.user?.quickDownload;
     },
     quickDownloadPlaceholder() {
       if (getters.isShare()) {
@@ -762,6 +776,15 @@ export default {
             mutations.resetSelected();
             mutations.addSelected(this.index);
             mutations.setLastSelectedIndex(this.index);
+            return;
+          }
+
+          // Single-select: clicking the only selected item again should deselect it.
+          // ListingView's clickClear only runs when the click target is a child element,
+          // but list/compact rows are full-width <a> tags so clicks often hit the anchor directly.
+          mutations.resetSelected();
+          if (event.currentTarget instanceof HTMLElement) {
+            event.currentTarget.blur();
           }
           return;
         }

--- a/frontend/src/css/listing.css
+++ b/frontend/src/css/listing.css
@@ -170,6 +170,7 @@ body.rtl .listing-items {
   height: 100%;
   aspect-ratio: 1;
   transition: all 0.25s ease-out;
+  position: relative;
 }
 
 .listing-items.gallery .listing-item .text {


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored the missing download button in gallery view.
  - Improved selection behavior so clicking the only selected item clears the selection.

- **New Features**
  - Added quick-download controls to gallery items.
  - Added hover styling and clearer positioning for gallery download actions.
  - Preserved quick-download controls in other views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->