### PR TITLE
add more options to advanced search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. For commit 
  - Improvements to document thumbnail generation performance.
  - behavior changes for typing to select files in listing view.
  - next/previous buttons don't hide automatically on photos (#2767)
+ - added more actions available in advanced search (#2776)
 
  **Bugfixes**:
  - GroupMap mutations (`SyncUserGroups`, add/remove group members) are write-through to SQL so JWT/OIDC/LDAP group memberships survive restart (#2742).

--- a/backend/internal/database/access/access_test.go
+++ b/backend/internal/database/access/access_test.go
@@ -228,6 +228,12 @@ func TestPermitted_trailingSlashEquivalence(t *testing.T) {
 	if withSlash != withoutSlash {
 		t.Errorf("trailing slash mismatch: with=%v without=%v", withSlash, withoutSlash)
 	}
+	if withSlash {
+		t.Error("alice should be denied for /secret/ after DenyUser")
+	}
+	if withoutSlash {
+		t.Error("alice should be denied for /secret after DenyUser")
+	}
 }
 
 func TestPermitted_CombinedRules(t *testing.T) {

--- a/backend/internal/database/access/access_test.go
+++ b/backend/internal/database/access/access_test.go
@@ -215,6 +215,21 @@ func TestPermitted_NoRule(t *testing.T) {
 	}
 }
 
+func TestPermitted_trailingSlashEquivalence(t *testing.T) {
+	setupTestSources()
+	s, userStore := createTestStorage(t)
+	createTestUser(t, userStore, "alice")
+	if err := s.DenyUser("mnt/storage", idxPath("/secret/"), "alice"); err != nil {
+		t.Fatalf("DenyUser failed: %v", err)
+	}
+
+	withSlash := s.Permitted("mnt/storage", idxPath("/secret/"), "alice")
+	withoutSlash := s.Permitted("mnt/storage", idxPath("/secret"), "alice")
+	if withSlash != withoutSlash {
+		t.Errorf("trailing slash mismatch: with=%v without=%v", withSlash, withoutSlash)
+	}
+}
+
 func TestPermitted_CombinedRules(t *testing.T) {
 	setupTestSources()
 	s, userStore := createTestStorage(t)

--- a/backend/internal/web/resource.go
+++ b/backend/internal/web/resource.go
@@ -390,7 +390,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 		if err != nil {
 			response.Failed = append(response.Failed, BulkDeleteItem{
 				Source:  item.Source,
-				Path:    sanitizedPath,
+				Path:    rawPath,
 				Message: err.Error(),
 			})
 			continue
@@ -401,7 +401,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if sourceName == "" {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "source name is empty",
 				})
 				continue
@@ -411,7 +411,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if idx == nil {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "source not found",
 				})
 				continue
@@ -420,7 +420,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if idx.Config.ReadOnly {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "source is read-only",
 				})
 				continue
@@ -431,7 +431,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if err != nil {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "user does not have access",
 				})
 				continue
@@ -455,7 +455,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 				logger.Errorf("resource bulk delete handler: error deleting file/directory: %v", err)
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "error deleting file/directory, admin must check the logs",
 				})
 				continue
@@ -467,7 +467,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if item.Source == "" {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "source was empty, source is required",
 				})
 				continue
@@ -478,7 +478,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if err != nil {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: fmt.Sprintf("user does not have access: %v", err),
 				})
 				continue
@@ -487,7 +487,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if permErr != nil || !filePerms.Delete {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "user is not allowed to delete",
 				})
 				continue
@@ -497,7 +497,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if idx == nil {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "source not found",
 				})
 				continue
@@ -506,7 +506,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if idx.Config.ReadOnly {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: "source is read-only",
 				})
 				continue
@@ -522,7 +522,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if err != nil {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: err.Error(),
 				})
 				continue
@@ -531,16 +531,18 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 			if err != nil {
 				response.Failed = append(response.Failed, BulkDeleteItem{
 					Source:  item.Source,
-					Path:    sanitizedPath,
+					Path:    rawPath,
 					Message: err.Error(),
 				})
 				continue
 			}
 			preview.DelThumbs(r.Context(), *fileInfo)
 		}
-		// Success (log canonical path/source used for deletion)
-		loggedItem := item
-		loggedItem.Path = sanitizedPath
+		// Success — echo the client path in the response
+		loggedItem := BulkDeleteItem{
+			Source: item.Source,
+			Path:   rawPath,
+		}
 		if d.Share.Hash != "" {
 			loggedItem.Source = d.Share.GetSourceName()
 		}
