### PR TITLE
fix GHSA-rqqq-wv83-rp74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. For commit guidelines, please refer to [Standard Version](https://github.com/conventional-changelog/standard-version).
 
+## v1.5.2-stable
+
+ **Security**:
+ - [Moderate] Absolute paths in API path/file parameters could bypass user scope and read files outside the source mount (GHSA-rqqq-wv83-rp74)
+
 ## v1.5.5
 
  **BugFixes**:

--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -143,7 +143,7 @@ func checkPermissionsImpl(opts utils.FileOptions, access *access.Storage, user *
 	}
 
 	// Combine scope + sanitized path
-	indexPath := utils.JoinPathAsUnix(userScope, safePath)
+	indexPath := utils.JoinScopedIndexPath(userScope, safePath)
 	// Layer 1: USER ACCESS CONTROL
 	// Quick check: Does THIS user have permission?
 	if !access.Permitted(idx.Path, indexPath, user.Username) {
@@ -266,7 +266,7 @@ func fileInfoFasterImpl(opts utils.FileOptions, access *access.Storage, user *us
 
 	// Build response
 	response.FileInfo = *info
-	response.RealPath = filepath.Join(idx.Path, indexPath)
+	response.RealPath = utils.JoinUnderSourceRoot(idx.Path, indexPath)
 	response.Source = opts.Source
 	if shareStore != nil && user.Permissions.Share && opts.ShowSharedAttr {
 		for i := range response.Files {

--- a/backend/common/utils/path.go
+++ b/backend/common/utils/path.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// JoinScopedIndexPath joins a user's index scope with a sanitized path segment.
+// Unlike filepath.Join, a leading slash on rel does not discard scope (avoids absolute-path scope bypass).
+func JoinScopedIndexPath(scope, rel string) string {
+	rel = strings.TrimPrefix(path.Clean(rel), "/")
+	scope = strings.TrimRight(scope, "/")
+	if rel == "" {
+		if scope == "" || scope == "/" {
+			return "/"
+		}
+		return scope
+	}
+	if scope == "" || scope == "/" {
+		return "/" + rel
+	}
+	return scope + "/" + rel
+}
+
+// JoinUnderSourceRoot maps an index path onto a source filesystem root without treating
+// indexPath as a host-absolute path (filepath.Join would discard sourceRoot when indexPath starts with "/").
+func JoinUnderSourceRoot(sourceRoot, indexPath string) string {
+	rel := strings.TrimPrefix(path.Clean(indexPath), "/")
+	if rel == "" {
+		return sourceRoot
+	}
+	return filepath.Join(sourceRoot, rel)
+}

--- a/backend/common/utils/path_test.go
+++ b/backend/common/utils/path_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestJoinScopedIndexPath_absoluteRelDoesNotDropScope(t *testing.T) {
+	const scope = "/home/alice"
+	got := JoinScopedIndexPath(scope, "/etc/passwd")
+	want := "/home/alice/etc/passwd"
+	if got != want {
+		t.Fatalf("JoinScopedIndexPath(%q, /etc/passwd) = %q, want %q", scope, got, want)
+	}
+}
+
+func TestJoinScopedIndexPath_traversalResolvedUnderScope(t *testing.T) {
+	const scope = "/home/alice"
+	got := JoinScopedIndexPath(scope, "/../../../etc/passwd")
+	want := "/home/alice/etc/passwd"
+	if got != want {
+		t.Fatalf("JoinScopedIndexPath(%q, /../../../etc/passwd) = %q, want %q", scope, got, want)
+	}
+}
+
+func TestJoinScopedIndexPath_rootScope(t *testing.T) {
+	got := JoinScopedIndexPath("/", "projects/acme/file.txt")
+	if got != "/projects/acme/file.txt" {
+		t.Fatalf("got %q want /projects/acme/file.txt", got)
+	}
+}
+
+func TestJoinUnderSourceRoot_absoluteIndexPathStaysUnderSource(t *testing.T) {
+	const sourceRoot = "/srv/mount"
+	got := JoinUnderSourceRoot(sourceRoot, "/etc/passwd")
+	want := filepath.Join(sourceRoot, "etc/passwd")
+	if got != want {
+		t.Fatalf("JoinUnderSourceRoot = %q, want %q", got, want)
+	}
+}
+
+func TestJoinUnderSourceRoot_relativeIndexPath(t *testing.T) {
+	const sourceRoot = "/srv/mount"
+	got := JoinUnderSourceRoot(sourceRoot, "/home/alice/projects/foo")
+	want := filepath.Join(sourceRoot, "home/alice/projects/foo")
+	if got != want {
+		t.Fatalf("JoinUnderSourceRoot = %q, want %q", got, want)
+	}
+}

--- a/backend/http/download.go
+++ b/backend/http/download.go
@@ -179,7 +179,7 @@ func rawFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, 
 				// Try to get document ID for error logging
 				idx := indexing.GetIndex(source)
 				if idx != nil {
-					tempPath := utils.JoinPathAsUnix(userscope, firstFilePath)
+					tempPath := utils.JoinScopedIndexPath(userscope, firstFilePath)
 					if realPath, _, realErr := idx.GetRealPath(tempPath); realErr == nil {
 						if docId, _ := getOnlyOfficeId(realPath); docId != "" {
 							if ctx := getOnlyOfficeLogContext(docId); ctx != nil {
@@ -193,7 +193,7 @@ func rawFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, 
 			return http.StatusForbidden, err
 		}
 		for i, filePath := range fileList {
-			fileList[i] = utils.JoinPathAsUnix(userscope, filePath)
+			fileList[i] = utils.JoinScopedIndexPath(userscope, filePath)
 		}
 	}
 	firstFilePath = fileList[0]

--- a/backend/http/public.go
+++ b/backend/http/public.go
@@ -95,7 +95,7 @@ func publicDownloadHandler(w http.ResponseWriter, r *http.Request, d *requestCon
 		}
 
 		// Join the share path with the requested path
-		filePath := utils.JoinPathAsUnix(d.share.Path, cleanFile)
+		filePath := utils.JoinScopedIndexPath(d.share.Path, cleanFile)
 		fileList = append(fileList, filePath)
 	}
 
@@ -259,7 +259,7 @@ func publicPutHandler(w http.ResponseWriter, r *http.Request, d *requestContext)
 		return http.StatusBadRequest, err
 	}
 
-	resolvedPath := utils.JoinPathAsUnix(d.share.Path, cleanPath)
+	resolvedPath := utils.JoinScopedIndexPath(d.share.Path, cleanPath)
 	err = files.WriteFile(sourceName, resolvedPath, r.Body)
 	// hide the error
 	if err != nil {
@@ -373,13 +373,13 @@ func publicPatchHandler(w http.ResponseWriter, r *http.Request, d *requestContex
 			return http.StatusBadRequest, fmt.Errorf("invalid from path: %w", err)
 		}
 		req.Items[i].FromSource = sourceName
-		req.Items[i].FromPath = utils.JoinPathAsUnix(d.share.Path, sanitizedPath)
+		req.Items[i].FromPath = utils.JoinScopedIndexPath(d.share.Path, sanitizedPath)
 		sanitizedPath, err = utils.SanitizeUserPath(req.Items[i].ToPath)
 		if err != nil {
 			return http.StatusBadRequest, fmt.Errorf("invalid to path: %w", err)
 		}
 		req.Items[i].ToSource = sourceName
-		req.Items[i].ToPath = utils.JoinPathAsUnix(d.share.Path, sanitizedPath)
+		req.Items[i].ToPath = utils.JoinScopedIndexPath(d.share.Path, sanitizedPath)
 	}
 	d.Data = req
 

--- a/backend/http/resource.go
+++ b/backend/http/resource.go
@@ -333,7 +333,7 @@ func resourceBulkDeleteHandler(w http.ResponseWriter, r *http.Request, d *reques
 				continue
 			}
 			withoutUserScope := strings.TrimPrefix(d.share.Path, userScope)
-			indexPath := utils.JoinPathAsUnix(withoutUserScope, sanitizedPath)
+			indexPath := utils.JoinScopedIndexPath(withoutUserScope, sanitizedPath)
 
 			fileInfo, err := files.FileInfoFaster(utils.FileOptions{
 				FollowSymlinks: true,
@@ -471,13 +471,15 @@ func resourcePauseHandler(w http.ResponseWriter, r *http.Request, d *requestCont
 		logger.Debugf("source %s not found", source)
 		return http.StatusNotFound, fmt.Errorf("source %s not found", source)
 	}
-	if _, err := d.user.GetScopeForSourceName(source); err != nil {
+	userscope, err := d.user.GetScopeForSourceName(source)
+	if err != nil {
 		return http.StatusForbidden, err
 	}
-	if !store.Access.Permitted(idx.Path, path, d.user.Username) {
-		return http.StatusForbidden, fmt.Errorf("access denied to path %s", path)
+	fullIndexPath := utils.JoinScopedIndexPath(userscope, path)
+	if !store.Access.Permitted(idx.Path, fullIndexPath, d.user.Username) {
+		return http.StatusForbidden, fmt.Errorf("access denied to path %s", fullIndexPath)
 	}
-	pauseCache.Set(pauseUploadCacheKey(source, path), "1")
+	pauseCache.Set(pauseUploadCacheKey(source, fullIndexPath), "1")
 	return http.StatusOK, nil
 }
 
@@ -566,7 +568,7 @@ func resourcePostHandler(w http.ResponseWriter, r *http.Request, d *requestConte
 	}
 	userscope = strings.TrimRight(userscope, "/")
 
-	fullIndexPath := utils.JoinPathAsUnix(userscope, path)
+	fullIndexPath := utils.JoinScopedIndexPath(userscope, path)
 
 	// get scoped path
 	realPath, _, _ := idx.GetRealPath(fullIndexPath)
@@ -765,7 +767,7 @@ func resourcePutHandler(w http.ResponseWriter, r *http.Request, d *requestContex
 	if err != nil {
 		return http.StatusForbidden, err
 	}
-	fullIndexPath := utils.JoinPathAsUnix(userScope, path)
+	fullIndexPath := utils.JoinScopedIndexPath(userScope, path)
 	// Check access control for the target path
 	idx := indexing.GetIndex(source)
 	if idx == nil {
@@ -930,8 +932,8 @@ func resourcePatchHandler(w http.ResponseWriter, r *http.Request, d *requestCont
 		}
 
 		// Build full index paths for access control
-		fullSrcIndexPath := utils.JoinPathAsUnix(userscopeSrc, item.FromPath)
-		fullDstIndexPath := utils.JoinPathAsUnix(userscopeDst, item.ToPath)
+		fullSrcIndexPath := utils.JoinScopedIndexPath(userscopeSrc, item.FromPath)
+		fullDstIndexPath := utils.JoinScopedIndexPath(userscopeDst, item.ToPath)
 		if fullDstIndexPath == "/" || fullSrcIndexPath == "/" {
 			item.Message = "source or destination is the root or unautharized directory"
 			response.Failed = append(response.Failed, item)
@@ -964,7 +966,7 @@ func resourcePatchHandler(w http.ResponseWriter, r *http.Request, d *requestCont
 
 		// Get real paths
 		// Combine user scope with item paths BEFORE calling GetRealPath to avoid double scope application
-		fullSrcPath := utils.JoinPathAsUnix(userscopeSrc, item.FromPath)
+		fullSrcPath := utils.JoinScopedIndexPath(userscopeSrc, item.FromPath)
 		realSrc, isSrcDir, err := srcIdx.GetRealPath(fullSrcPath)
 		if err != nil {
 			logger.Errorf("could not resolve source path: %v, item.FromPath: %v", err, item.FromPath)
@@ -981,7 +983,7 @@ func resourcePatchHandler(w http.ResponseWriter, r *http.Request, d *requestCont
 
 		// Check destination parent directory exists
 		dstParentPath := filepath.Dir(item.ToPath)
-		fullDstParentPath := utils.JoinPathAsUnix(userscopeDst, dstParentPath)
+		fullDstParentPath := utils.JoinScopedIndexPath(userscopeDst, dstParentPath)
 		parentDir, _, err := dstIdx.GetRealPath(fullDstParentPath)
 		if err != nil {
 			item.Message = "destination directory does not exist"

--- a/backend/http/share.go
+++ b/backend/http/share.go
@@ -389,7 +389,7 @@ func sharePostHandler(w http.ResponseWriter, r *http.Request, d *requestContext)
 		return http.StatusBadRequest, err
 	}
 
-	body.Path = utils.JoinPathAsUnix(userscope, cleanPath)
+	body.Path = utils.JoinScopedIndexPath(userscope, cleanPath)
 	body.Path = utils.AddTrailingSlashIfNotExists(body.Path)
 	// validate path exists as file or folder
 	_, _, err = idx.GetRealPath(body.Path)

--- a/backend/indexing/indexingFiles.go
+++ b/backend/indexing/indexingFiles.go
@@ -3,6 +3,7 @@ package indexing
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -442,7 +443,7 @@ type FileInfoRequest struct {
 // resolvePathContext resolves all path characteristics in a SINGLE stat call
 // This eliminates duplicate stat/lstat calls and redundant isHidden/isSymlink checks
 func (idx *Index) resolvePathContext(indexPath string, followSymlinks bool) (*PathContext, error) {
-	realPath := filepath.Join(idx.Path, indexPath)
+	realPath := utils.JoinUnderSourceRoot(idx.Path, indexPath)
 
 	// ONE filesystem stat call
 	fileInfo, err := os.Lstat(realPath)
@@ -598,7 +599,7 @@ func (idx *Index) indexDirectory(indexPath string, opts Options, scanner *Scanne
 	if !strings.HasSuffix(indexPath, "/") {
 		indexPath = indexPath + "/"
 	}
-	realPath := filepath.Join(idx.Path, indexPath)
+	realPath := utils.JoinUnderSourceRoot(idx.Path, indexPath)
 
 	// Open the directory
 	dir, err := os.Open(realPath)
@@ -636,7 +637,7 @@ func (idx *Index) indexDirectory(indexPath string, opts Options, scanner *Scanne
 // GetFsInfoCore is the consolidated implementation for both GetFsInfo and GetFsInfoViewableOnly
 func (idx *Index) GetFsInfoCore(indexPath string, opts Options) (*iteminfo.FileInfo, error) {
 	// Handle symlinks if not following them
-	realPath := filepath.Join(idx.Path, indexPath)
+	realPath := utils.JoinUnderSourceRoot(idx.Path, indexPath)
 	if opts.FollowSymlinks {
 		var err error
 		realPath, err = filepath.EvalSymlinks(realPath)
@@ -995,8 +996,12 @@ func (idx *Index) GetDirInfo(dirInfo *os.File, stat os.FileInfo, indexPath strin
 }
 
 func (idx *Index) GetRealPath(relativePath ...string) (string, bool, error) {
-	combined := append([]string{idx.Path}, relativePath...)
-	joinedPath := filepath.Join(combined...)
+	parts := make([]string, 0, len(relativePath)+1)
+	parts = append(parts, idx.Path)
+	for _, p := range relativePath {
+		parts = append(parts, strings.TrimPrefix(path.Clean(p), "/"))
+	}
+	joinedPath := filepath.Join(parts...)
 	isDir, _ := IsDirCache.Get(joinedPath + ":isdir")
 	cached, ok := RealPathCache.Get(joinedPath)
 	if ok && cached != "" {
@@ -1038,7 +1043,7 @@ func (idx *Index) RefreshDirectory(indexPath string, recursive bool) error {
 		indexPath = indexPath + "/"
 	}
 
-	realPath := filepath.Join(idx.Path, indexPath)
+	realPath := utils.JoinUnderSourceRoot(idx.Path, indexPath)
 
 	// Check if directory exists
 	dirInfo, err := os.Stat(realPath)

--- a/backend/indexing/unix.go
+++ b/backend/indexing/unix.go
@@ -4,10 +4,10 @@ package indexing
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"syscall"
 
+	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
 	"github.com/gtsteffaniak/go-logger/logger"
 )
 
@@ -66,7 +66,7 @@ func (idx *Index) handleFile(file os.FileInfo, indexPath string, realFilePath st
 
 	// Use provided realFilePath if available, otherwise construct it
 	if realFilePath == "" {
-		realFilePath = filepath.Join(idx.Path, indexPath)
+		realFilePath = utils.JoinUnderSourceRoot(idx.Path, indexPath)
 	}
 
 	sys := file.Sys()


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability that could allow absolute file paths to bypass scope restrictions.
  * Ensured downloads, uploads, file operations, sharing, and indexing remain within the permitted source directory.
  * Improved handling of absolute and traversal-style paths to prevent unauthorized file access.

* **Documentation**
  * Added a changelog entry describing the security fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->