### PR TITLE
fix: onlyoffice content fetch permission issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file. For commit 
  - fixed HEIC rotation regression from v1.5.x
  - fixed raw image preview regression from v1.5.x
  - html viewer takes full height
+ - Members without download permission receive 403 when opening text-based files despite OnlyOffice preview being enabled (#2777)
 
 ## v2.0.0
 

--- a/frontend/src/store/getters.ts
+++ b/frontend/src/store/getters.ts
@@ -505,6 +505,12 @@ export const getters = {
     }
     return false
   },
+  shouldFetchFileContent: (fileInfo: { name: string; source?: string; onlyOfficeId?: string }) => {
+    if (getters.fileViewingDisabled(fileInfo.name)) return false
+    if (fileInfo.onlyOfficeId && !getters.officeViewingDisabled(fileInfo.name)) return false
+    if (!getters.sourcePermissions(fileInfo.source).download) return false
+    return true
+  },
   anonymous: () => {
     return {
       id: 0,

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -49,21 +49,23 @@ async function fetchShareItemWithParent(sharePassword) {
     return file;
   }
 
-  const content = !getters.fileViewingDisabled(file.name);
   let directoryPath = removeLastDir(state.shareInfo.subPath);
   if (!directoryPath || directoryPath === "") {
     directoryPath = "/";
   }
   const shouldFetchParent = directoryPath !== state.shareInfo.subPath;
-  const promises = [
-    resourcesApi.fetchFilesPublic(
-      state.shareInfo.subPath,
-      state.shareInfo.hash,
-      sharePassword,
-      content,
-      false
-    ),
-  ];
+  const contentPromise = getters.shouldFetchFileContent(file)
+    ? resourcesApi
+        .fetchFilesPublic(
+          state.shareInfo.subPath,
+          state.shareInfo.hash,
+          sharePassword,
+          true,
+          false
+        )
+        .catch(() => file)
+    : Promise.resolve(file);
+  const promises = [contentPromise];
   if (shouldFetchParent) {
     promises.push(
       resourcesApi
@@ -87,13 +89,15 @@ async function fetchAuthItemWithParent(fetchSource, fetchPath) {
   if (res.type === "directory") {
     return res;
   }
-  const content = !getters.fileViewingDisabled(res.name);
   let directoryPath = removeLastDir(res.path);
   if (!directoryPath || directoryPath === "") {
     directoryPath = "/";
   }
   const shouldFetchParent = directoryPath !== res.path;
-  const promises = [resourcesApi.fetchFiles(res.source, res.path, content, false)];
+  const contentPromise = getters.shouldFetchFileContent(res)
+    ? resourcesApi.fetchFiles(res.source, res.path, true, false).catch(() => res)
+    : Promise.resolve(res);
+  const promises = [contentPromise];
   if (shouldFetchParent) {
     promises.push(
       resourcesApi.fetchFiles(res.source, directoryPath, false, false).catch(() => null)


### PR DESCRIPTION
fixes (#2777)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where members without download permission received an error when opening text-based files with OnlyOffice preview enabled.
  * Improved file preview handling by preventing unauthorized content requests and gracefully falling back when content cannot be fetched.
* **Documentation**
  * Added a release note for version 2.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->