### PR TITLE
fix bypass scope issue on some api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v2.0.1
 
+ **Security**:
+ - [Moderate] Absolute paths in API path/file parameters could bypass user scope and read files outside the source mount (GHSA-rqqq-wv83-rp74)
+
  **Notes**:
  - GroupMap `SyncUserGroups` fix so JWT/OIDC/LDAP group memberships survive restart (#2742).
  - Session renew is handled by client keep-alive. removed per-request `X-Renew-Token` header handling.

--- a/backend/internal/adapters/fs/files/files.go
+++ b/backend/internal/adapters/fs/files/files.go
@@ -154,7 +154,7 @@ func checkPermissionsImpl(opts utils.FileOptions, user *users.User, s *Service) 
 		return "", "", errors.ErrAccessDenied
 	}
 
-	indexPath := utils.JoinPathAsUnix(userScope, safePath)
+	indexPath := utils.JoinScopedIndexPath(userScope, safePath)
 	parsedPath, err := utils.ParseSanitizedIndexPath(indexPath, true)
 	if err != nil {
 		return "", "", errors.ErrAccessDenied
@@ -285,7 +285,7 @@ func fileInfoFasterImpl(opts utils.FileOptions, user *users.User, s *Service) (*
 
 	// Build response
 	response.FileInfo = *info
-	response.RealPath = filepath.Join(idx.Path, indexPath)
+	response.RealPath = utils.JoinUnderSourceRoot(idx.Path, indexPath)
 	response.Source = opts.Source
 	if user.Permissions.Share && opts.ShowSharedAttr {
 		for i := range response.Files {

--- a/backend/internal/utils/path.go
+++ b/backend/internal/utils/path.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -39,6 +40,33 @@ func JoinPathAsUnix(parts ...string) string {
 		joinedPath = strings.ReplaceAll(joinedPath, "\\", "/")
 	}
 	return joinedPath
+}
+
+// JoinScopedIndexPath joins a user's index scope with a sanitized path segment.
+// Unlike filepath.Join, a leading slash on rel does not discard scope (avoids absolute-path scope bypass).
+func JoinScopedIndexPath(scope, rel string) string {
+	rel = strings.TrimPrefix(path.Clean(rel), "/")
+	scope = strings.TrimRight(scope, "/")
+	if rel == "" {
+		if scope == "" || scope == "/" {
+			return "/"
+		}
+		return scope
+	}
+	if scope == "" || scope == "/" {
+		return "/" + rel
+	}
+	return scope + "/" + rel
+}
+
+// JoinUnderSourceRoot maps an index path onto a source filesystem root without treating
+// indexPath as a host-absolute path (filepath.Join would discard sourceRoot when indexPath starts with "/").
+func JoinUnderSourceRoot(sourceRoot, indexPath string) string {
+	rel := strings.TrimPrefix(path.Clean(indexPath), "/")
+	if rel == "" {
+		return sourceRoot
+	}
+	return filepath.Join(sourceRoot, rel)
 }
 
 // AddTrailingSlashIfNotExists ensures a directory index path has a trailing slash (root stays "/").

--- a/backend/internal/utils/path.go
+++ b/backend/internal/utils/path.go
@@ -42,10 +42,15 @@ func JoinPathAsUnix(parts ...string) string {
 	return joinedPath
 }
 
+// CleanIndexPathSegment normalizes an index path segment and clamps ".." at the virtual root.
+func CleanIndexPathSegment(segment string) string {
+	return strings.TrimPrefix(path.Clean("/"+segment), "/")
+}
+
 // JoinScopedIndexPath joins a user's index scope with a sanitized path segment.
 // Unlike filepath.Join, a leading slash on rel does not discard scope (avoids absolute-path scope bypass).
 func JoinScopedIndexPath(scope, rel string) string {
-	rel = strings.TrimPrefix(path.Clean(rel), "/")
+	rel = CleanIndexPathSegment(rel)
 	scope = strings.TrimRight(scope, "/")
 	if rel == "" {
 		if scope == "" || scope == "/" {
@@ -62,7 +67,7 @@ func JoinScopedIndexPath(scope, rel string) string {
 // JoinUnderSourceRoot maps an index path onto a source filesystem root without treating
 // indexPath as a host-absolute path (filepath.Join would discard sourceRoot when indexPath starts with "/").
 func JoinUnderSourceRoot(sourceRoot, indexPath string) string {
-	rel := strings.TrimPrefix(path.Clean(indexPath), "/")
+	rel := CleanIndexPathSegment(indexPath)
 	if rel == "" {
 		return sourceRoot
 	}

--- a/backend/internal/utils/path_test.go
+++ b/backend/internal/utils/path_test.go
@@ -23,6 +23,15 @@ func TestJoinScopedIndexPath_traversalResolvedUnderScope(t *testing.T) {
 	}
 }
 
+func TestJoinScopedIndexPath_relativeTraversalWithoutLeadingSlash(t *testing.T) {
+	const scope = "/home/alice"
+	got := JoinScopedIndexPath(scope, "../../../etc/passwd")
+	want := "/home/alice/etc/passwd"
+	if got != want {
+		t.Fatalf("JoinScopedIndexPath(%q, ../../../etc/passwd) = %q, want %q", scope, got, want)
+	}
+}
+
 func TestJoinScopedIndexPath_rootScope(t *testing.T) {
 	got := JoinScopedIndexPath("/", "projects/acme/file.txt")
 	if got != "/projects/acme/file.txt" {
@@ -43,6 +52,15 @@ func TestJoinUnderSourceRoot_relativeIndexPath(t *testing.T) {
 	const sourceRoot = "/srv/mount"
 	got := JoinUnderSourceRoot(sourceRoot, "/home/alice/projects/foo")
 	want := filepath.Join(sourceRoot, "home/alice/projects/foo")
+	if got != want {
+		t.Fatalf("JoinUnderSourceRoot = %q, want %q", got, want)
+	}
+}
+
+func TestJoinUnderSourceRoot_relativeTraversalWithoutLeadingSlash(t *testing.T) {
+	const sourceRoot = "/srv/mount"
+	got := JoinUnderSourceRoot(sourceRoot, "../../../etc/passwd")
+	want := filepath.Join(sourceRoot, "etc/passwd")
 	if got != want {
 		t.Fatalf("JoinUnderSourceRoot = %q, want %q", got, want)
 	}

--- a/backend/internal/utils/path_test.go
+++ b/backend/internal/utils/path_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestJoinScopedIndexPath_absoluteRelDoesNotDropScope(t *testing.T) {
+	const scope = "/home/alice"
+	got := JoinScopedIndexPath(scope, "/etc/passwd")
+	want := "/home/alice/etc/passwd"
+	if got != want {
+		t.Fatalf("JoinScopedIndexPath(%q, /etc/passwd) = %q, want %q", scope, got, want)
+	}
+}
+
+func TestJoinScopedIndexPath_traversalResolvedUnderScope(t *testing.T) {
+	const scope = "/home/alice"
+	got := JoinScopedIndexPath(scope, "/../../../etc/passwd")
+	want := "/home/alice/etc/passwd"
+	if got != want {
+		t.Fatalf("JoinScopedIndexPath(%q, /../../../etc/passwd) = %q, want %q", scope, got, want)
+	}
+}
+
+func TestJoinScopedIndexPath_rootScope(t *testing.T) {
+	got := JoinScopedIndexPath("/", "projects/acme/file.txt")
+	if got != "/projects/acme/file.txt" {
+		t.Fatalf("got %q want /projects/acme/file.txt", got)
+	}
+}
+
+func TestJoinUnderSourceRoot_absoluteIndexPathStaysUnderSource(t *testing.T) {
+	const sourceRoot = "/srv/mount"
+	got := JoinUnderSourceRoot(sourceRoot, "/etc/passwd")
+	want := filepath.Join(sourceRoot, "etc/passwd")
+	if got != want {
+		t.Fatalf("JoinUnderSourceRoot = %q, want %q", got, want)
+	}
+}
+
+func TestJoinUnderSourceRoot_relativeIndexPath(t *testing.T) {
+	const sourceRoot = "/srv/mount"
+	got := JoinUnderSourceRoot(sourceRoot, "/home/alice/projects/foo")
+	want := filepath.Join(sourceRoot, "home/alice/projects/foo")
+	if got != want {
+		t.Fatalf("JoinUnderSourceRoot = %q, want %q", got, want)
+	}
+}

--- a/backend/internal/web/download.go
+++ b/backend/internal/web/download.go
@@ -189,7 +189,7 @@ func publicDownloadHandler(w http.ResponseWriter, r *http.Request, d *Context) (
 		if err != nil {
 			return http.StatusBadRequest, fmt.Errorf("invalid file path: %v", err)
 		}
-		filePath := utils.JoinPathAsUnix(d.Share.Path, cleanFile)
+		filePath := utils.JoinScopedIndexPath(d.Share.Path, cleanFile)
 		fileList = append(fileList, filePath)
 	}
 
@@ -242,7 +242,7 @@ func RawFilesHandler(w http.ResponseWriter, r *http.Request, d *Context, source 
 			return http.StatusForbidden, err
 		}
 		for i, filePath := range fileList {
-			fileList[i] = utils.JoinPathAsUnix(userscope, filePath)
+			fileList[i] = utils.JoinScopedIndexPath(userscope, filePath)
 		}
 	}
 	firstFilePath = fileList[0]

--- a/backend/internal/web/resource.go
+++ b/backend/internal/web/resource.go
@@ -1368,10 +1368,8 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 			continue
 		}
 
-		// Get real paths
-		// Combine user scope with item paths BEFORE calling GetRealPath to avoid double scope application
-		fullSrcPath := utils.JoinScopedIndexPath(userscopeSrc, cleanFromPath)
-		realSrc, isSrcDir, err := srcIdx.GetRealPath(fullSrcPath)
+		// Get real paths (fullSrcIndexPath already includes user scope)
+		realSrc, isSrcDir, err := srcIdx.GetRealPath(fullSrcIndexPath)
 		if err != nil {
 			logger.Errorf("could not resolve source path: %v, fromPath: %v", err, clientFromPath)
 			item.Message = "could not resolve source path"

--- a/backend/internal/web/resource.go
+++ b/backend/internal/web/resource.go
@@ -437,7 +437,7 @@ func ResourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *Contex
 				continue
 			}
 			withoutUserScope := strings.TrimPrefix(d.Share.Path, userScope)
-			indexPath := utils.JoinPathAsUnix(withoutUserScope, sanitizedPath)
+			indexPath := utils.JoinScopedIndexPath(withoutUserScope, sanitizedPath)
 
 			fileInfo, err := files.FileInfoFaster(utils.FileOptions{
 				FollowSymlinks: true,
@@ -628,7 +628,7 @@ func resourcePauseHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 	if err != nil {
 		return http.StatusForbidden, err
 	}
-	fullIndexPath := utils.JoinPathAsUnix(userscope, cleanPath)
+	fullIndexPath := utils.JoinScopedIndexPath(userscope, cleanPath)
 	if !state.AccessPermitted(idx.Path, utils.IndexPathFromNormalized(fullIndexPath, true), d.User.Username) {
 		return http.StatusForbidden, fmt.Errorf("access denied to path %s", fullIndexPath)
 	}
@@ -717,7 +717,7 @@ func ResourcePostHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 	}
 	userscope = strings.TrimRight(userscope, "/")
 
-	fullIndexPath := utils.JoinPathAsUnix(userscope, path)
+	fullIndexPath := utils.JoinScopedIndexPath(userscope, path)
 
 	// get scoped path
 	realPath, _, _ := idx.GetRealPath(fullIndexPath)
@@ -1109,7 +1109,7 @@ func resourcePutHandler(w http.ResponseWriter, r *http.Request, d *Context) (int
 	if err != nil {
 		return http.StatusForbidden, err
 	}
-	fullIndexPath := utils.JoinPathAsUnix(userScope, path)
+	fullIndexPath := utils.JoinScopedIndexPath(userScope, path)
 	// Check access control for the target path
 	idx := indexing.GetIndex(source)
 	if idx == nil {
@@ -1163,7 +1163,7 @@ func publicPutHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, 
 		return http.StatusBadRequest, err
 	}
 
-	resolvedPath := utils.JoinPathAsUnix(d.Share.Path, cleanPath)
+	resolvedPath := utils.JoinScopedIndexPath(d.Share.Path, cleanPath)
 	err = files.WriteFile(sourceName, resolvedPath, r.Body)
 	if err != nil {
 		logger.Errorf("public put handler: error updating resource with error %v", err)
@@ -1336,8 +1336,8 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 		}
 
 		// Build full index paths for access control
-		fullSrcIndexPath := utils.JoinPathAsUnix(userscopeSrc, cleanFromPath)
-		fullDstIndexPath := utils.JoinPathAsUnix(userscopeDst, cleanToPath)
+		fullSrcIndexPath := utils.JoinScopedIndexPath(userscopeSrc, cleanFromPath)
+		fullDstIndexPath := utils.JoinScopedIndexPath(userscopeDst, cleanToPath)
 		if fullDstIndexPath == "/" || fullSrcIndexPath == "/" {
 			item.Message = "source or destination is the root or unautharized directory"
 			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))
@@ -1370,7 +1370,7 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 
 		// Get real paths
 		// Combine user scope with item paths BEFORE calling GetRealPath to avoid double scope application
-		fullSrcPath := utils.JoinPathAsUnix(userscopeSrc, cleanFromPath)
+		fullSrcPath := utils.JoinScopedIndexPath(userscopeSrc, cleanFromPath)
 		realSrc, isSrcDir, err := srcIdx.GetRealPath(fullSrcPath)
 		if err != nil {
 			logger.Errorf("could not resolve source path: %v, fromPath: %v", err, clientFromPath)
@@ -1387,7 +1387,7 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 
 		// Check destination parent directory exists
 		dstParentPath := filepath.Dir(cleanToPath)
-		fullDstParentPath := utils.JoinPathAsUnix(userscopeDst, dstParentPath)
+		fullDstParentPath := utils.JoinScopedIndexPath(userscopeDst, dstParentPath)
 		parentDir, _, err := dstIdx.GetRealPath(fullDstParentPath)
 		if err != nil {
 			item.Message = "destination directory does not exist"
@@ -1536,13 +1536,13 @@ func publicPatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (int
 			return http.StatusBadRequest, fmt.Errorf("invalid from path: %w", err)
 		}
 		req.Items[i].FromSource = sourceName
-		req.Items[i].FromPath = utils.JoinPathAsUnix(d.Share.Path, sanitizedPath)
+		req.Items[i].FromPath = utils.JoinScopedIndexPath(d.Share.Path, sanitizedPath)
 		sanitizedPath, err = utils.SanitizePath(req.Items[i].ToPath)
 		if err != nil {
 			return http.StatusBadRequest, fmt.Errorf("invalid to path: %w", err)
 		}
 		req.Items[i].ToSource = sourceName
-		req.Items[i].ToPath = utils.JoinPathAsUnix(d.Share.Path, sanitizedPath)
+		req.Items[i].ToPath = utils.JoinScopedIndexPath(d.Share.Path, sanitizedPath)
 	}
 	d.Data = req
 

--- a/backend/internal/web/stream.go
+++ b/backend/internal/web/stream.go
@@ -553,7 +553,7 @@ func streamHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, err
 	if err != nil {
 		return http.StatusForbidden, err
 	}
-	scopedPath := utils.JoinPathAsUnix(userscope, cleanPath)
+	scopedPath := utils.JoinScopedIndexPath(userscope, cleanPath)
 	return streamFilesHandler(w, r, d, source, []string{scopedPath})
 }
 
@@ -600,7 +600,7 @@ func publicStreamHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 	if !IsMediaStreamFile(shareRelativeDisplayName(d, cleanFile)) {
 		return http.StatusForbidden, fmt.Errorf("stream endpoint supports audio and video only")
 	}
-	scopedPath := utils.JoinPathAsUnix(d.Share.Path, cleanFile)
+	scopedPath := utils.JoinScopedIndexPath(d.Share.Path, cleanFile)
 	status, err := streamFilesHandler(w, r, d, sourceInfo.Name, []string{scopedPath})
 	if err != nil {
 		if status == http.StatusForbidden {

--- a/backend/internal/web/view.go
+++ b/backend/internal/web/view.go
@@ -63,7 +63,7 @@ func viewHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, error
 	if err != nil {
 		return http.StatusForbidden, err
 	}
-	scopedPath := utils.JoinPathAsUnix(userscope, cleanPath)
+	scopedPath := utils.JoinScopedIndexPath(userscope, cleanPath)
 	return viewFilesHandler(w, r, d, source, []string{scopedPath})
 }
 
@@ -107,7 +107,7 @@ func PublicViewHandler(w http.ResponseWriter, r *http.Request, d *Context) (int,
 	if err = ValidateViewGrant(token, d, ""); err != nil {
 		return http.StatusForbidden, err
 	}
-	scopedPath := utils.JoinPathAsUnix(d.Share.Path, cleanFile)
+	scopedPath := utils.JoinScopedIndexPath(d.Share.Path, cleanFile)
 	status, err := viewFilesHandler(w, r, d, sourceInfo.Name, []string{scopedPath})
 	if err != nil {
 		if status == http.StatusForbidden {

--- a/backend/pkg/indexing/indexingFiles.go
+++ b/backend/pkg/indexing/indexingFiles.go
@@ -3,6 +3,7 @@ package indexing
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -438,7 +439,7 @@ type FileInfoRequest struct {
 // resolvePathContext resolves all path characteristics in a SINGLE stat call
 // This eliminates duplicate stat/lstat calls and redundant isHidden/isSymlink checks
 func (idx *Index) resolvePathContext(indexPath string, followSymlinks bool) (*PathContext, error) {
-	realPath := filepath.Join(idx.Path, indexPath)
+	realPath := utils.JoinUnderSourceRoot(idx.Path, indexPath)
 
 	// ONE filesystem stat call
 	fileInfo, err := os.Lstat(realPath)
@@ -594,7 +595,7 @@ func (idx *Index) indexDirectory(indexPath string, opts Options, scanner *Scanne
 	if !strings.HasSuffix(indexPath, "/") {
 		indexPath = indexPath + "/"
 	}
-	realPath := filepath.Join(idx.Path, indexPath)
+	realPath := utils.JoinUnderSourceRoot(idx.Path, indexPath)
 
 	// Open the directory
 	dir, err := os.Open(realPath)
@@ -632,7 +633,7 @@ func (idx *Index) indexDirectory(indexPath string, opts Options, scanner *Scanne
 // GetFsInfoCore is the consolidated implementation for both GetFsInfo and GetFsInfoViewableOnly
 func (idx *Index) GetFsInfoCore(indexPath string, opts Options) (*iteminfo.FileInfo, error) {
 	// Handle symlinks if not following them
-	realPath := filepath.Join(idx.Path, indexPath)
+	realPath := utils.JoinUnderSourceRoot(idx.Path, indexPath)
 	if opts.FollowSymlinks {
 		var err error
 		realPath, err = filepath.EvalSymlinks(realPath)
@@ -991,8 +992,12 @@ func (idx *Index) GetDirInfo(dirInfo *os.File, stat os.FileInfo, indexPath strin
 }
 
 func (idx *Index) GetRealPath(relativePath ...string) (string, bool, error) {
-	combined := append([]string{idx.Path}, relativePath...)
-	joinedPath := filepath.Join(combined...)
+	parts := make([]string, 0, len(relativePath)+1)
+	parts = append(parts, idx.Path)
+	for _, p := range relativePath {
+		parts = append(parts, strings.TrimPrefix(path.Clean(p), "/"))
+	}
+	joinedPath := filepath.Join(parts...)
 	isDir, _ := IsDirCache.Get(joinedPath + ":isdir")
 	cached, ok := RealPathCache.Get(joinedPath)
 	if ok && cached != "" {
@@ -1034,7 +1039,7 @@ func (idx *Index) RefreshDirectory(indexPath string, recursive bool) error {
 		indexPath = indexPath + "/"
 	}
 
-	realPath := filepath.Join(idx.Path, indexPath)
+	realPath := utils.JoinUnderSourceRoot(idx.Path, indexPath)
 
 	// Check if directory exists
 	dirInfo, err := os.Stat(realPath)

--- a/backend/pkg/indexing/indexingFiles.go
+++ b/backend/pkg/indexing/indexingFiles.go
@@ -3,7 +3,6 @@ package indexing
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"

--- a/backend/pkg/indexing/unix.go
+++ b/backend/pkg/indexing/unix.go
@@ -4,10 +4,10 @@ package indexing
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"syscall"
 
+	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
 	"github.com/gtsteffaniak/go-logger/logger"
 )
 
@@ -66,7 +66,7 @@ func (idx *Index) handleFile(file os.FileInfo, indexPath string, realFilePath st
 
 	// Use provided realFilePath if available, otherwise construct it
 	if realFilePath == "" {
-		realFilePath = filepath.Join(idx.Path, indexPath)
+		realFilePath = utils.JoinUnderSourceRoot(idx.Path, indexPath)
 	}
 
 	sys := file.Sys()


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Fixed a vulnerability that could allow absolute paths or traversal-like inputs to bypass access scope and reach files outside the configured source location.
  * Applied consistent path safety to downloads, uploads, streaming, viewing, deletion, and directory operations.
* **Documentation**
  * Added a v2.0.1 changelog entry describing the security fix.
* **Tests**
  * Added coverage verifying scoped paths and filesystem paths remain within their intended boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->