### PR TITLE
next/previous button and typing selection on listing view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. For commit 
  - GroupMap `SyncUserGroups` fix so JWT/OIDC/LDAP group memberships survive restart (#2742).
  - Session renew is handled by client keep-alive. removed per-request `X-Renew-Token` header handling.
  - Improvements to document thumbnail generation performance.
+ - behavior changes for typing to select files in listing view.
+ - next/previous buttons don't hide automatically on photos (#2767)
 
  **Bugfixes**:
  - GroupMap mutations (`SyncUserGroups`, add/remove group members) are write-through to SQL so JWT/OIDC/LDAP group memberships survive restart (#2742).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. For commit 
  - gallery view download button missing (#2767)
  - fixed HEIC rotation regression from v1.5.x
  - fixed raw image preview regression from v1.5.x
+ - html viewer takes full height
 
 ## v2.0.0
 

--- a/frontend/src/components/Search.vue
+++ b/frontend/src/components/Search.vue
@@ -156,6 +156,7 @@ import { getters, mutations, state } from "@/store";
 import { url } from "@/utils/";
 import { globalVars } from "@/utils/constants";
 import { getHumanReadableFilesize } from "@/utils/filesizes";
+import { isTypeAheadSessionActive } from "@/utils/listingTypeAhead.js";
 import { utcStartOfDaySecondsFromDateInput } from "@/utils/moment";
 
 const boxes = {
@@ -266,6 +267,14 @@ export default {
 
     // Add keyboard event listener for "/" to activate search
     this.handleKeydown = (event) => {
+      if (
+        (event.key === '/' || event.key === ' ') &&
+        isTypeAheadSessionActive() &&
+        getters.currentView() === 'listingView'
+      ) {
+        event.preventDefault();
+        return;
+      }
       if ((event.key === '/' || event.key === ' ') && !state.isSearchActive && !getters.currentPrompt()) {
         event.preventDefault();
         this.open();

--- a/frontend/src/components/files/ExtendedImage.vue
+++ b/frontend/src/components/files/ExtendedImage.vue
@@ -41,10 +41,6 @@ import { getters, mutations, state } from '@/store';
 import { globalVars } from "@/utils/constants";
 import { getBestCachedImage } from "@/utils/imageCache";
 import { isRawImageMimeType } from "@/utils/mimetype";
-import {
-  isInLeftNavTapZone,
-  isInRightNavTapZone,
-} from "@/utils/navigationEdgeZones.js";
 import { refreshViewToken, requestViewIdentity } from "@/api/viewToken.js";
 import throttle from "@/utils/throttle";
 
@@ -104,6 +100,13 @@ export default {
       edgeRubberMax: 100,
       pinchActive: false,
       viewTokenRetried: false,
+      zoomTapStartX: 0,
+      zoomTapStartY: 0,
+      zoomTapMoved: false,
+      zoomTapToggleTimer: null,
+      zoomMouseMoved: false,
+      zoomMouseStartX: 0,
+      zoomMouseStartY: 0,
     };
   },
   computed: {
@@ -206,6 +209,7 @@ export default {
       clearTimeout(this.disabledTimer);
       this.disabledTimer = null;
     }
+    this.cancelZoomTapNavToggle();
     this.teardownEdgeMouseListeners();
     mutations.setNavigationGestureHint({});
     window.removeEventListener("resize", this.onResize);
@@ -232,17 +236,26 @@ export default {
       }
       mutations.setNavigationGestureHint({ kind, commitReady, flashClose });
     },
-    peekNavChromeForEdgeTap(clientX) {
-      if (!this.navigationGestureAllowed) {
-        return;
+    cancelZoomTapNavToggle() {
+      if (this.zoomTapToggleTimer) {
+        clearTimeout(this.zoomTapToggleTimer);
+        this.zoomTapToggleTimer = null;
       }
-      const moveWithSidebar = getters.isSidebarVisible() && getters.isStickySidebar();
-      const sidebarWidthEm = state.sidebar?.width || 20;
-      const opts = { moveWithSidebar, sidebarWidthEm };
-      if (this.hasImagePrevious && isInLeftNavTapZone(clientX, opts)) {
-        mutations.peekNavigationChrome('left');
-      } else if (this.hasImageNext && isInRightNavTapZone(clientX)) {
-        mutations.peekNavigationChrome('right');
+    },
+    scheduleZoomTapNavToggle() {
+      this.cancelZoomTapNavToggle();
+      this.zoomTapToggleTimer = setTimeout(() => {
+        this.zoomTapToggleTimer = null;
+        if (this.navigationGestureAllowed) {
+          mutations.toggleNavigationChrome();
+        }
+      }, 300);
+    },
+    tryToggleNavOnZoomedTap(startX, startY, endX, endY) {
+      const ax = Math.abs(endX - startX);
+      const ay = Math.abs(endY - startY);
+      if (ax < this.edgeHintPx && ay < this.edgeHintPx) {
+        this.scheduleZoomTapNavToggle();
       }
     },
     loadFullImage() {
@@ -515,9 +528,9 @@ export default {
         const ax = Math.abs(this.edgeDx);
         const ay = Math.abs(this.edgeDy);
         if (ax < this.edgeHintPx && ay < this.edgeHintPx) {
-          // Short tap: image touch handlers suppress synthetic click, so peek
-          // nav chrome here the same way plyrViewer does for video edge taps.
-          this.peekNavChromeForEdgeTap(this.edgeStartClientX);
+          if (this.navigationGestureAllowed) {
+            mutations.toggleNavigationChrome();
+          }
           this.snapBackEdgeGesture();
           return;
         }
@@ -616,11 +629,18 @@ export default {
       this.lastX = null;
       this.lastY = null;
       this.inDrag = true;
+      this.zoomMouseMoved = false;
+      this.cancelZoomTapNavToggle();
+      this.zoomMouseStartX = event.clientX;
+      this.zoomMouseStartY = event.clientY;
       event.preventDefault();
     },
     mouseMove(event) {
       if (event.button !== 0) return;
       if (this.scale > 1 && this.inDrag) {
+        if (event.movementX !== 0 || event.movementY !== 0) {
+          this.zoomMouseMoved = true;
+        }
         this.doMove(event.movementX, event.movementY);
         event.preventDefault();
       }
@@ -628,6 +648,14 @@ export default {
     mouseUp(event) {
       if (event.button !== 0) return;
       if (this.scale > 1) {
+        if (!this.zoomMouseMoved) {
+          this.tryToggleNavOnZoomedTap(
+            this.zoomMouseStartX,
+            this.zoomMouseStartY,
+            event.clientX,
+            event.clientY,
+          );
+        }
         this.inDrag = false;
         event.preventDefault();
       }
@@ -653,6 +681,12 @@ export default {
         this.edgeDy = 0;
         this.edgeKind = null;
         this.gestureDecided = false;
+      } else if (event.targetTouches.length === 1 && this.scale > 1) {
+        this.cancelZoomTapNavToggle();
+        const touch = event.targetTouches[0];
+        this.zoomTapStartX = touch.pageX;
+        this.zoomTapStartY = touch.pageY;
+        this.zoomTapMoved = false;
       } else {
         this.resetEdgeGestureImmediate();
         this.applyImgTransform();
@@ -665,6 +699,7 @@ export default {
         }, 300);
         this.touches++;
         if (this.touches > 1) {
+          this.cancelZoomTapNavToggle();
           // zoomAuto may set scale back to 1 before touchend; do not treat that
           // touchend as an edge swipe (stale edgeStart would navigate).
           this.edgeGestureActive = false;
@@ -732,15 +767,21 @@ export default {
       }
       if (event.targetTouches.length === 1 && this.scale > 1) {
         if (this.moveDisabled) return;
+        const touch = event.targetTouches[0];
+        const ax = Math.abs(touch.pageX - this.zoomTapStartX);
+        const ay = Math.abs(touch.pageY - this.zoomTapStartY);
+        if (ax > 10 || ay > 10) {
+          this.zoomTapMoved = true;
+        }
         if (this.lastX === null) {
-          this.lastX = event.targetTouches[0].pageX;
-          this.lastY = event.targetTouches[0].pageY;
+          this.lastX = touch.pageX;
+          this.lastY = touch.pageY;
           return;
         }
-        const x = event.targetTouches[0].pageX - this.lastX;
-        const y = event.targetTouches[0].pageY - this.lastY;
-        this.lastX = event.targetTouches[0].pageX;
-        this.lastY = event.targetTouches[0].pageY;
+        const x = touch.pageX - this.lastX;
+        const y = touch.pageY - this.lastY;
+        this.lastX = touch.pageX;
+        this.lastY = touch.pageY;
         this.doMove(x, y);
       }
     },
@@ -784,7 +825,16 @@ export default {
         this.edgeDy = t.pageY - this.edgeStartY;
         this.finishEdgeGesture();
         event.preventDefault();
-      } else if (this.scale > 1) {
+      } else if (this.scale > 1 && event.changedTouches.length > 0) {
+        if (!this.zoomTapMoved) {
+          const t = event.changedTouches[0];
+          this.tryToggleNavOnZoomedTap(
+            this.zoomTapStartX,
+            this.zoomTapStartY,
+            t.pageX,
+            t.pageY,
+          );
+        }
         event.preventDefault();
       }
       this.edgeGestureActive = false;

--- a/frontend/src/components/files/Icon.vue
+++ b/frontend/src/components/files/Icon.vue
@@ -670,6 +670,10 @@ export default {
   position: relative;
 }
 
+.gallery .image-preview {
+  border-radius: 0;
+}
+
 /* Universal icon styling - uses --icon-font-size variable */
 .image-preview i {
   padding: 0.1em;

--- a/frontend/src/components/files/nextPrevious.vue
+++ b/frontend/src/components/files/nextPrevious.vue
@@ -172,8 +172,10 @@ export default {
       );
     },
     autoShowNavForMediaPreview() {
-      const pt = getters.previewType();
-      return pt === 'image' || pt === 'video';
+      return getters.previewType() === 'video';
+    },
+    isImagePreview() {
+      return getters.previewType() === 'image';
     },
     /** Close mirrors swipe-down dismiss only (not with prev/next on load or edge hover). */
     showCloseNavChrome() {
@@ -483,24 +485,32 @@ export default {
       });
     },
     showInitialNavigation() {
-      // Show navigation initially for 3 seconds when navigation is set up
-      if (this.enabled && (this.hasPrevious || this.hasNext || this.autoShowNavForMediaPreview)) {
-        mutations.setNavigationShow(true);
-
-        mutations.clearNavigationTimeout();
-        if (this.navigationTimeout) {
-          clearTimeout(this.navigationTimeout);
-          this.navigationTimeout = null;
-        }
-
-        this.navigationTimeout = setTimeout(() => {
-          if (!this.hoverNav) {
-            mutations.setNavigationShow(false);
-          }
-          this.navigationTimeout = null;
-        }, 3000);
-        mutations.setNavigationTimeout(this.navigationTimeout);
+      if (!this.enabled) {
+        return;
       }
+      if (!(this.hasPrevious || this.hasNext || this.autoShowNavForMediaPreview || this.isImagePreview)) {
+        return;
+      }
+
+      mutations.clearNavigationTimeout();
+      if (this.navigationTimeout) {
+        clearTimeout(this.navigationTimeout);
+        this.navigationTimeout = null;
+      }
+
+      if (this.isImagePreview) {
+        mutations.showNavigationChromePersistent();
+        return;
+      }
+
+      mutations.setNavigationShow(true);
+      this.navigationTimeout = setTimeout(() => {
+        if (!this.hoverNav) {
+          mutations.setNavigationShow(false);
+        }
+        this.navigationTimeout = null;
+      }, 3000);
+      mutations.setNavigationTimeout(this.navigationTimeout);
     },
     async handleClosePreviewClick() {
       if (!(await this.checkForUnsavedChanges())) {
@@ -1009,7 +1019,7 @@ export default {
   transform: translateY(-50%);
   width: 50px;
   height: 50px;
-  border: none;
+  border: var(--borderWidth) solid var(--divider);
   border-radius: 50%;
   background: var(--background);
   color: var(--textPrimary);

--- a/frontend/src/store/getters.ts
+++ b/frontend/src/store/getters.ts
@@ -4,7 +4,7 @@ import { state } from './state';
 import { url } from '@/utils';
 import { globalVars, previewViews, tools } from '@/utils/constants';
 import { getFileExtension } from '@/utils/files.js';
-import { getTypeInfo, isRichTextPreviewMimeType } from '@/utils/mimetype';
+import { getTypeInfo, isHtmlMimeType, isRichTextPreviewMimeType } from '@/utils/mimetype';
 import { fromNow } from '@/utils/moment';
 import { getNestedProperty, getObjectProperty } from '@/utils/object.js';
 import { buildItemUrl, removeLeadingSlash, removePrefix } from '@/utils/url.js';
@@ -52,7 +52,10 @@ export const getters = {
   },
   isScrollable: () => {
     if (getters.currentView() === 'markdownViewer') {
-      return true
+      if (isHtmlMimeType(state.req?.type)) {
+        return false;
+      }
+      return true;
     }
     if (getters.isPreviewView()) {
       return false

--- a/frontend/src/store/mutations.ts
+++ b/frontend/src/store/mutations.ts
@@ -987,13 +987,18 @@ export const mutations = {
 
     // Auto-show navigation when it's first set up (timer tracked so new opens clear it)
     if (state.navigation.enabled && (state.navigation.previousLink || state.navigation.nextLink)) {
-      mutations.setNavigationShow(true);
-      const hideTimer = setTimeout(() => {
-        if (!state.navigation.hoverNav) {
-          mutations.setNavigationShow(false);
-        }
-      }, 3000);
-      mutations.setNavigationTimeout(hideTimer);
+      const isImage = getTypeInfo(currentItem.type).simpleType === 'image';
+      if (isImage) {
+        mutations.showNavigationChromePersistent();
+      } else {
+        mutations.setNavigationShow(true);
+        const hideTimer = setTimeout(() => {
+          if (!state.navigation.hoverNav) {
+            mutations.setNavigationShow(false);
+          }
+        }, 3000);
+        mutations.setNavigationTimeout(hideTimer);
+      }
     }
   },
   getPrefetchUrl: (item) => {
@@ -1022,6 +1027,20 @@ export const mutations = {
     state.navigation.show = show;
     emitStateChanged();
   },
+  showNavigationChromePersistent: () => {
+    if (!state.navigation.enabled) {
+      return;
+    }
+    mutations.clearNavigationTimeout();
+    mutations.setNavigationShow(true);
+  },
+  toggleNavigationChrome: () => {
+    if (!state.navigation.enabled) {
+      return;
+    }
+    mutations.clearNavigationTimeout();
+    mutations.setNavigationShow(!state.navigation.show);
+  },
   /** Briefly reveal prev/next chrome (e.g. edge tap on video while gestures capture the event). */
   peekNavigationChrome: (side = null) => {
     if (!state.navigation.enabled) {
@@ -1041,6 +1060,10 @@ export const mutations = {
       return;
     }
     if (!side && !hasPrevious && !hasNext) {
+      return;
+    }
+    if (getters.previewType() === 'image') {
+      mutations.showNavigationChromePersistent();
       return;
     }
     mutations.setNavigationShow(true);

--- a/frontend/src/utils/listingTypeAhead.js
+++ b/frontend/src/utils/listingTypeAhead.js
@@ -1,0 +1,118 @@
+const TYPE_AHEAD_RESET_MS = 1000;
+const LOG_PREFIX = '[listingTypeAhead]';
+
+function log(...args) {
+  console.log(LOG_PREFIX, ...args);
+}
+
+const session = {
+  prefix: '',
+  lastKey: '',
+};
+
+let resetTimeoutId = null;
+
+export function normalizeTypeAheadName(name) {
+  return String(name ?? '').normalize('NFC').toLocaleLowerCase();
+}
+
+export function normalizeTypeAheadKey(key) {
+  if (typeof key !== 'string' || !/^[a-z0-9]$/i.test(key)) {
+    return '';
+  }
+  return key.toLocaleLowerCase();
+}
+
+export function getTypeAheadPrefix() {
+  return session.prefix;
+}
+
+export function isTypeAheadSessionActive() {
+  return session.prefix !== '';
+}
+
+export function resetTypeAheadSession(reason = 'manual') {
+  log('session reset', { reason, previousPrefix: session.prefix, previousLastKey: session.lastKey });
+  if (resetTimeoutId !== null) {
+    clearTimeout(resetTimeoutId);
+    resetTimeoutId = null;
+  }
+  session.prefix = '';
+  session.lastKey = '';
+}
+
+export function scheduleTypeAheadReset(onExpire = resetTypeAheadSession) {
+  if (resetTimeoutId !== null) {
+    clearTimeout(resetTimeoutId);
+  }
+  resetTimeoutId = setTimeout(() => {
+    resetTimeoutId = null;
+    onExpire('timer');
+  }, TYPE_AHEAD_RESET_MS);
+  log('timer scheduled', { resetMs: TYPE_AHEAD_RESET_MS, prefix: session.prefix });
+}
+
+/**
+ * @param {string} key
+ * @param {Array<{ name: string, index: number }>} items
+ * @param {number | null} selectedIndex
+ * @returns {{ prefix: string, matches: Array<{ name: string, index: number }>, nextPos: number }}
+ */
+export function processTypeAheadKey(key, items, selectedIndex = null) {
+  const lowerKey = normalizeTypeAheadKey(key);
+  if (!lowerKey) {
+    log('ignored key', { key, reason: 'not alphanumeric single char' });
+    return { prefix: session.prefix, matches: [], nextPos: 0, isSameKeyRepeat: false };
+  }
+
+  const previousPrefix = session.prefix;
+  const previousLastKey = session.lastKey;
+  const hasActiveSession = session.prefix !== '';
+  const isSameKeyRepeat = lowerKey === session.lastKey && hasActiveSession;
+
+  let prefix;
+  if (isSameKeyRepeat) {
+    prefix = session.prefix;
+  } else if (!hasActiveSession) {
+    prefix = lowerKey;
+  } else {
+    prefix = session.prefix + lowerKey;
+  }
+
+  session.prefix = prefix;
+  session.lastKey = lowerKey;
+  scheduleTypeAheadReset();
+
+  const normalizedPrefix = normalizeTypeAheadName(prefix);
+  const matches = items.filter((item) =>
+    normalizeTypeAheadName(item.name).startsWith(normalizedPrefix)
+  );
+
+  let nextPos = 0;
+  if (isSameKeyRepeat && selectedIndex !== null) {
+    const curPos = matches.findIndex((m) => m.index === selectedIndex);
+    if (curPos !== -1) {
+      nextPos = (curPos + 1) % matches.length;
+    }
+  }
+
+  log('key processed', {
+    key,
+    lowerKey,
+    previousPrefix,
+    previousLastKey,
+    hasActiveSession,
+    isSameKeyRepeat,
+    newPrefix: prefix,
+    normalizedPrefix,
+    selectedIndex,
+    matchCount: matches.length,
+    matchNames: matches.slice(0, 8).map((m) => m.name),
+    nextPos,
+    willSelect: matches.length > 0 ? matches.at(nextPos)?.name : null,
+  });
+
+  return { prefix, matches, nextPos, isSameKeyRepeat };
+}
+
+export { TYPE_AHEAD_RESET_MS };

--- a/frontend/src/utils/listingTypeAhead.js
+++ b/frontend/src/utils/listingTypeAhead.js
@@ -1,9 +1,4 @@
 const TYPE_AHEAD_RESET_MS = 1000;
-const LOG_PREFIX = '[listingTypeAhead]';
-
-function log(...args) {
-  console.log(LOG_PREFIX, ...args);
-}
 
 const session = {
   prefix: '',
@@ -31,8 +26,7 @@ export function isTypeAheadSessionActive() {
   return session.prefix !== '';
 }
 
-export function resetTypeAheadSession(reason = 'manual') {
-  log('session reset', { reason, previousPrefix: session.prefix, previousLastKey: session.lastKey });
+export function resetTypeAheadSession() {
   if (resetTimeoutId !== null) {
     clearTimeout(resetTimeoutId);
     resetTimeoutId = null;
@@ -47,26 +41,22 @@ export function scheduleTypeAheadReset(onExpire = resetTypeAheadSession) {
   }
   resetTimeoutId = setTimeout(() => {
     resetTimeoutId = null;
-    onExpire('timer');
+    onExpire();
   }, TYPE_AHEAD_RESET_MS);
-  log('timer scheduled', { resetMs: TYPE_AHEAD_RESET_MS, prefix: session.prefix });
 }
 
 /**
  * @param {string} key
  * @param {Array<{ name: string, index: number }>} items
  * @param {number | null} selectedIndex
- * @returns {{ prefix: string, matches: Array<{ name: string, index: number }>, nextPos: number }}
+ * @returns {{ prefix: string, matches: Array<{ name: string, index: number }>, nextPos: number, isSameKeyRepeat: boolean }}
  */
 export function processTypeAheadKey(key, items, selectedIndex = null) {
   const lowerKey = normalizeTypeAheadKey(key);
   if (!lowerKey) {
-    log('ignored key', { key, reason: 'not alphanumeric single char' });
     return { prefix: session.prefix, matches: [], nextPos: 0, isSameKeyRepeat: false };
   }
 
-  const previousPrefix = session.prefix;
-  const previousLastKey = session.lastKey;
   const hasActiveSession = session.prefix !== '';
   const isSameKeyRepeat = lowerKey === session.lastKey && hasActiveSession;
 
@@ -95,22 +85,6 @@ export function processTypeAheadKey(key, items, selectedIndex = null) {
       nextPos = (curPos + 1) % matches.length;
     }
   }
-
-  log('key processed', {
-    key,
-    lowerKey,
-    previousPrefix,
-    previousLastKey,
-    hasActiveSession,
-    isSameKeyRepeat,
-    newPrefix: prefix,
-    normalizedPrefix,
-    selectedIndex,
-    matchCount: matches.length,
-    matchNames: matches.slice(0, 8).map((m) => m.name),
-    nextPos,
-    willSelect: matches.length > 0 ? matches.at(nextPos)?.name : null,
-  });
 
   return { prefix, matches, nextPos, isSameKeyRepeat };
 }

--- a/frontend/src/utils/listingTypeAhead.test.js
+++ b/frontend/src/utils/listingTypeAhead.test.js
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getTypeAheadPrefix,
+  isTypeAheadSessionActive,
+  normalizeTypeAheadName,
+  processTypeAheadKey,
+  resetTypeAheadSession,
+} from './listingTypeAhead.js';
+
+const items = [
+  { name: 'kitchen.txt', index: 0 },
+  { name: 'notes.txt', index: 1 },
+  { name: 'WORK.doc', index: 2 },
+  { name: 'wombat', index: 3 },
+];
+
+afterEach(() => {
+  resetTypeAheadSession();
+});
+
+describe('listingTypeAhead', () => {
+  it('matches names case-insensitively', () => {
+    expect(normalizeTypeAheadName('WORK.doc')).toBe('work.doc');
+  });
+
+  it('accumulates a full prefix across rapid keys', () => {
+    processTypeAheadKey('w', items);
+    processTypeAheadKey('o', items);
+    processTypeAheadKey('r', items);
+    const result = processTypeAheadKey('k', items);
+    expect(getTypeAheadPrefix()).toBe('work');
+    expect(result.matches.map((m) => m.name)).toEqual(['WORK.doc']);
+  });
+
+  it('keeps the buffer without changing selection when no items match', () => {
+    processTypeAheadKey('w', items);
+    processTypeAheadKey('o', items);
+    processTypeAheadKey('r', items);
+    const noMatch = processTypeAheadKey('x', items);
+    expect(getTypeAheadPrefix()).toBe('worx');
+    expect(noMatch.matches).toHaveLength(0);
+    processTypeAheadKey('k', items);
+    expect(getTypeAheadPrefix()).toBe('worxk');
+  });
+
+  it('tracks whether a type-ahead session is active', () => {
+    expect(isTypeAheadSessionActive()).toBe(false);
+    processTypeAheadKey('w', items);
+    expect(isTypeAheadSessionActive()).toBe(true);
+    resetTypeAheadSession();
+    expect(isTypeAheadSessionActive()).toBe(false);
+  });
+
+  it('cycles single-letter matches on repeated key presses', () => {
+    const first = processTypeAheadKey('w', items, null);
+    expect(first.matches.map((m) => m.name)).toEqual(['WORK.doc', 'wombat']);
+    expect(first.nextPos).toBe(0);
+
+    const second = processTypeAheadKey('w', items, items[2].index);
+    expect(second.prefix).toBe('w');
+    expect(second.nextPos).toBe(1);
+  });
+});

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -189,8 +189,12 @@ import { url } from "@/utils";
 import Item from "@/components/files/ListingItem.vue";
 import Upload from "@/components/prompts/Upload.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
-
-const TYPE_AHEAD_RESET_MS = 1000;
+import {
+  getTypeAheadPrefix,
+  isTypeAheadSessionActive,
+  processTypeAheadKey,
+  resetTypeAheadSession,
+} from "@/utils/listingTypeAhead.js";
 
 export default {
   name: "listingView",
@@ -218,9 +222,6 @@ export default {
       selectionUpdatePending: false,
       isResizing: false,
       resizeTimeout: null,
-      typeAheadPrefix: '',
-      typeAheadLastKey: '',
-      typeAheadTimeoutId: null,
     };
   },
   watch: {
@@ -524,7 +525,7 @@ export default {
     }
   },
   beforeUnmount() {
-    this.resetTypeAhead();
+    resetTypeAheadSession();
 
     if (this.resizeTimeout) {
       clearTimeout(this.resizeTimeout);
@@ -782,6 +783,16 @@ export default {
       if (state.isSearchActive || getters.currentView() !== "listingView" ||
         getters.currentPromptName() || (event.repeat && (!isArrowKey || altKey))) return;
 
+      if (
+        (key === ' ' || key === '/') &&
+        isTypeAheadSessionActive() &&
+        !state.isSearchActive &&
+        !getters.currentPromptName()
+      ) {
+        event.preventDefault();
+        return;
+      }
+
       const isAlphanumeric = /^[a-z0-9]$/i.test(key);
       const modifierKeys = ctrlKey || metaKey;
       if (isAlphanumeric && !modifierKeys && state.selected.length <= 1) {
@@ -794,6 +805,12 @@ export default {
           !t.isContentEditable
         ) {
           event.preventDefault();
+          console.log('[listingTypeAhead] keyEvent → alphanumeric', {
+            key,
+            repeat: event.repeat,
+            selected: [...state.selected],
+            prefixBefore: getTypeAheadPrefix(),
+          });
           this.alphanumericKeyPress(key);
           return;
         }
@@ -879,55 +896,35 @@ export default {
           break;
       }
     },
-    resetTypeAhead() {
-      if (this.typeAheadTimeoutId !== null) {
-        clearTimeout(this.typeAheadTimeoutId);
-        this.typeAheadTimeoutId = null;
-      }
-      this.typeAheadPrefix = '';
-      this.typeAheadLastKey = '';
-    },
-    scheduleTypeAheadReset() {
-      if (this.typeAheadTimeoutId !== null) {
-        clearTimeout(this.typeAheadTimeoutId);
-      }
-      this.typeAheadTimeoutId = setTimeout(() => {
-        this.resetTypeAhead();
-      }, TYPE_AHEAD_RESET_MS);
-    },
     alphanumericKeyPress(key) {
-      const lowerKey = key.toLowerCase();
-      const isSameKeyRepeat =
-        this.typeAheadPrefix.length === 1 &&
-        lowerKey === this.typeAheadLastKey &&
-        this.typeAheadPrefix === lowerKey;
-
-      let prefix;
-      if (isSameKeyRepeat) {
-        prefix = this.typeAheadPrefix;
-      } else if (this.typeAheadPrefix === '') {
-        prefix = lowerKey;
-      } else {
-        prefix = this.typeAheadPrefix + lowerKey;
-      }
-
-      const matches = this.allItems.filter(item =>
-        item.name.toLowerCase().startsWith(prefix)
-      );
-      if (matches.length === 0) return;
-
-      this.typeAheadPrefix = prefix;
-      this.typeAheadLastKey = lowerKey;
-      this.scheduleTypeAheadReset();
-
-      let nextPos = 0;
-      if (isSameKeyRepeat && state.selected.length === 1) {
-        const curPos = matches.findIndex(m => m.index === state.selected[0]);
-        if (curPos !== -1) nextPos = (curPos + 1) % matches.length;
+      const selectedIndex = state.selected.length === 1 ? state.selected[0] : null;
+      const selectedName = selectedIndex !== null
+        ? this.allItems.find((item) => item.index === selectedIndex)?.name
+        : null;
+      const { matches, nextPos } = processTypeAheadKey(key, this.allItems, selectedIndex);
+      if (matches.length === 0) {
+        console.log('[listingTypeAhead] no matches — selection unchanged', {
+          key,
+          selectedIndex,
+          selectedName,
+          prefixAfter: getTypeAheadPrefix(),
+        });
+        return;
       }
 
       const target = matches.at(nextPos);
-      if (!target) return;
+      if (!target) {
+        console.log('[listingTypeAhead] no target at nextPos', { key, nextPos, matchCount: matches.length });
+        return;
+      }
+      console.log('[listingTypeAhead] selecting', {
+        key,
+        from: selectedName,
+        to: target.name,
+        targetIndex: target.index,
+        nextPos,
+        matchCount: matches.length,
+      });
       mutations.resetSelected();
       mutations.addSelected(target.index);
       this.scrollSelectedIntoView();

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -898,7 +898,9 @@ export default {
     alphanumericKeyPress(key) {
       const lowerKey = key.toLowerCase();
       const isSameKeyRepeat =
-        lowerKey === this.typeAheadLastKey && this.typeAheadPrefix !== '';
+        this.typeAheadPrefix.length === 1 &&
+        lowerKey === this.typeAheadLastKey &&
+        this.typeAheadPrefix === lowerKey;
 
       let prefix;
       if (isSameKeyRepeat) {

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -190,6 +190,8 @@ import Item from "@/components/files/ListingItem.vue";
 import Upload from "@/components/prompts/Upload.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 
+const TYPE_AHEAD_RESET_MS = 1000;
+
 export default {
   name: "listingView",
   components: {
@@ -216,6 +218,9 @@ export default {
       selectionUpdatePending: false,
       isResizing: false,
       resizeTimeout: null,
+      typeAheadPrefix: '',
+      typeAheadLastKey: '',
+      typeAheadTimeoutId: null,
     };
   },
   watch: {
@@ -519,6 +524,8 @@ export default {
     }
   },
   beforeUnmount() {
+    this.resetTypeAhead();
+
     if (this.resizeTimeout) {
       clearTimeout(this.resizeTimeout);
       this.resizeTimeout = null;
@@ -872,18 +879,48 @@ export default {
           break;
       }
     },
+    resetTypeAhead() {
+      if (this.typeAheadTimeoutId !== null) {
+        clearTimeout(this.typeAheadTimeoutId);
+        this.typeAheadTimeoutId = null;
+      }
+      this.typeAheadPrefix = '';
+      this.typeAheadLastKey = '';
+    },
+    scheduleTypeAheadReset() {
+      if (this.typeAheadTimeoutId !== null) {
+        clearTimeout(this.typeAheadTimeoutId);
+      }
+      this.typeAheadTimeoutId = setTimeout(() => {
+        this.resetTypeAhead();
+      }, TYPE_AHEAD_RESET_MS);
+    },
     alphanumericKeyPress(key) {
-      const prefix = key.toLowerCase();
-      const allItems = this.allItems;
-      const matches = allItems.filter(item =>
+      const lowerKey = key.toLowerCase();
+      const isSameKeyRepeat =
+        lowerKey === this.typeAheadLastKey && this.typeAheadPrefix !== '';
+
+      let prefix;
+      if (isSameKeyRepeat) {
+        prefix = this.typeAheadPrefix;
+      } else if (this.typeAheadPrefix === '') {
+        prefix = lowerKey;
+      } else {
+        prefix = this.typeAheadPrefix + lowerKey;
+      }
+
+      const matches = this.allItems.filter(item =>
         item.name.toLowerCase().startsWith(prefix)
       );
       if (matches.length === 0) return;
 
+      this.typeAheadPrefix = prefix;
+      this.typeAheadLastKey = lowerKey;
+      this.scheduleTypeAheadReset();
+
       let nextPos = 0;
-      if (state.selected.length === 1) {
-        const curIdx = state.selected[0];
-        const curPos = matches.findIndex(m => m.index === curIdx);
+      if (isSameKeyRepeat && state.selected.length === 1) {
+        const curPos = matches.findIndex(m => m.index === state.selected[0]);
         if (curPos !== -1) nextPos = (curPos + 1) % matches.length;
       }
 

--- a/frontend/src/views/files/ListingView.vue
+++ b/frontend/src/views/files/ListingView.vue
@@ -190,7 +190,6 @@ import Item from "@/components/files/ListingItem.vue";
 import Upload from "@/components/prompts/Upload.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import {
-  getTypeAheadPrefix,
   isTypeAheadSessionActive,
   processTypeAheadKey,
   resetTypeAheadSession,
@@ -805,12 +804,6 @@ export default {
           !t.isContentEditable
         ) {
           event.preventDefault();
-          console.log('[listingTypeAhead] keyEvent → alphanumeric', {
-            key,
-            repeat: event.repeat,
-            selected: [...state.selected],
-            prefixBefore: getTypeAheadPrefix(),
-          });
           this.alphanumericKeyPress(key);
           return;
         }
@@ -898,33 +891,13 @@ export default {
     },
     alphanumericKeyPress(key) {
       const selectedIndex = state.selected.length === 1 ? state.selected[0] : null;
-      const selectedName = selectedIndex !== null
-        ? this.allItems.find((item) => item.index === selectedIndex)?.name
-        : null;
       const { matches, nextPos } = processTypeAheadKey(key, this.allItems, selectedIndex);
       if (matches.length === 0) {
-        console.log('[listingTypeAhead] no matches — selection unchanged', {
-          key,
-          selectedIndex,
-          selectedName,
-          prefixAfter: getTypeAheadPrefix(),
-        });
         return;
       }
 
       const target = matches.at(nextPos);
-      if (!target) {
-        console.log('[listingTypeAhead] no target at nextPos', { key, nextPos, matchCount: matches.length });
-        return;
-      }
-      console.log('[listingTypeAhead] selecting', {
-        key,
-        from: selectedName,
-        to: target.name,
-        targetIndex: target.index,
-        nextPos,
-        matchCount: matches.length,
-      });
+      if (!target) return;
       mutations.resetSelected();
       mutations.addSelected(target.index);
       this.scrollSelectedIntoView();

--- a/frontend/src/views/files/MarkdownViewer.vue
+++ b/frontend/src/views/files/MarkdownViewer.vue
@@ -1,5 +1,9 @@
 <template>
-  <div id="markedown-viewer">
+  <div
+    id="markedown-viewer"
+    :class="{ 'html-viewer-mode': isHtml }"
+    :style="htmlViewerStyle"
+  >
     <iframe
       v-if="isHtml"
       ref="viewer"
@@ -13,7 +17,7 @@
     <div v-else class="markdown-content-container" :class="{ 'dark-mode': darkMode }">
       <div ref="viewer" v-html="renderedContent" class="markdown-content"></div>
     </div>
-    <div class="spacer" :style="{ height: `${spaceForStatusBar}em` }"></div>
+    <div v-if="!isHtml" class="spacer" :style="{ height: `${spaceForStatusBar}em` }"></div>
   </div>
 </template>
 
@@ -337,6 +341,17 @@ export default {
     spaceForStatusBar() {
       return state.isMobile ? 3.1 : 3.5;
     },
+    htmlViewerStyle() {
+      if (!this.isHtml) {
+        return undefined;
+      }
+      const statusBar = this.spaceForStatusBar;
+      const height = `calc(100vh - 4em - ${statusBar}em - 0.5em)`;
+      return {
+        height,
+        minHeight: height,
+      };
+    },
   },
   mounted() {
     this.reinit();
@@ -358,6 +373,15 @@ export default {
   word-break: break-word;
 }
 
+#markedown-viewer.html-viewer-mode {
+  margin: 0.5em;
+  width: calc(100% - 1em);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
 #markedown-viewer .markdown-content-container {
   background-color: var(--alt-background);
   border-radius: 1em;
@@ -375,6 +399,13 @@ export default {
   min-height: 24em;
   background: #fff;
   color-scheme: light dark;
+}
+
+#markedown-viewer.html-viewer-mode .html-content {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
 }
 
 #markedown-viewer .html-content img {

--- a/frontend/tests/playwright/settings/user-actions.spec.ts
+++ b/frontend/tests/playwright/settings/user-actions.spec.ts
@@ -25,14 +25,8 @@ function userEditScopeBlock(modal: Locator, sourceName: string): Locator {
 
 async function expandUserEditSourceScope(modal: Locator, sourceName: string) {
     const block = userEditScopeBlock(modal, sourceName);
-    const permissions = block.locator(".source-file-permissions");
-    if (!(await permissions.isVisible())) {
-        await block.locator(".settings-group-title").click();
-    }
-    await expect(permissions).toBeVisible();
-    await expect(
-        permissions.locator(".toggle-container .toggle-row--value").first(),
-    ).toBeVisible();
+    await block.locator(".settings-group-title").click();
+    await expect(block.locator(".source-file-permissions")).toBeVisible();
 }
 
 function userEditSourcePermissionCheckbox(
@@ -42,7 +36,7 @@ function userEditSourcePermissionCheckbox(
 ): Locator {
     return userEditScopeBlock(modal, sourceName)
         .locator(".source-file-permissions .toggle-container", { hasText: permissionLabel })
-        .locator('.toggle-row--value input[type="checkbox"]');
+        .locator('input[type="checkbox"]');
 }
 
 function userEditSourcePermissionToggle(
@@ -52,37 +46,7 @@ function userEditSourcePermissionToggle(
 ): Locator {
     return userEditScopeBlock(modal, sourceName)
         .locator(".source-file-permissions .toggle-container", { hasText: permissionLabel })
-        .locator(".toggle-row--value label.switch");
-}
-
-async function clickToggleUntilChecked(toggle: Locator, checkbox: Locator, checked: boolean) {
-    await expect(toggle).toBeVisible();
-    await expect(checkbox).toBeEnabled();
-    await toggle.scrollIntoViewIfNeeded();
-    await expect(async () => {
-        if ((await checkbox.isChecked()) !== checked) {
-            await toggle.click();
-        }
-        await expect(checkbox).toBeChecked({ checked });
-    }).toPass();
-}
-
-async function saveUserEditModal(page: Page, modal: Locator) {
-    const userUpdate = page.waitForResponse(
-        (resp) => {
-            const pathname = new URL(resp.url()).pathname;
-            return (
-                /\/api\/users\//.test(pathname) &&
-                resp.request().method() === "PUT" &&
-                resp.ok()
-            );
-        },
-        { timeout: 20_000 },
-    );
-    await modal.locator('button[aria-label="Save"]').click();
-    await confirmActorPasswordPrompt(page);
-    await userUpdate;
-    await expect(modal).not.toBeVisible({ timeout: 10_000 });
+        .locator("label.switch");
 }
 
 /**
@@ -93,10 +57,10 @@ async function confirmActorPasswordPrompt(page: Page) {
     const passwordModal = page.locator(
         'div[aria-label="password-prompt"]:not(.prompt-behind)'
     );
-    await expect(passwordModal).toBeVisible({ timeout: 15_000 });
+    await expect(passwordModal).toBeVisible();
     await passwordModal.locator("input").fill("admin");
     await passwordModal.locator('button[aria-label="Confirm"]').click();
-    await expect(passwordModal).not.toBeVisible({ timeout: 10_000 });
+    await expect(passwordModal).not.toBeVisible();
 }
 
 test("create, check settings, and delete user (retry-safe name)", async ({
@@ -219,7 +183,6 @@ test("two factor auth check", async ({ page, checkForErrors }) => {
 });
 
 test.describe("User Settings Persistence", () => {
-
     const username = "testuser1";
     test.beforeEach(async ({ page }) => {
         await page.goto("/settings");
@@ -240,8 +203,11 @@ test.describe("User Settings Persistence", () => {
 
         // --- Toggle to opposite state and save ---
         const toggleSwitch = modal.locator(".toggle-container", { hasText: settingName }).locator("label.switch");
-        await clickToggleUntilChecked(toggleSwitch, checkbox, !initialChecked);
-        await saveUserEditModal(page, modal);
+        await toggleSwitch.click();
+        await expect(checkbox).toBeChecked({ checked: !initialChecked });
+        await modal.locator('button[aria-label="Save"]').click();
+        await confirmActorPasswordPrompt(page);
+        await expect(modal).not.toBeVisible();
 
         // --- Re-open and check persisted state ---
         await editUserTrigger(userRow).click();
@@ -251,8 +217,11 @@ test.describe("User Settings Persistence", () => {
 
         // --- Toggle back to initial state and save ---
         const toggleSwitchBack = modal.locator(".toggle-container", { hasText: settingName }).locator("label.switch");
-        await clickToggleUntilChecked(toggleSwitchBack, checkboxToggled, initialChecked);
-        await saveUserEditModal(page, modal);
+        await toggleSwitchBack.click();
+        await expect(checkboxToggled).toBeChecked({ checked: initialChecked });
+        await modal.locator('button[aria-label="Save"]').click();
+        await confirmActorPasswordPrompt(page);
+        await expect(modal).not.toBeVisible();
 
         // --- Re-open and check state is restored ---
         await editUserTrigger(userRow).click();
@@ -275,7 +244,6 @@ test.describe("User Settings Persistence", () => {
         const userRow = userRowInSettingsUsersTable(page, username);
         const modal = page.locator('div[aria-label="user-edit-prompt"]');
 
-        await expect(userRow).toBeVisible();
         await editUserTrigger(userRow).click();
         await expect(modal).toBeVisible();
         await expandUserEditSourceScope(modal, SETTINGS_TEST_SOURCE);
@@ -292,17 +260,22 @@ test.describe("User Settings Persistence", () => {
         );
 
         const wasChecked = await editFilesCheckbox.isChecked();
-        await clickToggleUntilChecked(editFilesToggle, editFilesCheckbox, !wasChecked);
+        await editFilesToggle.click();
+        await expect(editFilesCheckbox).toBeChecked({ checked: !wasChecked });
 
-        await saveUserEditModal(page, modal);
+        await modal.locator('button[aria-label="Save"]').click();
+        await confirmActorPasswordPrompt(page);
+        await expect(modal).not.toBeVisible();
 
         await editUserTrigger(userRow).click();
         await expect(modal).toBeVisible();
         await expandUserEditSourceScope(modal, SETTINGS_TEST_SOURCE);
         await expect(editFilesCheckbox).toBeChecked({ checked: !wasChecked });
 
-        await clickToggleUntilChecked(editFilesToggle, editFilesCheckbox, wasChecked);
-        await saveUserEditModal(page, modal);
+        await editFilesToggle.click();
+        await modal.locator('button[aria-label="Save"]').click();
+        await confirmActorPasswordPrompt(page);
+        await expect(modal).not.toBeVisible();
     });
 
     test('should persist "Share files" setting', async ({ page }) => {

--- a/frontend/tests/playwright/settings/user-actions.spec.ts
+++ b/frontend/tests/playwright/settings/user-actions.spec.ts
@@ -25,8 +25,14 @@ function userEditScopeBlock(modal: Locator, sourceName: string): Locator {
 
 async function expandUserEditSourceScope(modal: Locator, sourceName: string) {
     const block = userEditScopeBlock(modal, sourceName);
-    await block.locator(".settings-group-title").click();
-    await expect(block.locator(".source-file-permissions")).toBeVisible();
+    const permissions = block.locator(".source-file-permissions");
+    if (!(await permissions.isVisible())) {
+        await block.locator(".settings-group-title").click();
+    }
+    await expect(permissions).toBeVisible();
+    await expect(
+        permissions.locator(".toggle-container .toggle-row--value").first(),
+    ).toBeVisible();
 }
 
 function userEditSourcePermissionCheckbox(
@@ -36,7 +42,7 @@ function userEditSourcePermissionCheckbox(
 ): Locator {
     return userEditScopeBlock(modal, sourceName)
         .locator(".source-file-permissions .toggle-container", { hasText: permissionLabel })
-        .locator('input[type="checkbox"]');
+        .locator('.toggle-row--value input[type="checkbox"]');
 }
 
 function userEditSourcePermissionToggle(
@@ -46,7 +52,37 @@ function userEditSourcePermissionToggle(
 ): Locator {
     return userEditScopeBlock(modal, sourceName)
         .locator(".source-file-permissions .toggle-container", { hasText: permissionLabel })
-        .locator("label.switch");
+        .locator(".toggle-row--value label.switch");
+}
+
+async function clickToggleUntilChecked(toggle: Locator, checkbox: Locator, checked: boolean) {
+    await expect(checkbox).toBeVisible();
+    await expect(checkbox).toBeEnabled();
+    await toggle.scrollIntoViewIfNeeded();
+    await expect(async () => {
+        if ((await checkbox.isChecked()) !== checked) {
+            await toggle.click();
+        }
+        await expect(checkbox).toBeChecked({ checked });
+    }).toPass();
+}
+
+async function saveUserEditModal(page: Page, modal: Locator) {
+    const userUpdate = page.waitForResponse(
+        (resp) => {
+            const pathname = new URL(resp.url()).pathname;
+            return (
+                /\/api\/users\//.test(pathname) &&
+                resp.request().method() === "PUT" &&
+                resp.ok()
+            );
+        },
+        { timeout: 20_000 },
+    );
+    await modal.locator('button[aria-label="Save"]').click();
+    await confirmActorPasswordPrompt(page);
+    await userUpdate;
+    await expect(modal).not.toBeVisible({ timeout: 10_000 });
 }
 
 /**
@@ -57,10 +93,10 @@ async function confirmActorPasswordPrompt(page: Page) {
     const passwordModal = page.locator(
         'div[aria-label="password-prompt"]:not(.prompt-behind)'
     );
-    await expect(passwordModal).toBeVisible();
+    await expect(passwordModal).toBeVisible({ timeout: 15_000 });
     await passwordModal.locator("input").fill("admin");
     await passwordModal.locator('button[aria-label="Confirm"]').click();
-    await expect(passwordModal).not.toBeVisible();
+    await expect(passwordModal).not.toBeVisible({ timeout: 10_000 });
 }
 
 test("create, check settings, and delete user (retry-safe name)", async ({
@@ -203,11 +239,8 @@ test.describe("User Settings Persistence", () => {
 
         // --- Toggle to opposite state and save ---
         const toggleSwitch = modal.locator(".toggle-container", { hasText: settingName }).locator("label.switch");
-        await toggleSwitch.click();
-        await expect(checkbox).toBeChecked({ checked: !initialChecked });
-        await modal.locator('button[aria-label="Save"]').click();
-        await confirmActorPasswordPrompt(page);
-        await expect(modal).not.toBeVisible();
+        await clickToggleUntilChecked(toggleSwitch, checkbox, !initialChecked);
+        await saveUserEditModal(page, modal);
 
         // --- Re-open and check persisted state ---
         await editUserTrigger(userRow).click();
@@ -217,11 +250,8 @@ test.describe("User Settings Persistence", () => {
 
         // --- Toggle back to initial state and save ---
         const toggleSwitchBack = modal.locator(".toggle-container", { hasText: settingName }).locator("label.switch");
-        await toggleSwitchBack.click();
-        await expect(checkboxToggled).toBeChecked({ checked: initialChecked });
-        await modal.locator('button[aria-label="Save"]').click();
-        await confirmActorPasswordPrompt(page);
-        await expect(modal).not.toBeVisible();
+        await clickToggleUntilChecked(toggleSwitchBack, checkboxToggled, initialChecked);
+        await saveUserEditModal(page, modal);
 
         // --- Re-open and check state is restored ---
         await editUserTrigger(userRow).click();
@@ -244,6 +274,7 @@ test.describe("User Settings Persistence", () => {
         const userRow = userRowInSettingsUsersTable(page, username);
         const modal = page.locator('div[aria-label="user-edit-prompt"]');
 
+        await expect(userRow).toBeVisible();
         await editUserTrigger(userRow).click();
         await expect(modal).toBeVisible();
         await expandUserEditSourceScope(modal, SETTINGS_TEST_SOURCE);
@@ -260,22 +291,17 @@ test.describe("User Settings Persistence", () => {
         );
 
         const wasChecked = await editFilesCheckbox.isChecked();
-        await editFilesToggle.click();
-        await expect(editFilesCheckbox).toBeChecked({ checked: !wasChecked });
+        await clickToggleUntilChecked(editFilesToggle, editFilesCheckbox, !wasChecked);
 
-        await modal.locator('button[aria-label="Save"]').click();
-        await confirmActorPasswordPrompt(page);
-        await expect(modal).not.toBeVisible();
+        await saveUserEditModal(page, modal);
 
         await editUserTrigger(userRow).click();
         await expect(modal).toBeVisible();
         await expandUserEditSourceScope(modal, SETTINGS_TEST_SOURCE);
         await expect(editFilesCheckbox).toBeChecked({ checked: !wasChecked });
 
-        await editFilesToggle.click();
-        await modal.locator('button[aria-label="Save"]').click();
-        await confirmActorPasswordPrompt(page);
-        await expect(modal).not.toBeVisible();
+        await clickToggleUntilChecked(editFilesToggle, editFilesCheckbox, wasChecked);
+        await saveUserEditModal(page, modal);
     });
 
     test('should persist "Share files" setting', async ({ page }) => {

--- a/frontend/tests/playwright/settings/user-actions.spec.ts
+++ b/frontend/tests/playwright/settings/user-actions.spec.ts
@@ -56,7 +56,7 @@ function userEditSourcePermissionToggle(
 }
 
 async function clickToggleUntilChecked(toggle: Locator, checkbox: Locator, checked: boolean) {
-    await expect(checkbox).toBeVisible();
+    await expect(toggle).toBeVisible();
     await expect(checkbox).toBeEnabled();
     await toggle.scrollIntoViewIfNeeded();
     await expect(async () => {
@@ -219,6 +219,7 @@ test("two factor auth check", async ({ page, checkForErrors }) => {
 });
 
 test.describe("User Settings Persistence", () => {
+
     const username = "testuser1";
     test.beforeEach(async ({ page }) => {
         await page.goto("/settings");

--- a/frontend/tests/playwright/settings/z-source-defaults-lock.spec.ts
+++ b/frontend/tests/playwright/settings/z-source-defaults-lock.spec.ts
@@ -1,18 +1,15 @@
 import { expect, test } from "../test-setup";
 
-function isSourceDefaultsGet(response: import("@playwright/test").Response) {
-  const pathname = new URL(response.url()).pathname;
-  return (
-    pathname.endsWith("/settings/source") &&
-    response.request().method() === "GET" &&
-    response.ok()
-  );
-}
-
 async function openAccessSettings(page: import("@playwright/test").Page) {
-  const defaultsResponse = page.waitForResponse(isSourceDefaultsGet);
   await page.goto("/settings");
   await expect(page).toHaveTitle("Graham's Filebrowser - Settings");
+
+  const defaultsResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/settings/source") &&
+      response.request().method() === "GET" &&
+      response.ok(),
+  );
   await page.locator("#access-sidebar").click();
 
   const permissionsGroup = page
@@ -23,9 +20,9 @@ async function openAccessSettings(page: import("@playwright/test").Page) {
     await permissionsGroup.locator(".settings-group-title.button").click();
     await expect(content).toBeVisible();
   }
-  await expect(permissionsGroup.locator(".loading-hint")).not.toBeVisible();
 
-  return defaultsResponse;
+  const response = await defaultsResponse;
+  return response;
 }
 
 test("config-locked source defaults show lock help and skip patch", async ({ page, checkForErrors }) => {
@@ -67,7 +64,7 @@ test("config-locked source defaults show lock help and skip patch", async ({ pag
     const initialEnforced = await enforceInput.isChecked();
     const enforcePatch = page.waitForResponse(
       (resp) =>
-        new URL(resp.url()).pathname.endsWith("/settings/source") &&
+        resp.url().includes("/api/settings/source") &&
         resp.request().method() === "PATCH" &&
         resp.ok(),
     );


### PR DESCRIPTION
adjusts image viewer next/previous button changes according to #2767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Type letters or numbers in listing view to quickly select matching items, with repeated keys cycling through results.
  - Navigation controls remain visible when viewing images.
  - Tap a zoomed image to toggle navigation controls without interrupting pan or pinch gestures.
  - HTML previews now fill the available viewing area more effectively.

- **Bug Fixes**
  - Improved keyboard selection and navigation behavior.
  - Added themed borders to navigation controls.
  - Prevented type-ahead keystrokes from unintentionally opening Search.
  - Improved image preview styling in gallery views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->