### PR TITLE
v1.5.2-stable GHSA-cw65-p35p-633w fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. For commit guidelines, please refer to [Standard Version](https://github.com/conventional-changelog/standard-version).
 
+## v1.5.2-stable
+
+ **Security**:
+ - [Moderate] Authenticated upload and pause endpoints checked access rules on scope-relative paths, bypassing per-folder DENY rules (GHSA-cw65-p35p-633w)
+ - [High] Public upload ACL check used scope-stripped path, bypassing per-folder DENY rules (GHSA-qv53-4557-m65h)
+
 ## v1.5.5
 
  **BugFixes**:

--- a/backend/http/resource.go
+++ b/backend/http/resource.go
@@ -471,13 +471,15 @@ func resourcePauseHandler(w http.ResponseWriter, r *http.Request, d *requestCont
 		logger.Debugf("source %s not found", source)
 		return http.StatusNotFound, fmt.Errorf("source %s not found", source)
 	}
-	if _, err := d.user.GetScopeForSourceName(source); err != nil {
+	userScope, err := d.user.GetScopeForSourceName(source)
+	if err != nil {
 		return http.StatusForbidden, err
 	}
-	if !store.Access.Permitted(idx.Path, path, d.user.Username) {
-		return http.StatusForbidden, fmt.Errorf("access denied to path %s", path)
+	fullIndexPath := utils.JoinPathAsUnix(userScope, path)
+	if !store.Access.Permitted(idx.Path, fullIndexPath, d.user.Username) {
+		return http.StatusForbidden, fmt.Errorf("access denied to path %s", fullIndexPath)
 	}
-	pauseCache.Set(pauseUploadCacheKey(source, path), "1")
+	pauseCache.Set(pauseUploadCacheKey(source, fullIndexPath), "1")
 	return http.StatusOK, nil
 }
 
@@ -572,8 +574,8 @@ func resourcePostHandler(w http.ResponseWriter, r *http.Request, d *requestConte
 	realPath, _, _ := idx.GetRealPath(fullIndexPath)
 
 	// Check access control for the target path
-	if !store.Access.Permitted(idx.Path, path, filePermUser.Username) {
-		return http.StatusForbidden, fmt.Errorf("access denied to path %s", path)
+	if !store.Access.Permitted(idx.Path, fullIndexPath, filePermUser.Username) {
+		return http.StatusForbidden, fmt.Errorf("access denied to path %s", fullIndexPath)
 	}
 
 	// Check for file/folder conflicts before creation

--- a/backend/http/resource_acl_test.go
+++ b/backend/http/resource_acl_test.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
+	"github.com/gtsteffaniak/filebrowser/backend/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/indexing"
+)
+
+func TestResourcePostACLUsesFullIndexPathKey(t *testing.T) {
+	setupTestEnv(t)
+
+	const (
+		sourcePath   = "/srv"
+		userScope    = "/home/alice"
+		deniedFolder = "/home/alice/projects/acme/private"
+		relPath      = "/projects/acme/private/poison.docx"
+	)
+	fullIndexPath := utils.JoinPathAsUnix(userScope, relPath)
+
+	alice := &users.User{
+		ID:       1,
+		Username: "alice",
+	}
+	if err := store.Users.Save(alice, true, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Access.DenyUser(sourcePath, deniedFolder, "alice"); err != nil {
+		t.Fatalf("DenyUser: %v", err)
+	}
+
+	if !store.Access.Permitted(sourcePath, relPath, "alice") {
+		t.Fatal("scope-stripped path does not match deny rule keyed at full index path (documents pre-fix ACL miss)")
+	}
+	if store.Access.Permitted(sourcePath, fullIndexPath, "alice") {
+		t.Fatalf("full index path %q should be denied for alice", fullIndexPath)
+	}
+}
+
+func TestResourcePostHandler_DeniesAuthenticatedUploadToDeniedPath(t *testing.T) {
+	setupTestEnv(t)
+
+	srvRoot := t.TempDir()
+	indexing.SetTestIndex("srv", srvRoot)
+	t.Cleanup(indexing.ClearTestIndices)
+
+	alice := &users.User{
+		ID:          1,
+		Username:    "alice",
+		Permissions: users.Permissions{Create: true},
+		Scopes: []users.SourceScope{
+			{Name: "/srv", Scope: "/home/alice"},
+		},
+	}
+	if err := store.Users.Save(alice, true, true); err != nil {
+		t.Fatal(err)
+	}
+
+	deniedFolder := "/home/alice/projects/acme/private"
+	if err := store.Access.DenyUser("/srv", deniedFolder, "alice"); err != nil {
+		t.Fatalf("DenyUser: %v", err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/resources?source=srv&path=/projects/acme/private/evil.txt",
+		strings.NewReader("payload"),
+	)
+	rec := httptest.NewRecorder()
+
+	status, err := resourcePostHandler(rec, req, &requestContext{user: alice})
+	if status != http.StatusForbidden {
+		t.Fatalf("expected 403 for denied upload path, got status=%d err=%v", status, err)
+	}
+}
+
+func TestResourcePauseHandler_DeniesAuthenticatedPauseOnDeniedPath(t *testing.T) {
+	setupTestEnv(t)
+
+	indexing.SetTestIndex("srv", t.TempDir())
+	t.Cleanup(indexing.ClearTestIndices)
+
+	alice := &users.User{
+		ID:          1,
+		Username:    "alice",
+		Permissions: users.Permissions{Create: true},
+		Scopes: []users.SourceScope{
+			{Name: "/srv", Scope: "/home/alice"},
+		},
+	}
+	if err := store.Users.Save(alice, true, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Access.DenyUser("/srv", "/home/alice/projects/acme/private", "alice"); err != nil {
+		t.Fatalf("DenyUser: %v", err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/resources/pause?source=srv&path=/projects/acme/private/evil.txt",
+		http.NoBody,
+	)
+	rec := httptest.NewRecorder()
+
+	status, err := resourcePauseHandler(rec, req, &requestContext{user: alice})
+	if status != http.StatusForbidden {
+		t.Fatalf("expected 403 for denied pause path, got status=%d err=%v", status, err)
+	}
+}


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path-based access control for authenticated uploads and upload pause requests.
  * Prevented access to restricted paths when using relative path references.
  * Strengthened public upload ACL enforcement.
  * Restricted requests now correctly return HTTP 403 responses.

* **Documentation**
  * Added changelog entries documenting the security fixes in version 1.5.2-stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->