### PR TITLE
updated with share bug fix for stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. For commit guidelines, please refer to [Standard Version](https://github.com/conventional-changelog/standard-version).
 
+## v1.5.2-stable
+
+ **Security**:
+ - [Moderate] PATCH /api/share could re-point a share outside the owner's scope (GHSA-wfjp-qhvc-69wp)
+
 ## v1.5.5
 
  **BugFixes**:

--- a/backend/http/share.go
+++ b/backend/http/share.go
@@ -220,8 +220,28 @@ func sharePatchHandler(w http.ResponseWriter, r *http.Request, d *requestContext
 	if thisShare.UserID != d.user.ID && !d.user.Permissions.Admin {
 		return http.StatusForbidden, fmt.Errorf("you are not allowed to update this share")
 	}
-	// Update the share path
-	err = store.Share.UpdateSharePath(body.Hash, sanitizedPath)
+
+	sourceName := thisShare.GetSourceName()
+	if sourceName == "" {
+		return http.StatusBadRequest, fmt.Errorf("source not available for share")
+	}
+	userscope, err := d.user.GetScopeForSourceName(sourceName)
+	if err != nil {
+		return http.StatusForbidden, err
+	}
+	storedPath := utils.JoinPathAsUnix(userscope, body.Path)
+	storedPath = utils.AddTrailingSlashIfNotExists(storedPath)
+
+	idx := indexing.GetIndex(sourceName)
+	if idx == nil {
+		return http.StatusBadRequest, fmt.Errorf("index not found for source: %s", sourceName)
+	}
+	_, _, err = idx.GetRealPath(storedPath)
+	if err != nil {
+		return http.StatusForbidden, fmt.Errorf("path not found: %s", body.Path)
+	}
+
+	err = store.Share.UpdateSharePath(body.Hash, storedPath)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/backend/http/share_patch_test.go
+++ b/backend/http/share_patch_test.go
@@ -1,0 +1,92 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/common/settings"
+	"github.com/gtsteffaniak/filebrowser/backend/database/share"
+	"github.com/gtsteffaniak/filebrowser/backend/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/indexing"
+)
+
+func TestSharePatchHandler_AnchorsPathToOwnerScope(t *testing.T) {
+	setupTestEnv(t)
+
+	srvRoot := t.TempDir()
+	publicDir := filepath.Join(srvRoot, "public")
+	if err := os.MkdirAll(publicDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(publicDir, "marker.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	settings.Config.Server.SourceMap = map[string]*settings.Source{
+		"/srv": {Path: "/srv", Name: "srv"},
+	}
+	settings.Config.Server.NameToSource = map[string]*settings.Source{
+		"srv": {Path: "/srv", Name: "srv"},
+	}
+	indexing.SetTestIndex("srv", srvRoot)
+	t.Cleanup(indexing.ClearTestIndices)
+
+	guest := &users.User{
+		ID:       2,
+		Username: "guest",
+		Permissions: users.Permissions{
+			Share: true,
+		},
+		Scopes: []users.SourceScope{
+			{Name: "/srv", Scope: "/public"},
+		},
+	}
+	if err := store.Users.Save(guest, true, true); err != nil {
+		t.Fatal(err)
+	}
+
+	initialPath := "/public/"
+	link := &share.Link{
+		Hash:    "patch_scope_hash",
+		UserID:  guest.ID,
+		Version: 1,
+		CommonShare: share.CommonShare{
+			Path:   initialPath,
+			Source: "/srv",
+		},
+	}
+	if err := store.Share.Save(link); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"hash": link.Hash,
+		"path": "/",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPatch, "/api/share", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	status, handlerErr := sharePatchHandler(rec, req, &requestContext{user: guest})
+	if status != http.StatusOK {
+		t.Fatalf("sharePatchHandler status=%d err=%v", status, handlerErr)
+	}
+
+	updated, err := store.Share.GetByHash(link.Hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Path == "/" {
+		t.Fatalf("share path escaped to source root: %q", updated.Path)
+	}
+	if updated.Path != initialPath {
+		t.Fatalf("share path = %q, want %q", updated.Path, initialPath)
+	}
+}


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue affecting shared-link path updates.
  * Share paths now remain within the owner’s permitted scope and require a valid indexed destination.
  * Added safeguards to confirm the target path exists before updating a share.

* **Documentation**
  * Added a changelog entry describing the security fix in version 1.5.2-stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->