### PR TITLE
backport security fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. For commit guidelines, please refer to [Standard Version](https://github.com/conventional-changelog/standard-version).
 
+## v1.5.2-stable
+
+ **Security**:
+ - [Moderate] PATCH /api/share could re-point a share outside the owner's scope (GHSA-wfjp-qhvc-69wp) @maximeborges
+ - [High] Public upload ACL check used scope-stripped path, bypassing per-folder DENY rules (GHSA-qv53-4557-m65h) @hypnguyen1209
+
 ## v1.5.5
 
  **BugFixes**:

--- a/backend/http/resource.go
+++ b/backend/http/resource.go
@@ -692,7 +692,7 @@ func resourcePostHandler(w http.ResponseWriter, r *http.Request, d *requestConte
 					publicPauseCache.Delete(k)
 				}
 			} else {
-				k := pauseUploadCacheKey(source, path)
+				k := pauseUploadCacheKey(source, fullIndexPath)
 				if _, ok := pauseCache.Get(k); ok {
 					gracefulPause = true
 					pauseCache.Delete(k)

--- a/backend/http/resource.go
+++ b/backend/http/resource.go
@@ -471,13 +471,15 @@ func resourcePauseHandler(w http.ResponseWriter, r *http.Request, d *requestCont
 		logger.Debugf("source %s not found", source)
 		return http.StatusNotFound, fmt.Errorf("source %s not found", source)
 	}
-	if _, err := d.user.GetScopeForSourceName(source); err != nil {
+	userScope, err := d.user.GetScopeForSourceName(source)
+	if err != nil {
 		return http.StatusForbidden, err
 	}
-	if !store.Access.Permitted(idx.Path, path, d.user.Username) {
-		return http.StatusForbidden, fmt.Errorf("access denied to path %s", path)
+	fullIndexPath := utils.JoinPathAsUnix(userScope, path)
+	if !store.Access.Permitted(idx.Path, fullIndexPath, d.user.Username) {
+		return http.StatusForbidden, fmt.Errorf("access denied to path %s", fullIndexPath)
 	}
-	pauseCache.Set(pauseUploadCacheKey(source, path), "1")
+	pauseCache.Set(pauseUploadCacheKey(source, fullIndexPath), "1")
 	return http.StatusOK, nil
 }
 
@@ -572,8 +574,8 @@ func resourcePostHandler(w http.ResponseWriter, r *http.Request, d *requestConte
 	realPath, _, _ := idx.GetRealPath(fullIndexPath)
 
 	// Check access control for the target path
-	if !store.Access.Permitted(idx.Path, path, filePermUser.Username) {
-		return http.StatusForbidden, fmt.Errorf("access denied to path %s", path)
+	if !store.Access.Permitted(idx.Path, fullIndexPath, filePermUser.Username) {
+		return http.StatusForbidden, fmt.Errorf("access denied to path %s", fullIndexPath)
 	}
 
 	// Check for file/folder conflicts before creation

--- a/backend/http/resource_acl_test.go
+++ b/backend/http/resource_acl_test.go
@@ -1,0 +1,39 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
+	"github.com/gtsteffaniak/filebrowser/backend/database/users"
+)
+
+func TestResourcePostACLUsesFullIndexPathKey(t *testing.T) {
+	setupTestEnv(t)
+
+	const (
+		sourcePath   = "/srv"
+		userScope    = "/home/alice"
+		deniedFolder = "/home/alice/projects/acme/private"
+		relPath      = "/projects/acme/private/poison.docx"
+	)
+	fullIndexPath := utils.JoinPathAsUnix(userScope, relPath)
+
+	alice := &users.User{
+		ID:       1,
+		Username: "alice",
+	}
+	if err := store.Users.Save(alice, true, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Access.DenyUser(sourcePath, deniedFolder, "alice"); err != nil {
+		t.Fatalf("DenyUser: %v", err)
+	}
+
+	if !store.Access.Permitted(sourcePath, relPath, "alice") {
+		t.Fatal("scope-stripped path does not match deny rule keyed at full index path (documents pre-fix ACL miss)")
+	}
+	if store.Access.Permitted(sourcePath, fullIndexPath, "alice") {
+		t.Fatalf("full index path %q should be denied for alice", fullIndexPath)
+	}
+}


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Fixed folder-level access controls for uploads, preventing public uploads from bypassing explicit DENY rules.
  * Improved permission checks for authenticated uploads and resource creation using the complete folder path.
  * Fixed share updates that could incorrectly repoint access scopes.
* **Bug Fixes**
  * Added coverage to prevent regressions in nested-folder access control behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->