### PR TITLE
fix(i18n): fix German wording for closeAnyway button

### DIFF
--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -21,7 +21,7 @@
     "discardAndExit": "Verwerfen und Beenden",
     "saveAndExit": "Speichern und Beenden",
     "keepEditing": "Weiter bearbeiten",
-    "closeAnyway": "Jedenfalls schließen",
+    "closeAnyway": "Trotzdem schließen",
     "watchFile": "Datei beobachten",
     "showMore": "Erweiterte Optionen anzeigen",
     "showLess": "Erweiterte Optionen ausblenden",


### PR DESCRIPTION
## Summary
Update German translation for the closeAnyway button from "Jedenfalls schließen" to "Trotzdem schließen" because it sounded unnatural like "close in any case / anyhow".

## Testing
- jq empty frontend/src/i18n/de.json
- Not run: npm i18n checks / make check-all because node is not installed in this environment