### PR TITLE
fix expired jwt access on share path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v2.0.1
 
+ **Security**:
+ - [Moderate] Revoked JWTs could still authenticate on public-share and withOrWithoutUser routes until natural expiry, bypassing logout and Api-permission revocation on that surface (GHSA-4wmj-rq3c-m65v)
+
  **Notes**:
  - GroupMap `SyncUserGroups` fix so JWT/OIDC/LDAP group memberships survive restart (#2742).
  - Session renew is handled by client keep-alive. removed per-request `X-Renew-Token` header handling.

--- a/backend/internal/web/middleware.go
+++ b/backend/internal/web/middleware.go
@@ -210,8 +210,13 @@ func extractUserFromExpiredToken(r *http.Request, data *requestContext) *users.U
 		return nil
 	}
 
-	// Token is valid (but might be expired or revoked)
-	// Try to get the user regardless of expiration status
+	// Signature is valid but the operator may have revoked this token (logout, DELETE /api/auth/token,
+	// or removal of the user's Api permission). Do not resurrect revoked tokens here.
+	if state.IsTokenRevoked(tokenString) {
+		return nil
+	}
+
+	// Token is valid and not revoked (but might be expired — jwt.ParseWithClaims rejects expired tokens)
 	var user *users.User
 	userValue, err := state.UserFromAPIToken(tk, tokenString)
 	if err == nil {

--- a/backend/internal/web/middleware.go
+++ b/backend/internal/web/middleware.go
@@ -201,7 +201,10 @@ func extractUserFromExpiredToken(r *http.Request, data *requestContext) *users.U
 
 	data.Token = tokenString
 	var tk users.AuthToken
-	token, err := jwt.ParseWithClaims(tokenString, &tk, keyFunc)
+	// Validate signature without enforcing exp/iat so expired session JWTs can still yield
+	// user context on public-share routes; revocation is checked explicitly below.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, err := parser.ParseWithClaims(tokenString, &tk, keyFunc)
 	if err != nil {
 		return nil
 	}
@@ -210,13 +213,9 @@ func extractUserFromExpiredToken(r *http.Request, data *requestContext) *users.U
 		return nil
 	}
 
-	// Signature is valid but the operator may have revoked this token (logout, DELETE /api/auth/token,
-	// or removal of the user's Api permission). Do not resurrect revoked tokens here.
 	if state.IsTokenRevoked(tokenString) {
 		return nil
 	}
