### PR TITLE
fix symlink attack escapes scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v2.0.1
 
+ **Security**:
+  - [High] Symlink following on read paths no longer escapes source or user/share scope (GHSA-mgqf-5mf5-prfj)
+
  **Notes**:
  - GroupMap `SyncUserGroups` fix so JWT/OIDC/LDAP group memberships survive restart (#2742).
  - Session renew is handled by client keep-alive. removed per-request `X-Renew-Token` header handling.

--- a/backend/internal/adapters/fs/files/files.go
+++ b/backend/internal/adapters/fs/files/files.go
@@ -261,14 +261,18 @@ func fileInfoFasterImpl(opts utils.FileOptions, user *users.User, s *Service) (*
 	}
 	// Layer 2: INDEX RULES (global)
 	// Get file info using unified entry point (applies IsViewable/ShouldSkip)
-	info, err := idx.GetFileInfo(indexing.FileInfoRequest{
+	fileInfoReq := indexing.FileInfoRequest{
 		IndexPath:         indexPath,
 		FollowSymlinks:    opts.FollowSymlinks,
 		ShowHidden:        opts.ShowHidden,
 		HideFileExt:       opts.HideFileExt,
 		Expand:            opts.Expand,
 		SkipExtendedAttrs: opts.SkipExtendedAttrs,
-	})
+	}
+	if opts.FollowSymlinks {
+		fileInfoReq.BoundIndexPath = userScope
+	}
+	info, err := idx.GetFileInfo(fileInfoReq)
 	if err != nil {
 		return response, err // Path excluded by index rules OR doesn't exist
 	}
@@ -285,7 +289,15 @@ func fileInfoFasterImpl(opts utils.FileOptions, user *users.User, s *Service) (*
 
 	// Build response
 	response.FileInfo = *info
-	response.RealPath = filepath.Join(idx.Path, indexPath)
+	if opts.FollowSymlinks && info.Type != "directory" {
+		realPath, _, err := idx.GetRealPathScoped(userScope, indexPath)
+		if err != nil {
+			return response, err
+		}
+		response.RealPath = realPath
+	} else {
+		response.RealPath = filepath.Join(idx.Path, indexPath)
+	}
 	response.Source = opts.Source
 	if user.Permissions.Share && opts.ShowSharedAttr {
 		for i := range response.Files {

--- a/backend/internal/errors/errors.go
+++ b/backend/internal/errors/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrUnauthorized         = errors.New("user unauthorized")
 	ErrNotIndexed           = errors.New("directory or item excluded from indexing")
 	ErrNotViewable          = errors.New("directory or item is not viewable")
+	ErrPathEscapesScope     = errors.New("resolved path escapes scope")
 	ErrWrongLoginMethod     = errors.New("user attempted to login with wrong login method")
 	ErrDownloadNotAllowed   = errors.New("downloads are not allowed for this share")
 	ErrUseMediaStream       = errors.New("use /media/stream for audio and video")

--- a/backend/internal/web/http.go
+++ b/backend/internal/web/http.go
@@ -127,6 +127,8 @@ func ErrToStatus(err error) int {
 		return http.StatusForbidden
 	case errors.Is(err, libErrors.ErrAccessDenied):
 		return http.StatusForbidden
+	case errors.Is(err, libErrors.ErrPathEscapesScope):
+		return http.StatusForbidden
 	case os.IsNotExist(err), err == libErrors.ErrNotExist:
 		return http.StatusNotFound
 	case os.IsExist(err), err == libErrors.ErrExist:

--- a/backend/internal/web/stream.go
+++ b/backend/internal/web/stream.go
@@ -434,13 +434,16 @@ func ServeSingleFile(w http.ResponseWriter, r *http.Request, d *Context, source 
 		return http.StatusForbidden, fmt.Errorf("access denied to path %s", scopedFilePath)
 	}
 
-	bound := "/"
+	var bound string
 	if d.Share.Hash != "" {
+		if d.Share.Path == "" {
+			return http.StatusForbidden, fmt.Errorf("share has no path scope")
+		}
 		bound = d.Share.Path
 	} else {
 		userScope, scopeErr := d.User.GetScopeForSourceName(source)
-		if scopeErr != nil {
-			return http.StatusForbidden, scopeErr
+		if scopeErr != nil || userScope == "" {
+			return http.StatusForbidden, fmt.Errorf("user has no access to source: %s", source)
 		}
 		bound = userScope
 	}

--- a/backend/internal/web/stream.go
+++ b/backend/internal/web/stream.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gtsteffaniak/filebrowser/backend/internal/state"
+	liberrors "github.com/gtsteffaniak/filebrowser/backend/internal/errors"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
@@ -433,8 +434,22 @@ func ServeSingleFile(w http.ResponseWriter, r *http.Request, d *Context, source 
 		return http.StatusForbidden, fmt.Errorf("access denied to path %s", scopedFilePath)
 	}
 
-	realPath, _, err := idx.GetRealPath(scopedFilePath)
+	bound := "/"
+	if d.Share.Hash != "" {
+		bound = d.Share.Path
+	} else {
+		userScope, scopeErr := d.User.GetScopeForSourceName(source)
+		if scopeErr != nil {
+			return http.StatusForbidden, scopeErr
+		}
+		bound = userScope
+	}
+
+	realPath, _, err := idx.GetRealPathScoped(bound, scopedFilePath)
 	if err != nil {
+		if errors.Is(err, liberrors.ErrPathEscapesScope) {
+			return http.StatusForbidden, err
+		}
 		return http.StatusInternalServerError, err
 	}
 

--- a/backend/pkg/indexing/indexingFiles.go
+++ b/backend/pkg/indexing/indexingFiles.go
@@ -1057,14 +1057,11 @@ func (idx *Index) GetRealPathScoped(boundIndexPath string, relativePath ...strin
 func (idx *Index) getRealPathInternal(boundIndexPath string, enforceScope bool, relativePath ...string) (string, bool, error) {
 	combined := append([]string{idx.Path}, relativePath...)
 	joinedPath := filepath.Join(combined...)
-	cacheKey := joinedPath
-	if enforceScope {
-		bound := boundIndexPath
-		if bound == "" {
-			bound = "/"
-		}
-		cacheKey = joinedPath + ":bound:" + bound
+	bound := boundIndexPath
+	if enforceScope && bound == "" {
+		bound = "/"
 	}
+	cacheKey := fmt.Sprintf("realpath|scoped=%t|bound=%q|path=%q", enforceScope, bound, joinedPath)
 	isDir, _ := IsDirCache.Get(cacheKey + ":isdir")
 	cached, ok := RealPathCache.Get(cacheKey)
 	if ok && cached != "" {

--- a/backend/pkg/indexing/indexingFiles.go
+++ b/backend/pkg/indexing/indexingFiles.go
@@ -428,6 +428,7 @@ type PathContext struct {
 type FileInfoRequest struct {
 	IndexPath         string
 	FollowSymlinks    bool
+	BoundIndexPath    string // index prefix for symlink containment (e.g. user scope)
 	ShowHidden        bool
 	HideFileExt       string // Hide files based on their extension
 	Expand            bool   // get child items for directories
@@ -435,9 +436,63 @@ type FileInfoRequest struct {
 	SkipExtendedAttrs bool   // whether to skip extended attributes
 }
 
+// filesystemBound resolves the filesystem path for an index prefix under this source.
+func (idx *Index) filesystemBound(boundIndexPath string) (string, error) {
+	bound := boundIndexPath
+	if bound == "" {
+		bound = "/"
+	}
+	fsPath := idx.Path
+	if bound != "/" {
+		fsPath = filepath.Join(idx.Path, strings.TrimPrefix(bound, "/"))
+	}
+	abs, err := filepath.Abs(fsPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(abs)
+}
+
+// ensureResolvedContained rejects resolved filesystem paths outside the source or scope prefix.
+func (idx *Index) ensureResolvedContained(realPath, boundIndexPath string) error {
+	sourceRoot, err := idx.filesystemBound("/")
+	if err != nil {
+		return err
+	}
+	if err := iteminfo.PathWithinRoot(sourceRoot, realPath); err != nil {
+		return errors.ErrPathEscapesScope
+	}
+	bound := boundIndexPath
+	if bound == "" {
+		bound = "/"
+	}
+	if bound != "/" {
+		scopeRoot, err := idx.filesystemBound(bound)
+		if err != nil {
+			return err
+		}
+		if err := iteminfo.PathWithinRoot(scopeRoot, realPath); err != nil {
+			return errors.ErrPathEscapesScope
+		}
+	}
+	return nil
+}
+
+// resolveSymlinksContained resolves symlinks and ensures the target stays within bounds.
+func (idx *Index) resolveSymlinksContained(fsPath, boundIndexPath string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(fsPath)
+	if err != nil {
+		return "", err
+	}
+	if err := idx.ensureResolvedContained(resolved, boundIndexPath); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
 // resolvePathContext resolves all path characteristics in a SINGLE stat call
 // This eliminates duplicate stat/lstat calls and redundant isHidden/isSymlink checks
-func (idx *Index) resolvePathContext(indexPath string, followSymlinks bool) (*PathContext, error) {
+func (idx *Index) resolvePathContext(indexPath string, followSymlinks bool, boundIndexPath string) (*PathContext, error) {
 	realPath := filepath.Join(idx.Path, indexPath)
 
 	// ONE filesystem stat call
@@ -450,7 +505,7 @@ func (idx *Index) resolvePathContext(indexPath string, followSymlinks bool) (*Pa
 
 	// Resolve symlink if requested
 	if isSymlink && followSymlinks {
-		realPath, err = filepath.EvalSymlinks(realPath)
+		realPath, err = idx.resolveSymlinksContained(realPath, boundIndexPath)
 		if err != nil {
 			return nil, err
 		}
@@ -506,7 +561,7 @@ func (idx *Index) evaluateIndexRules(ctx *PathContext, isRoutineScan bool) (isVi
 // User permission checking happens in the API layer (FileInfoFaster)
 func (idx *Index) GetFileInfo(req FileInfoRequest) (*iteminfo.FileInfo, error) {
 	// 1. Resolve path context (single stat call)
-	ctx, err := idx.resolvePathContext(req.IndexPath, req.FollowSymlinks)
+	ctx, err := idx.resolvePathContext(req.IndexPath, req.FollowSymlinks, req.BoundIndexPath)
 	if err != nil {
 		return nil, err
 	}
@@ -635,7 +690,7 @@ func (idx *Index) GetFsInfoCore(indexPath string, opts Options) (*iteminfo.FileI
 	realPath := filepath.Join(idx.Path, indexPath)
 	if opts.FollowSymlinks {
 		var err error
-		realPath, err = filepath.EvalSymlinks(realPath)
+		realPath, err = idx.resolveSymlinksContained(realPath, "/")
 		if err != nil {
 			return nil, err
 		}
@@ -991,10 +1046,27 @@ func (idx *Index) GetDirInfo(dirInfo *os.File, stat os.FileInfo, indexPath strin
 }
 
 func (idx *Index) GetRealPath(relativePath ...string) (string, bool, error) {
+	return idx.getRealPathInternal("/", false, relativePath...)
+}
+
+// GetRealPathScoped resolves an index path and rejects symlink targets outside the source and bound prefix.
+func (idx *Index) GetRealPathScoped(boundIndexPath string, relativePath ...string) (string, bool, error) {
+	return idx.getRealPathInternal(boundIndexPath, true, relativePath...)
+}
+
+func (idx *Index) getRealPathInternal(boundIndexPath string, enforceScope bool, relativePath ...string) (string, bool, error) {
 	combined := append([]string{idx.Path}, relativePath...)
 	joinedPath := filepath.Join(combined...)
-	isDir, _ := IsDirCache.Get(joinedPath + ":isdir")
-	cached, ok := RealPathCache.Get(joinedPath)
+	cacheKey := joinedPath
+	if enforceScope {
+		bound := boundIndexPath
+		if bound == "" {
+			bound = "/"
+		}
+		cacheKey = joinedPath + ":bound:" + bound
+	}
+	isDir, _ := IsDirCache.Get(cacheKey + ":isdir")
+	cached, ok := RealPathCache.Get(cacheKey)
 	if ok && cached != "" {
 		return cached, isDir, nil
 	}
@@ -1003,11 +1075,19 @@ func (idx *Index) GetRealPath(relativePath ...string) (string, bool, error) {
 		return absolutePath, false, fmt.Errorf("could not get real path: %v, %s", joinedPath, err)
 	}
 	realPath, isDir, err := iteminfo.ResolveSymlinks(absolutePath)
-	if err == nil {
-		RealPathCache.Set(joinedPath, realPath)
-		IsDirCache.Set(joinedPath+":isdir", isDir)
+	if err != nil {
+		return realPath, isDir, err
 	}
-	return realPath, isDir, err
+	if enforceScope {
+		if err := idx.ensureResolvedContained(realPath, boundIndexPath); err != nil {
+			return "", false, err
+		}
+	} else if err := idx.ensureResolvedContained(realPath, "/"); err != nil {
+		return "", false, err
+	}
+	RealPathCache.Set(cacheKey, realPath)
+	IsDirCache.Set(cacheKey+":isdir", isDir)
+	return realPath, isDir, nil
 }
 
 func (idx *Index) RefreshFileInfo(opts utils.FileOptions) error {

--- a/backend/pkg/indexing/iteminfo/utils.go
+++ b/backend/pkg/indexing/iteminfo/utils.go
@@ -105,6 +105,35 @@ func (info *FileInfo) SortItems() {
 	})
 }
 
+// PathWithinRoot reports whether path is equal to or under root after resolving symlinks.
+func PathWithinRoot(root, path string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("invalid root path: %w", err)
+	}
+	rootReal, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return fmt.Errorf("could not resolve root path: %w", err)
+	}
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+	pathReal, err := filepath.EvalSymlinks(pathAbs)
+	if err != nil {
+		return fmt.Errorf("could not resolve path: %w", err)
+	}
+	rel, err := filepath.Rel(rootReal, pathReal)
+	if err != nil {
+		return fmt.Errorf("path outside root: %w", err)
+	}
+	sep := string(filepath.Separator)
+	if rel == ".." || strings.HasPrefix(rel, ".."+sep) {
+		return fmt.Errorf("path escapes root")
+	}
+	return nil
+}
+
 // ResolveSymlinks resolves symlinks in the given path and returns
 // Uses Go's filepath.EvalSymlinks which properly detects circular symlinks.
 func ResolveSymlinks(path string) (string, bool, error) {

--- a/backend/pkg/indexing/symlink_containment_test.go
+++ b/backend/pkg/indexing/symlink_containment_test.go
@@ -126,6 +126,43 @@ func TestGetRealPathScoped_AllowsInScopeTarget(t *testing.T) {
 	}
 }
 
+func TestGetRealPathScoped_CacheKeyDoesNotCollideWithUnscoped(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	insideSource := filepath.Join(sourceRoot, "secret-in-source.txt")
+	if err := os.WriteFile(insideSource, []byte("in source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.WriteFile(filepath.Join(userDir, "foo"), []byte("legitimate"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Legacy scoped cache keys used joinedPath + ":bound:" + bound, which could collide
+	// with an unscoped joinedPath when ":bound:" appeared in a path component.
+	legacyKey := filepath.Join(sourceRoot, "user1", "foo") + ":bound:" + "/user1"
+	RealPathCache.Set(legacyKey, insideSource)
+	IsDirCache.Set(legacyKey+":isdir", false)
+
+	realPath, _, err := idx.GetRealPathScoped(userScope, "/user1/foo")
+	if err != nil {
+		t.Fatalf("scoped in-scope file should resolve: %v", err)
+	}
+	want := filepath.Join(userDir, "foo")
+	want, err = filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realPath, err = filepath.EvalSymlinks(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if realPath != want {
+		t.Fatalf("scoped lookup returned %q, want in-scope file %q", realPath, want)
+	}
+}
+
 func TestGetFileInfo_RejectsSymlinkEscapeWithBound(t *testing.T) {
 	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
 	idx := symlinkTestIndex(sourceRoot)

--- a/backend/pkg/indexing/symlink_containment_test.go
+++ b/backend/pkg/indexing/symlink_containment_test.go
@@ -1,0 +1,141 @@
+package indexing
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	liberrors "github.com/gtsteffaniak/filebrowser/backend/internal/errors"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
+)
+
+func setupSymlinkEscapeFixture(t *testing.T) (sourceRoot, userScope string) {
+	t.Helper()
+	root := t.TempDir()
+	sourceRoot = filepath.Join(root, "srv")
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outsideSecret := filepath.Join(root, "secret-outside.txt")
+	if err := os.WriteFile(outsideSecret, []byte("ROOT_DB_PASSWORD=supersecret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideSecret, filepath.Join(userDir, "secret_link")); err != nil {
+		t.Fatal(err)
+	}
+	sibling := filepath.Join(root, "outside-sibling.txt")
+	if err := os.WriteFile(sibling, []byte("outside sibling"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(sibling, filepath.Join(userDir, "sibling_link")); err != nil {
+		t.Fatal(err)
+	}
+	inside := filepath.Join(userDir, "allowed.txt")
+	if err := os.WriteFile(inside, []byte("allowed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return sourceRoot, "/user1"
+}
+
+func symlinkTestIndex(sourceRoot string) *Index {
+	return &Index{Source: settings.Source{Path: sourceRoot}}
+}
+
+func TestPathWithinRoot(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "inner", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(inside), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(inside, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(filepath.Dir(root), "outside.txt")
+	if err := os.WriteFile(outside, []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := iteminfo.PathWithinRoot(root, inside); err != nil {
+		t.Fatalf("expected inside path to be allowed: %v", err)
+	}
+	if err := iteminfo.PathWithinRoot(root, outside); err == nil {
+		t.Fatal("expected outside path to be rejected")
+	}
+}
+
+func TestGetRealPath_RejectsEscapeOutsideSource(t *testing.T) {
+	sourceRoot, _ := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	_, _, err := idx.GetRealPath("/user1/secret_link")
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope, got %v", err)
+	}
+	_, _, err = idx.GetRealPath("/user1/sibling_link")
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope for sibling link, got %v", err)
+	}
+}
+
+func TestGetRealPathScoped_RejectsEscapeOutsideUserScope(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	// Under source but outside /user1: place secret inside source root
+	insideSource := filepath.Join(sourceRoot, "secret-in-source.txt")
+	if err := os.WriteFile(insideSource, []byte("in source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.Symlink(insideSource, filepath.Join(userDir, "in_source_link")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := idx.GetRealPathScoped(userScope, "/user1/in_source_link")
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope for in-source escape, got %v", err)
+	}
+}
+
+func TestGetRealPathScoped_AllowsInScopeTarget(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.Symlink("allowed.txt", filepath.Join(userDir, "good_link")); err != nil {
+		t.Fatal(err)
+	}
+
+	realPath, _, err := idx.GetRealPathScoped(userScope, "/user1/good_link")
+	if err != nil {
+		t.Fatalf("expected in-scope symlink to resolve: %v", err)
+	}
+	want := filepath.Join(userDir, "allowed.txt")
+	realPath, err = filepath.EvalSymlinks(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err = filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if realPath != want {
+		t.Fatalf("got real path %q, want %q", realPath, want)
+	}
+}
+
+func TestGetFileInfo_RejectsSymlinkEscapeWithBound(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	_, err := idx.GetFileInfo(FileInfoRequest{
+		IndexPath:      "/user1/secret_link",
+		FollowSymlinks: true,
+		BoundIndexPath: userScope,
+	})
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope from GetFileInfo, got %v", err)
+	}
+}


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Fixed a high-severity issue where symbolic links could access files outside permitted source, user, or shared-file boundaries.
  * Out-of-scope path requests are now rejected with **403 Forbidden**.
* **Bug Fixes**
  * Valid symbolic links within authorized locations continue to resolve normally.
* **Tests**
  * Added coverage for blocked path escapes and valid in-scope symbolic links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->