@@ -1213,9 +1215,11 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 
 	// Process each item
 	for _, item := range req.Items {
+		clientFromPath := item.FromPath
+		clientToPath := item.ToPath
 
 		// Validate all fields are provided
-		if item.FromSource == "" || item.FromPath == "" || item.ToSource == "" || item.ToPath == "" {
+		if item.FromSource == "" || clientFromPath == "" || item.ToSource == "" || clientToPath == "" {
 			item.Message = "fromSource, fromPath, toSource, and toPath are required"
 			if d.Share.Hash != "" {
 				response.Failed = append(response.Failed, MoveCopyItem{
@@ -1223,23 +1227,21 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
-		cleanFromPath, err := utils.SanitizePath(item.FromPath)
+		cleanFromPath, err := utils.SanitizePath(clientFromPath)
 		if err != nil {
 			item.Message = fmt.Sprintf("invalid fromPath: %v", err)
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
-		cleanToPath, err := utils.SanitizePath(item.ToPath)
+		cleanToPath, err := utils.SanitizePath(clientToPath)
 		if err != nil {
 			item.Message = fmt.Sprintf("invalid toPath: %v", err)
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
-		item.FromPath = cleanFromPath
-		item.ToPath = cleanToPath
 
 		// Get user scopes for both sources
 		// For shares, paths are already absolute, so use empty scope
@@ -1249,19 +1251,19 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 			userscopeSrc, err = d.User.GetScopeForSourceName(item.FromSource)
 			if err != nil {
 				item.Message = "source not available"
-				response.Failed = append(response.Failed, item)
+				response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 				continue
 			}
 			userscopeDst, err = d.User.GetScopeForSourceName(item.ToSource)
 			if err != nil {
 				item.Message = "destination source not available"
-				response.Failed = append(response.Failed, item)
+				response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 				continue
 			}
 			fromPerms, permErr := effectiveFilePerms(d, item.FromSource)
 			if permErr != nil {
 				item.Message = "permission denied"
-				response.Failed = append(response.Failed, item)
+				response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 				continue
 			}
 			toPerms := fromPerms
@@ -1270,13 +1272,13 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				toPerms, toErr = effectiveFilePerms(d, item.ToSource)
 				if toErr != nil {
 					item.Message = "permission denied"
-					response.Failed = append(response.Failed, item)
+					response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 					continue
 				}
 			}
 			if msg := resourcePatchPermCheck(req.Action, item.FromSource, item.ToSource, fromPerms, toPerms); msg != "" {
 				item.Message = msg
-				response.Failed = append(response.Failed, item)
+				response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 				continue
 			}
 		}
@@ -1291,7 +1293,7 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 
@@ -1305,7 +1307,7 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 
@@ -1317,7 +1319,7 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 
@@ -1329,16 +1331,16 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 
 		// Build full index paths for access control
-		fullSrcIndexPath := utils.JoinPathAsUnix(userscopeSrc, item.FromPath)
-		fullDstIndexPath := utils.JoinPathAsUnix(userscopeDst, item.ToPath)
+		fullSrcIndexPath := utils.JoinPathAsUnix(userscopeSrc, cleanFromPath)
+		fullDstIndexPath := utils.JoinPathAsUnix(userscopeDst, cleanToPath)
 		if fullDstIndexPath == "/" || fullSrcIndexPath == "/" {
 			item.Message = "source or destination is the root or unautharized directory"
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 
@@ -1351,7 +1353,7 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 		if !state.AccessPermitted(dstIdx.Path, utils.IndexPathFromNormalized(fullDstIndexPath, true), d.User.Username) {
@@ -1362,16 +1364,16 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 
 		// Get real paths
 		// Combine user scope with item paths BEFORE calling GetRealPath to avoid double scope application
-		fullSrcPath := utils.JoinPathAsUnix(userscopeSrc, item.FromPath)
+		fullSrcPath := utils.JoinPathAsUnix(userscopeSrc, cleanFromPath)
 		realSrc, isSrcDir, err := srcIdx.GetRealPath(fullSrcPath)
 		if err != nil {
-			logger.Errorf("could not resolve source path: %v, item.FromPath: %v", err, item.FromPath)
+			logger.Errorf("could not resolve source path: %v, fromPath: %v", err, clientFromPath)
 			item.Message = "could not resolve source path"
 			if d.Share.Hash != "" {
 				response.Failed = append(response.Failed, MoveCopyItem{
@@ -1379,12 +1381,12 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 
 		// Check destination parent directory exists
-		dstParentPath := filepath.Dir(item.ToPath)
+		dstParentPath := filepath.Dir(cleanToPath)
 		fullDstParentPath := utils.JoinPathAsUnix(userscopeDst, dstParentPath)
 		parentDir, _, err := dstIdx.GetRealPath(fullDstParentPath)
 		if err != nil {
@@ -1395,10 +1397,10 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				})
 				continue
 			}
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
-		realDest := parentDir + "/" + filepath.Base(item.ToPath)
+		realDest := parentDir + "/" + filepath.Base(cleanToPath)
 
 		// Auto-rename if requested
 		if req.Rename {
@@ -1415,7 +1417,7 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 					})
 					continue
 				}
-				response.Failed = append(response.Failed, item)
+				response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 				continue
 			}
 		}
@@ -1440,13 +1442,13 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 				continue
 			}
 			item.Message = err.Error()
-			response.Failed = append(response.Failed, item)
+			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
 			continue
 		}
 
 		// Success
-		response.Succeeded = append(response.Succeeded, item)
-		activity.RecordPatchItem(r, toActor(d), req.Action, activity.MoveCopyItem{FromSource: item.FromSource, FromPath: item.FromPath, ToPath: item.ToPath})
+		response.Succeeded = append(response.Succeeded, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
+		activity.RecordPatchItem(r, toActor(d), req.Action, activity.MoveCopyItem{FromSource: item.FromSource, FromPath: clientFromPath, ToPath: clientToPath})
 	}
 
 	if len(response.Failed) == 0 && len(response.Succeeded) == 0 {
@@ -1716,6 +1718,12 @@ func publicItemsGetHandler(w http.ResponseWriter, r *http.Request, d *Context) (
 		return http.StatusInternalServerError, err
 	}
 	return RenderJSON(w, r, items)
+}
+
+func moveCopyWithClientPaths(item MoveCopyItem, clientFrom, clientTo string) MoveCopyItem {
+	item.FromPath = clientFrom
+	item.ToPath = clientTo
+	return item
 }
 
 func bulkDeleteActivityItems(items []BulkDeleteItem) []activity.BulkDeleteItem {

--- a/frontend/src/api/resources.js
+++ b/frontend/src/api/resources.js
@@ -143,29 +143,34 @@ export async function bulkDelete(items) {
   }
   try {
     const apiPath = getApiPath('resources/bulk')
-    const response = await fetchURL(apiPath, {
+    const response = await fetch(apiPath, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
+        'sessionId': state.sessionId,
       },
+      credentials: 'same-origin',
       body: JSON.stringify(items),
     })
     const data = await response.json()
     // 200 = all succeeded, 207 = partial success (some succeeded, some failed)
-    // Both are valid responses that should be returned, not thrown as errors
     if (response.status === 200 || response.status === 207) {
       items.forEach((item) => {
         invalidateDirMetadataCache({ source: item.source, path: getParentDir(item.path) })
       })
       return data
     }
-    // For other error status codes, throw an error
     const error = new Error(data.message || response.statusText)
     error.status = response.status
+    if (data.failed) {
+      error.failed = data.failed
+    }
+    if (data.succeeded) {
+      error.succeeded = data.succeeded
+    }
     throw error
   } catch (err) {
-    // Only show notification and re-throw if it's a real error (not 200/207)
-    if (err.status && err.status !== 200 && err.status !== 207) {
+    if (!err.status || (err.status !== 500 && err.status !== 200 && err.status !== 207)) {
       notify.showError(err.message || 'Error performing bulk delete')
     }
     throw err

--- a/frontend/src/components/ContextMenu.vue
+++ b/frontend/src/components/ContextMenu.vue
@@ -286,7 +286,31 @@ export default {
       return this.showLimitedOptions && this.selectedCount === 1;
     },
     permissions() {
-      return { ...getters.globalPermissions(), ...getters.sourcePermissions() };
+      const global = getters.globalPermissions();
+      const items = this.providedItems;
+
+      if (items.length > 0) {
+        const merged = {
+          view: true,
+          download: true,
+          modify: true,
+          create: false,
+          delete: true,
+        };
+        for (const item of items) {
+          const source = item.source || state.sources?.current || "";
+          const perms = getters.sourcePermissions(source);
+          merged.view = merged.view && perms.view;
+          merged.download = merged.download && perms.download;
+          merged.modify = merged.modify && perms.modify;
+          merged.create = merged.create || perms.create;
+          merged.delete = merged.delete && perms.delete;
+        }
+        return { ...global, ...merged };
+      }
+
+      const source = state.req?.source || state.sources?.current || "";
+      return { ...global, ...getters.sourcePermissions(source) };
     },
     /**
      * Whether the (+) panel can be opened (create file ops and/or admin-only rows like access rules).
@@ -382,7 +406,11 @@ export default {
       return !this.showCreate && this.selectedCount === 1 && !!state.user?.showCopyPath;
     },
     showOpenParentFolder() {
-      return !this.showCreate && this.selectedCount === 1 && (this.isSearchActive || this.showLimitedOptions);
+      return (
+        !this.showCreate &&
+        this.selectedCount === 1 &&
+        (this.isSearchActive || this.showLimitedOptions || getters.currentTool()?.component === "AdvancedSearch")
+      );
     },
     showMove() {
       if (this.showLimitedOptions) return false;

--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -49,6 +49,7 @@
         type="button"
         @click="closeTopPrompt"
         class="button button--flat button--grey"
+        :disabled="deleting"
         :aria-label="$t('general.cancel')"
         :title="$t('general.cancel')">
         {{ $t("general.cancel") }}
@@ -57,6 +58,7 @@
         type="button"
         @click="submit"
         class="button button--flat button--red"
+        :disabled="deleting"
         aria-label="Confirm-Delete"
         :title="$t('general.delete')">
         {{ $t("general.delete") }}
@@ -179,11 +181,27 @@ export default {
       return parts[parts.length - 1] || path;
     },
     getItemError(item) {
-      // Find matching failed item by comparing source and path
       for (const failedItem of this.failedItems.values()) {
         if (failedItem.source === item.source && failedItem.path === item.path) {
-          return failedItem.message || 'Unknown error';
+          return failedItem.message || "Unknown error";
         }
+      }
+      return null;
+    },
+    parseBulkDeleteFailures(error) {
+      if (error?.failed?.length) {
+        return error.failed;
+      }
+      if (!error?.message) {
+        return null;
+      }
+      try {
+        const parsed = JSON.parse(error.message);
+        if (Array.isArray(parsed?.failed) && parsed.failed.length > 0) {
+          return parsed.failed;
+        }
+      } catch (_e) {
+        // Not JSON — fall through
       }
       return null;
     },
@@ -221,9 +239,9 @@ export default {
 
       try {
         // Extract source and path from items (ignore previewUrl)
-        const itemsForDelete = this.itemsToDelete.map(item => ({
+        const itemsForDelete = this.itemsToDelete.map((item) => ({
           source: item.source,
-          path: item.path
+          path: item.path,
         }));
 
         if (itemsForDelete.length === 0) {
@@ -237,15 +255,12 @@ export default {
           ? await resourcesApi.bulkDeletePublic(itemsForDelete)
           : await resourcesApi.bulkDelete(itemsForDelete);
 
-        // Store failed items directly from response
-        if (response.failed && response.failed.length > 0) {
-          this.failedItems = response.failed;
-        } else {
-          this.failedItems = [];
-        }
+        const failed = Array.isArray(response?.failed) ? response.failed : [];
+        const succeeded = Array.isArray(response?.succeeded) ? response.succeeded : [];
+        this.failedItems = failed;
 
-        const succeededCount = response.succeeded ? response.succeeded.length : 0;
-        const failedCount = response.failed ? response.failed.length : 0;
+        const succeededCount = succeeded.length;
+        const failedCount = failed.length;
 
         if (failedCount === 0) {
           // All succeeded - close prompt and handle navigation
@@ -254,8 +269,8 @@ export default {
 
           if (this.items && this.items.length > 0) {
             eventBus.emit("itemsDeleted", {
-              succeeded: response.succeeded || [],
-              failed: []
+              succeeded,
+              failed,
             });
           }
           mutations.closeTopPrompt();
@@ -304,13 +319,23 @@ export default {
           // Emit event with partial results if items were passed as props
           if (this.items && this.items.length > 0) {
             eventBus.emit("itemsDeleted", {
-              succeeded: response.succeeded || [],
-              failed: response.failed || []
+              succeeded,
+              failed,
             });
+          }
+          if (failedCount > 0) {
+            notify.showError(
+              failed[0]?.message || this.$t("prompts.operationFailed")
+            );
           }
         } else {
           // All failed
           buttons.done("delete");
+          if (failedCount > 0) {
+            notify.showError(
+              failed[0]?.message || this.$t("prompts.operationFailed")
+            );
+          }
         }
 
         this.deleting = false;
@@ -318,12 +343,20 @@ export default {
         buttons.done("delete");
         this.deleting = false;
         console.error(e);
-        // On network/API errors, show error for all items
-        this.failedItems = this.itemsToDelete.map(item => ({
-          source: item.source,
-          path: item.path,
-          message: e.message || 'Delete failed'
-        }));
+        const parsedFailures = this.parseBulkDeleteFailures(e);
+        if (parsedFailures) {
+          this.failedItems = parsedFailures;
+          notify.showError(
+            parsedFailures[0]?.message || this.$t("prompts.operationFailed")
+          );
+        } else {
+          this.failedItems = this.itemsToDelete.map((item) => ({
+            source: item.source,
+            path: item.path,
+            message: e.message || "Delete failed",
+          }));
+          notify.showError(e.message || this.$t("prompts.operationFailed"));
+        }
       }
     },
   },

--- a/frontend/src/components/prompts/MoveCopy.vue
+++ b/frontend/src/components/prompts/MoveCopy.vue
@@ -30,6 +30,7 @@
       type="button"
       v-if="canCreateFolder && showNewDirInput"
       class="button button--flat"
+      :disabled="isLoading"
       @click="cancelNewDir"
       :aria-label="$t('general.cancel')"
       :title="$t('general.cancel')"
@@ -40,6 +41,7 @@
       type="button"
       v-if="canCreateFolder && !showNewDirInput"
       class="button button--flat"
+      :disabled="isLoading"
       @click="createNewDir"
       :aria-label="$t('files.newFolder')"
       :title="$t('files.newFolder')"
@@ -50,7 +52,8 @@
     v-model.trim="newDirName" :placeholder="$t('files.newFolderMessage')" @keydown.enter="handleEnter" />
     <button
       type="button"
-      v-else :disabled="destContainsSrc"
+      v-else
+      :disabled="destContainsSrc || isLoading"
       class="button button--flat"
       @click="performOperation"
       :aria-label="operation === 'move' ? $t('general.move') : $t('general.copy')"
@@ -63,7 +66,7 @@
       v-if="showNewDirInput"
       class="button button--flat"
       @click="createDirectory"
-      :disabled="!newDirName || !isDirNameValid"
+      :disabled="isLoading || !newDirName || !isDirNameValid"
     >
       {{ $t("general.create") }}
     </button>
@@ -274,6 +277,9 @@ export default {
     },
     performOperation: async function (event) {
       event.preventDefault();
+      if (this.isLoading) {
+        return;
+      }
       this.isLoading = true; // Show loading spinner
       try {
         // Ensure destination source is set

--- a/frontend/src/store/getters.ts
+++ b/frontend/src/store/getters.ts
@@ -617,12 +617,17 @@ export const getters = {
     if (getters.isShare() && state.shareInfo.shareType === "upload") {
       return false;
     }
-    const isAdvancedSearchRoute = (state.route.path || "").startsWith("/tools/advancedSearch");
-    return getters.currentView() === "listingView" || getters.isEditorOrMarkdownView() || isAdvancedSearchRoute;
+    return (
+      getters.currentView() === "listingView" ||
+      getters.isEditorOrMarkdownView() ||
+      getters.currentTool()?.component === "AdvancedSearch"
+    );
   },
   showGallerySizeSlider: () => {
-    const isAdvancedSearchRoute = (state.route.path || "").startsWith("/tools/advancedSearch");
-    return getters.currentView() === "listingView" || isAdvancedSearchRoute;
+    return (
+      getters.currentView() === "listingView" ||
+      getters.currentTool()?.component === "AdvancedSearch"
+    );
   },
   globalPermissions: () => {
     if (getters.isShare()) {

--- a/frontend/src/views/tools/AdvancedSearch.vue
+++ b/frontend/src/views/tools/AdvancedSearch.vue
@@ -247,6 +247,7 @@
 import { toolsApi } from "@/api";
 import router from "@/router";
 import { state, getters, mutations } from "@/store";
+import { eventBus } from "@/store/eventBus";
 import { globalVars } from "@/utils/constants";
 import ToggleSwitch from "@/components/settings/ToggleSwitch.vue";
 import SettingsItem from "@/components/settings/SettingsItem.vue";
@@ -695,8 +696,19 @@ export default {
 
       return styles;
     },
+    reload() {
+      return state.reload;
+    },
   },
   watch: {
+    reload(shouldReload) {
+      if (!shouldReload || !this.isAdvancedSearchRoute || !this.searchExecuted) {
+        return;
+      }
+      mutations.setReload(false);
+      mutations.resetSelected();
+      void this.runSearch();
+    },
     termInputs: {
       deep: true,
       handler() {
@@ -844,6 +856,10 @@ export default {
     };
     window.addEventListener("resize", this.resizeListener);
 
+    eventBus.on("itemsDeleted", this.handleSearchResultsChanged);
+    eventBus.on("itemsMoved", this.handleSearchResultsChanged);
+    eventBus.on("itemsRenamed", this.handleSearchResultsChanged);
+
     if (state.req !== null && state.req !== undefined) {
       this.hadInitialReq = true;
       this.initialReqFrozen = JSON.stringify(state.req);
@@ -874,6 +890,11 @@ export default {
       window.removeEventListener("resize", this.resizeListener);
       this.resizeListener = null;
     }
+
+    eventBus.off("itemsDeleted", this.handleSearchResultsChanged);
+    eventBus.off("itemsMoved", this.handleSearchResultsChanged);
+    eventBus.off("itemsRenamed", this.handleSearchResultsChanged);
+
     if (!this.didApplySearchListing) {
       return;
     }
@@ -884,6 +905,16 @@ export default {
     mutations.replaceRequest(JSON.parse(this.initialReqFrozen));
   },
   methods: {
+    handleSearchResultsChanged(data) {
+      if (!this.isAdvancedSearchRoute || !this.searchExecuted) {
+        return;
+      }
+      if (data?.succeeded && data.succeeded.length === 0) {
+        return;
+      }
+      mutations.resetSelected();
+      void this.runSearch();
+    },
     /** When no source is toggled on, enable `state.sources.current` if known in the catalogue. */
     applyDefaultCurrentSourceIfNone() {
       if (!this.isAdvancedSearchRoute) {

--- a/frontend/src/views/tools/AdvancedSearch.vue
+++ b/frontend/src/views/tools/AdvancedSearch.vue
@@ -512,6 +512,7 @@ export default {
       suppressRouteQueryNavigation: false,
       emptyCatalogHydrateTimer: null,
       advancedOptionsExpanded: false,
+      refreshQueued: false,
     };
   },
   computed: {
@@ -706,8 +707,7 @@ export default {
         return;
       }
       mutations.setReload(false);
-      mutations.resetSelected();
-      void this.runSearch();
+      this.scheduleSearchRefresh();
     },
     termInputs: {
       deep: true,
@@ -912,8 +912,18 @@ export default {
       if (data?.succeeded && data.succeeded.length === 0) {
         return;
       }
-      mutations.resetSelected();
-      void this.runSearch();
+      this.scheduleSearchRefresh();
+    },
+    scheduleSearchRefresh() {
+      if (this.refreshQueued) {
+        return;
+      }
+      this.refreshQueued = true;
+      this.$nextTick(() => {
+        this.refreshQueued = false;
+        mutations.resetSelected();
+        void this.runSearch();
+      });
     },
     /** When no source is toggled on, enable `state.sources.current` if known in the catalogue. */
     applyDefaultCurrentSourceIfNone() {


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Advanced Search now refreshes automatically after successful deletions, moves, renames, and reload requests.
  - Parent-folder navigation, status bar, and gallery size controls are available in Advanced Search.
  - Bulk actions preserve submitted paths in results and activity details.

- **Bug Fixes**
  - Improved permission handling for selections spanning multiple sources.
  - Prevented duplicate move, copy, and delete submissions.
  - Bulk-delete results now distinguish successful and failed items, including partial failures.
  - Paths with or without trailing slashes now produce consistent permission results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->