-
-	// Token is valid and not revoked (but might be expired — jwt.ParseWithClaims rejects expired tokens)
 	var user *users.User
 	userValue, err := state.UserFromAPIToken(tk, tokenString)
 	if err == nil {

--- a/backend/internal/web/middleware_test.go
+++ b/backend/internal/web/middleware_test.go
@@ -299,7 +299,7 @@ func issueExtractUserTestToken(t *testing.T, duration time.Duration) (*users.Use
 		t.Fatal("failed to load user:", err)
 	}
 	user.Permissions = users.Permissions{Api: true}
-	if err := state.UpdateUser(&user, "", "permissions"); err != nil {
+	if err = state.UpdateUser(&user, "", "permissions"); err != nil {
 		t.Fatal("failed to set user permissions:", err)
 	}
 	user, err = state.GetUserByUsername("victim")

--- a/backend/internal/web/middleware_test.go
+++ b/backend/internal/web/middleware_test.go
@@ -149,6 +149,120 @@ func TestWithAdminHelper(t *testing.T) {
 	}
 }
 
+func TestPublicShare_RejectsRevokedJWT(t *testing.T) {
+	setupTestEnv(t)
+
+	victim := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username:    "victim",
+			Permissions: users.Permissions{Api: true},
+		},
+		BackendScopes: []users.BackendScope{
+			{Path: "/srv", Scope: "/"},
+		},
+	}
+	if err := state.CreateUser(victim, ""); err != nil {
+		t.Fatal("failed to create victim user:", err)
+	}
+	victim.Permissions = users.Permissions{Api: true}
+	if err := state.UpdateUser(victim, "", "permissions"); err != nil {
+		t.Fatal("failed to set victim permissions:", err)
+	}
+
+	originalAuthKey := settings.Config.Auth.Key
+	settings.Config.Auth.Key = "key"
+	t.Cleanup(func() { settings.Config.Auth.Key = originalAuthKey })
+
+	tokenString, _, err := auth.MakeSignedTokenAPI(victim, "WEB_TOKEN_"+utils.InsecureRandomIdentifier(4), time.Hour*2, victim.Permissions, false)
+	if err != nil {
+		t.Fatalf("failed to issue token: %v", err)
+	}
+
+	shareLink := &share.Share{
+		ShareSettings: share.ShareSettings{
+			ShareLimits: share.ShareLimits{
+				SourceName:       "srv",
+				AllowedUsernames: []string{"victim"},
+			},
+		},
+		ShareColumns: share.ShareColumns{
+			Hash: "revoked_jwt_hash",
+			Path: "/",
+		},
+		SourcePath: "/srv",
+		UserID:     victim.ID,
+	}
+	if err := state.CreateShare(shareLink); err != nil {
+		t.Fatal("failed to create share:", err)
+	}
+
+	handler := withHashFile(publicGetResourceHandler)
+
+	makeRequest := func(jwt string) *httptest.ResponseRecorder {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/public/api/resources?hash=revoked_jwt_hash&path=/", http.NoBody)
+		req.AddCookie(&http.Cookie{
+			Name:  "filebrowser_quantum_jwt",
+			Value: jwt,
+		})
+		handler(recorder, req)
+		return recorder
+	}
+
+	// Valid token: allow-listed user can access the share.
+	rec := makeRequest(tokenString)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid token: expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	if err := state.RevokeToken(tokenString); err != nil {
+		t.Fatalf("failed to revoke token: %v", err)
+	}
+
+	// Revoked token must not resurrect the victim on public-share routes.
+	rec = makeRequest(tokenString)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("revoked token: expected non-200 status, got %d (JWT resurrection bypass)", rec.Code)
+	}
+}
+
+func TestExtractUserFromExpiredToken_RejectsRevokedJWT(t *testing.T) {
+	setupTestEnv(t)
+
+	user := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username:    "victim",
+			Permissions: users.Permissions{Api: true},
+		},
+	}
+	if err := state.CreateUser(user, ""); err != nil {
+		t.Fatal("failed to create user:", err)
+	}
+
+	originalAuthKey := settings.Config.Auth.Key
+	settings.Config.Auth.Key = "key"
+	t.Cleanup(func() { settings.Config.Auth.Key = originalAuthKey })
+
+	tokenString, _, err := auth.MakeSignedTokenAPI(user, "WEB_TOKEN_"+utils.InsecureRandomIdentifier(4), time.Hour*2, user.Permissions, false)
+	if err != nil {
+		t.Fatalf("failed to issue token: %v", err)
+	}
+	if err := state.RevokeToken(tokenString); err != nil {
+		t.Fatalf("failed to revoke token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/public/api/resources", http.NoBody)
+	req.AddCookie(&http.Cookie{
+		Name:  "filebrowser_quantum_jwt",
+		Value: tokenString,
+	})
+
+	data := &requestContext{}
+	if got := extractUserFromExpiredToken(req, data); got != nil {
+		t.Fatalf("extractUserFromExpiredToken() = user %q, want nil for revoked token", got.Username)
+	}
+}
+
 func TestPublicShareHandlerAuthentication(t *testing.T) {
 	setupTestEnv(t)
 

--- a/backend/internal/web/middleware_test.go
+++ b/backend/internal/web/middleware_test.go
@@ -227,26 +227,7 @@ func TestPublicShare_RejectsRevokedJWT(t *testing.T) {
 }
 
 func TestExtractUserFromExpiredToken_RejectsRevokedJWT(t *testing.T) {
-	setupTestEnv(t)
-
-	user := &users.User{
-		FrontendUser: users.FrontendUser{
-			Username:    "victim",
-			Permissions: users.Permissions{Api: true},
-		},
-	}
-	if err := state.CreateUser(user, ""); err != nil {
-		t.Fatal("failed to create user:", err)
-	}
-
-	originalAuthKey := settings.Config.Auth.Key
-	settings.Config.Auth.Key = "key"
-	t.Cleanup(func() { settings.Config.Auth.Key = originalAuthKey })
-
-	tokenString, _, err := auth.MakeSignedTokenAPI(user, "WEB_TOKEN_"+utils.InsecureRandomIdentifier(4), time.Hour*2, user.Permissions, false)
-	if err != nil {
-		t.Fatalf("failed to issue token: %v", err)
-	}
+	_, tokenString := issueExtractUserTestToken(t, time.Hour*2)
 	if err := state.RevokeToken(tokenString); err != nil {
 		t.Fatalf("failed to revoke token: %v", err)
 	}
@@ -261,6 +242,80 @@ func TestExtractUserFromExpiredToken_RejectsRevokedJWT(t *testing.T) {
 	if got := extractUserFromExpiredToken(req, data); got != nil {
 		t.Fatalf("extractUserFromExpiredToken() = user %q, want nil for revoked token", got.Username)
 	}
+}
+
+func TestExtractUserFromExpiredToken_AcceptsExpiredNonRevoked(t *testing.T) {
+	user, tokenString := issueExtractUserTestToken(t, -time.Hour)
+
+	req := httptest.NewRequest(http.MethodGet, "/public/api/resources", http.NoBody)
+	req.AddCookie(&http.Cookie{
+		Name:  "filebrowser_quantum_jwt",
+		Value: tokenString,
+	})
+
+	data := &requestContext{}
+	got := extractUserFromExpiredToken(req, data)
+	if got == nil {
+		t.Fatal("extractUserFromExpiredToken() = nil, want user for expired non-revoked token")
+	}
+	if got.Username != user.Username {
+		t.Fatalf("extractUserFromExpiredToken() username = %q, want %q", got.Username, user.Username)
+	}
+}
+
+func TestExtractUserFromExpiredToken_RejectsRevokedExpired(t *testing.T) {
+	_, tokenString := issueExtractUserTestToken(t, -time.Hour)
+	if err := state.RevokeToken(tokenString); err != nil {
+		t.Fatalf("failed to revoke token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/public/api/resources", http.NoBody)
+	req.AddCookie(&http.Cookie{
+		Name:  "filebrowser_quantum_jwt",
+		Value: tokenString,
+	})
+
+	data := &requestContext{}
+	if got := extractUserFromExpiredToken(req, data); got != nil {
+		t.Fatalf("extractUserFromExpiredToken() = user %q, want nil for revoked expired token", got.Username)
+	}
+}
+
+func issueExtractUserTestToken(t *testing.T, duration time.Duration) (*users.User, string) {
+	t.Helper()
+	setupTestEnv(t)
+
+	stored := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username:    "victim",
+			Permissions: users.Permissions{Api: true},
+		},
+	}
+	if err := state.CreateUser(stored, ""); err != nil {
+		t.Fatal("failed to create user:", err)
+	}
+	user, err := state.GetUserByUsername("victim")
+	if err != nil {
+		t.Fatal("failed to load user:", err)
+	}
+	user.Permissions = users.Permissions{Api: true}
+	if err := state.UpdateUser(&user, "", "permissions"); err != nil {
+		t.Fatal("failed to set user permissions:", err)
+	}
+	user, err = state.GetUserByUsername("victim")
+	if err != nil {
+		t.Fatal("failed to reload user:", err)
+	}
+
+	originalAuthKey := settings.Config.Auth.Key
+	settings.Config.Auth.Key = "key"
+	t.Cleanup(func() { settings.Config.Auth.Key = originalAuthKey })
+
+	tokenString, _, err := auth.MakeSignedTokenAPI(&user, "WEB_TOKEN_"+utils.InsecureRandomIdentifier(4), duration, user.Permissions, false)
+	if err != nil {
+		t.Fatalf("failed to issue token: %v", err)
+	}
+	return &user, tokenString
 }
 
 func TestPublicShareHandlerAuthentication(t *testing.T) {


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Revoked authentication tokens are now rejected consistently, including on public-share and no-user-required routes.
  - Logging out or revoking API access immediately prevents further access with the revoked token, rather than allowing it until expiration.
  - Expired, non-revoked tokens continue to support permitted authentication flows.

- **Tests**
  - Added coverage confirming revoked tokens cannot access public shares or be recovered for authentication, whether expired or unexpired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->