### PR TITLE
fix GHSA-mgqf-5mf5-prfj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file. For commit 
 ## v1.5.2-stable
 
  **Security**:
+ - [High] Symlink following on read paths no longer escapes source or user/share scope (GHSA-mgqf-5mf5-prfj)
  - [Moderate] Stored XSS via unsanitized DOCX hyperlink in DocViewer (GHSA-9wm6-jcjh-3m8c) -- thanks @karen93shieh
  - [Moderate] Revoked JWTs could still authenticate on public-share and withOrWithoutUser routes until natural expiry, bypassing logout and Api-permission revocation on that surface (GHSA-4wmj-rq3c-m65v)
 
 ## v1.5.5
 
  **BugFixes**:
- - [High] Symlink following on read paths no longer escapes source or user/share scope (GHSA-mgqf-5mf5-prfj)
  - fix uncustomized (minimal) API tokens creation needed by webdav clients (#2503)
 
 ## v1.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. For commit 
 ## v1.5.5
 
  **BugFixes**:
+ - [High] Symlink following on read paths no longer escapes source or user/share scope (GHSA-mgqf-5mf5-prfj)
  - fix uncustomized (minimal) API tokens creation needed by webdav clients (#2503)
 
 ## v1.5.4

--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -173,7 +173,7 @@ func filterFilesByExt(files []iteminfo.ExtendedItemInfo, hideFileExt string) []i
 
 func GetDirItems(opts utils.FileOptions, access *access.Storage, user *users.User) (Items, error) {
 	items := Items{}
-	indexPath, _, topLevelErr := CheckPermissions(opts, access, user)
+	indexPath, userScope, topLevelErr := CheckPermissions(opts, access, user)
 	accessRulesErr := topLevelErr != nil && topLevelErr == errors.ErrAccessDenied && indexPath != ""
 	if topLevelErr != nil && !accessRulesErr {
 		return items, topLevelErr
@@ -183,14 +183,18 @@ func GetDirItems(opts utils.FileOptions, access *access.Storage, user *users.Use
 	if idx == nil {
 		return items, fmt.Errorf("could not get index: %v ", opts.Source)
 	}
-	info, err := idx.GetFileInfo(indexing.FileInfoRequest{
+	infoReq := indexing.FileInfoRequest{
 		IndexPath:         indexPath,
 		FollowSymlinks:    opts.FollowSymlinks,
 		ShowHidden:        opts.ShowHidden,
 		HideFileExt:       opts.HideFileExt,
 		Expand:            true,
 		SkipExtendedAttrs: true,
-	})
+	}
+	if opts.FollowSymlinks {
+		infoReq.BoundIndexPath = userScope
+	}
+	info, err := idx.GetFileInfo(infoReq)
 	if err != nil {
 		return items, err // Path excluded by index rules OR doesn't exist
 	}

--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -242,14 +242,18 @@ func fileInfoFasterImpl(opts utils.FileOptions, access *access.Storage, user *us
 	}
 	// Layer 2: INDEX RULES (global)
 	// Get file info using unified entry point (applies IsViewable/ShouldSkip)
-	info, err := idx.GetFileInfo(indexing.FileInfoRequest{
+	fileInfoReq := indexing.FileInfoRequest{
 		IndexPath:         indexPath,
 		FollowSymlinks:    opts.FollowSymlinks,
 		ShowHidden:        opts.ShowHidden,
 		HideFileExt:       opts.HideFileExt,
 		Expand:            opts.Expand,
 		SkipExtendedAttrs: opts.SkipExtendedAttrs,
-	})
+	}
+	if opts.FollowSymlinks {
+		fileInfoReq.BoundIndexPath = userScope
+	}
+	info, err := idx.GetFileInfo(fileInfoReq)
 	if err != nil {
 		return response, err // Path excluded by index rules OR doesn't exist
 	}
@@ -266,7 +270,15 @@ func fileInfoFasterImpl(opts utils.FileOptions, access *access.Storage, user *us
 
 	// Build response
 	response.FileInfo = *info
-	response.RealPath = filepath.Join(idx.Path, indexPath)
+	if opts.FollowSymlinks && info.Type != "directory" {
+		realPath, _, err := idx.GetRealPathScoped(userScope, indexPath)
+		if err != nil {
+			return response, err
+		}
+		response.RealPath = realPath
+	} else {
+		response.RealPath = filepath.Join(idx.Path, indexPath)
+	}
 	response.Source = opts.Source
 	if shareStore != nil && user.Permissions.Share && opts.ShowSharedAttr {
 		for i := range response.Files {

--- a/backend/adapters/fs/files/symlink_scope_test.go
+++ b/backend/adapters/fs/files/symlink_scope_test.go
@@ -1,0 +1,57 @@
+package files
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	liberrors "github.com/gtsteffaniak/filebrowser/backend/common/errors"
+	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
+	"github.com/gtsteffaniak/filebrowser/backend/database/access"
+	"github.com/gtsteffaniak/filebrowser/backend/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/indexing"
+)
+
+func setupSymlinkDirEscapeFixture(t *testing.T) (sourceRoot, userScope string) {
+	t.Helper()
+	root := t.TempDir()
+	sourceRoot = filepath.Join(root, "srv")
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	otherDir := filepath.Join(sourceRoot, "otheruser")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "leaked.txt"), []byte("leaked"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(otherDir, filepath.Join(userDir, "escape_dir")); err != nil {
+		t.Fatal(err)
+	}
+	return sourceRoot, "/user1"
+}
+
+func TestGetDirItems_RejectsDirectorySymlinkOutsideUserScope(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkDirEscapeFixture(t)
+	sourceName := "test_getdiritems_scope"
+	indexing.SetTestIndex(sourceName, sourceRoot)
+	t.Cleanup(indexing.ClearTestIndices)
+
+	origCheck := CheckPermissionsFunc
+	t.Cleanup(func() { CheckPermissionsFunc = origCheck })
+	CheckPermissionsFunc = func(opts utils.FileOptions, _ *access.Storage, _ *users.User) (string, string, error) {
+		return utils.JoinPathAsUnix(userScope, opts.Path), userScope, nil
+	}
+
+	_, err := GetDirItems(utils.FileOptions{
+		Source:         sourceName,
+		Path:           "/escape_dir",
+		FollowSymlinks: true,
+	}, nil, &users.User{})
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope, got %v", err)
+	}
+}

--- a/backend/common/errors/errors.go
+++ b/backend/common/errors/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrUnauthorized         = errors.New("user unauthorized")
 	ErrNotIndexed           = errors.New("directory or item excluded from indexing")
 	ErrNotViewable          = errors.New("directory or item is not viewable")
+	ErrPathEscapesScope     = errors.New("resolved path escapes scope")
 	ErrWrongLoginMethod     = errors.New("user attempted to login with wrong login method")
 	ErrDownloadNotAllowed   = errors.New("downloads are not allowed for this share")
 	ErrUploadNotAllowed     = errors.New("upload permission not allowed for this share")

--- a/backend/http/download.go
+++ b/backend/http/download.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -220,25 +219,30 @@ func rawFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, 
 		bound = userscope
 	}
 
-	realPath, isDir, err := idx.GetRealPathScoped(bound, firstFilePath)
-	if err != nil {
-		if errors.Is(err, liberrors.ErrPathEscapesScope) {
-			return http.StatusForbidden, err
-		}
-		// Send OnlyOffice error log if this was an OnlyOffice file
-		if isOnlyOffice {
-			if docId, _ := getOnlyOfficeId(realPath); docId != "" {
-				if ctx := getOnlyOfficeLogContext(docId); ctx != nil {
-					sendOnlyOfficeLogEvent(ctx, "ERROR", "download",
-						fmt.Sprintf("OnlyOffice download failed - could not resolve path: %s - %v", firstFilePath, err))
+	// ** Single file download with Content-Length **
+	if len(fileList) == 1 {
+		fd, fileInfo, openErr := idx.OpenScopedPath(bound, firstFilePath)
+		if openErr != nil {
+			if errors.Is(openErr, liberrors.ErrPathEscapesScope) {
+				return http.StatusForbidden, openErr
+			}
+			if isOnlyOffice {
+				if docId, _ := getOnlyOfficeId(filepath.Join(idx.Path, firstFilePath)); docId != "" {
+					if ctx := getOnlyOfficeLogContext(docId); ctx != nil {
+						sendOnlyOfficeLogEvent(ctx, "ERROR", "download",
+							fmt.Sprintf("OnlyOffice download failed - could not open file: %s - %v", firstFilePath, openErr))
+					}
 				}
 			}
+			return http.StatusInternalServerError, openErr
 		}
-		return http.StatusInternalServerError, err
-	}
+		defer fd.Close()
+		realPath := fd.Name()
 
-	// ** Single file download with Content-Length **
-	if len(fileList) == 1 && !isDir {
+		if fileInfo.IsDir() {
+			return BuildAndStreamArchive(w, r, d, source, fileList)
+		}
+
 		// Get document ID and log context for OnlyOffice downloads
 		if isOnlyOffice {
 			documentId, _ = getOnlyOfficeId(realPath)
@@ -247,39 +251,16 @@ func rawFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, 
 			}
 		}
 
-		// Verify access control before opening the file (direct rule check)
+		// Verify access control before serving the file (direct rule check)
 		if d.share == nil && store.Access != nil {
 			if !store.Access.Permitted(idx.Path, firstFilePath, d.user.Username) {
 				logger.Debugf("user %s denied access to path %s", d.user.Username, firstFilePath)
-				// Send OnlyOffice error log if this was an OnlyOffice download
 				if isOnlyOffice && logContext != nil {
 					sendOnlyOfficeLogEvent(logContext, "ERROR", "download",
 						fmt.Sprintf("OnlyOffice download failed - access denied by rule: %s", firstFilePath))
 				}
 				return http.StatusForbidden, fmt.Errorf("access denied to path %s", firstFilePath)
 			}
-		}
-
-		fd, err2 := os.Open(realPath)
-		if err2 != nil {
-			// Send OnlyOffice error log if this was an OnlyOffice download
-			if isOnlyOffice && logContext != nil {
-				sendOnlyOfficeLogEvent(logContext, "ERROR", "download",
-					fmt.Sprintf("OnlyOffice download failed - could not open file: %s - %v", firstFilePath, err2))
-			}
-			return http.StatusInternalServerError, err2
-		}
-		defer fd.Close()
-
-		// Get file size
-		fileInfo, err2 := fd.Stat()
-		if err2 != nil {
-			// Send OnlyOffice error log if this was an OnlyOffice download
-			if isOnlyOffice && logContext != nil {
-				sendOnlyOfficeLogEvent(logContext, "ERROR", "download",
-					fmt.Sprintf("OnlyOffice download failed - could not get file info: %s - %v", firstFilePath, err2))
-			}
-			return http.StatusInternalServerError, err2
 		}
 
 		// Send success log for OnlyOffice downloads
@@ -295,13 +276,9 @@ func rawFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, 
 		setContentDisposition(w, r, fileName)
 		w.Header().Set("Cache-Control", "private")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
-		// video scrubbing, etc.
-		// Note: http.ServeContent will respect our already-set Content-Disposition header
 		var reader io.ReadSeeker = fd
 		if d.share != nil && d.share.MaxBandwidth > 0 {
-			// convert KB/s to B/s
 			limit := rate.Limit(d.share.MaxBandwidth * 1024)
-			// burst size can be the same as limit
 			burst := d.share.MaxBandwidth * 1024
 			reader = newThrottledReadSeeker(fd, limit, burst, r.Context())
 		}

--- a/backend/http/download.go
+++ b/backend/http/download.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	liberrors "github.com/gtsteffaniak/filebrowser/backend/common/errors"
 	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
 	"github.com/gtsteffaniak/filebrowser/backend/indexing"
 	"github.com/gtsteffaniak/filebrowser/backend/indexing/iteminfo"
@@ -173,7 +175,7 @@ func rawFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, 
 	// modify all filepaths for user scope
 	if d.share == nil {
 		userscope, err = d.user.GetScopeForSourceName(source)
-		if err != nil {
+		if err != nil || userscope == "" {
 			// Send OnlyOffice error log if this was an OnlyOffice file
 			if isOnlyOffice {
 				// Try to get document ID for error logging
@@ -190,7 +192,7 @@ func rawFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, 
 					}
 				}
 			}
-			return http.StatusForbidden, err
+			return http.StatusForbidden, fmt.Errorf("user has no access to source: %s", source)
 		}
 		for i, filePath := range fileList {
 			fileList[i] = utils.JoinPathAsUnix(userscope, filePath)
@@ -207,8 +209,22 @@ func rawFilesHandler(w http.ResponseWriter, r *http.Request, d *requestContext, 
 		}
 		return http.StatusInternalServerError, fmt.Errorf("source %s is not available", source)
 	}
-	realPath, isDir, err := idx.GetRealPath(firstFilePath)
+
+	var bound string
+	if d.share != nil {
+		if d.share.Path == "" {
+			return http.StatusForbidden, fmt.Errorf("share has no path scope")
+		}
+		bound = d.share.Path
+	} else {
+		bound = userscope
+	}
+
+	realPath, isDir, err := idx.GetRealPathScoped(bound, firstFilePath)
 	if err != nil {
+		if errors.Is(err, liberrors.ErrPathEscapesScope) {
+			return http.StatusForbidden, err
+		}
 		// Send OnlyOffice error log if this was an OnlyOffice file
 		if isOnlyOffice {
 			if docId, _ := getOnlyOfficeId(realPath); docId != "" {

--- a/backend/indexing/indexingFiles.go
+++ b/backend/indexing/indexingFiles.go
@@ -1,6 +1,7 @@
 package indexing
 
 import (
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1089,6 +1090,40 @@ func (idx *Index) getRealPathInternal(boundIndexPath string, enforceScope bool, 
 	RealPathCache.Set(cacheKey, realPath)
 	IsDirCache.Set(cacheKey+":isdir", isDir)
 	return realPath, isDir, nil
+}
+
+func scopedIndexRel(boundIndexPath, indexPath string) string {
+	bound := boundIndexPath
+	if bound == "" {
+		bound = "/"
+	}
+	rel := indexPath
+	if bound != "/" {
+		rel = strings.TrimPrefix(indexPath, bound)
+	}
+	rel = strings.TrimPrefix(rel, "/")
+	return filepath.FromSlash(rel)
+}
+
+// OpenScopedPath opens indexPath relative to boundIndexPath using traversal-resistant APIs.
+func (idx *Index) OpenScopedPath(boundIndexPath, indexPath string) (*os.File, os.FileInfo, error) {
+	scopeRoot, err := idx.filesystemBound(boundIndexPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	file, err := iteminfo.OpenContained(scopeRoot, scopedIndexRel(boundIndexPath, indexPath))
+	if err != nil {
+		if _, _, scopeErr := idx.GetRealPathScoped(boundIndexPath, indexPath); stderrors.Is(scopeErr, errors.ErrPathEscapesScope) {
+			return nil, nil, scopeErr
+		}
+		return nil, nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, nil, err
+	}
+	return file, info, nil
 }
 
 func (idx *Index) RefreshFileInfo(opts utils.FileOptions) error {

--- a/backend/indexing/indexingFiles.go
+++ b/backend/indexing/indexingFiles.go
@@ -432,6 +432,7 @@ type PathContext struct {
 type FileInfoRequest struct {
 	IndexPath         string
 	FollowSymlinks    bool
+	BoundIndexPath    string // index prefix for symlink containment (e.g. user scope)
 	ShowHidden        bool
 	HideFileExt       string // Hide files based on their extension
 	Expand            bool   // get child items for directories
@@ -439,9 +440,63 @@ type FileInfoRequest struct {
 	SkipExtendedAttrs bool   // whether to skip extended attributes
 }
 
+// filesystemBound resolves the filesystem path for an index prefix under this source.
+func (idx *Index) filesystemBound(boundIndexPath string) (string, error) {
+	bound := boundIndexPath
+	if bound == "" {
+		bound = "/"
+	}
+	fsPath := idx.Path
+	if bound != "/" {
+		fsPath = filepath.Join(idx.Path, strings.TrimPrefix(bound, "/"))
+	}
+	abs, err := filepath.Abs(fsPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(abs)
+}
+
+// ensureResolvedContained rejects resolved filesystem paths outside the source or scope prefix.
+func (idx *Index) ensureResolvedContained(realPath, boundIndexPath string) error {
+	sourceRoot, err := idx.filesystemBound("/")
+	if err != nil {
+		return err
+	}
+	if err := iteminfo.PathWithinRoot(sourceRoot, realPath); err != nil {
+		return errors.ErrPathEscapesScope
+	}
+	bound := boundIndexPath
+	if bound == "" {
+		bound = "/"
+	}
+	if bound != "/" {
+		scopeRoot, err := idx.filesystemBound(bound)
+		if err != nil {
+			return err
+		}
+		if err := iteminfo.PathWithinRoot(scopeRoot, realPath); err != nil {
+			return errors.ErrPathEscapesScope
+		}
+	}
+	return nil
+}
+
+// resolveSymlinksContained resolves symlinks and ensures the target stays within bounds.
+func (idx *Index) resolveSymlinksContained(fsPath, boundIndexPath string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(fsPath)
+	if err != nil {
+		return "", err
+	}
+	if err := idx.ensureResolvedContained(resolved, boundIndexPath); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
 // resolvePathContext resolves all path characteristics in a SINGLE stat call
 // This eliminates duplicate stat/lstat calls and redundant isHidden/isSymlink checks
-func (idx *Index) resolvePathContext(indexPath string, followSymlinks bool) (*PathContext, error) {
+func (idx *Index) resolvePathContext(indexPath string, followSymlinks bool, boundIndexPath string) (*PathContext, error) {
 	realPath := filepath.Join(idx.Path, indexPath)
 
 	// ONE filesystem stat call
@@ -454,7 +509,7 @@ func (idx *Index) resolvePathContext(indexPath string, followSymlinks bool) (*Pa
 
 	// Resolve symlink if requested
 	if isSymlink && followSymlinks {
-		realPath, err = filepath.EvalSymlinks(realPath)
+		realPath, err = idx.resolveSymlinksContained(realPath, boundIndexPath)
 		if err != nil {
 			return nil, err
 		}
@@ -510,7 +565,7 @@ func (idx *Index) evaluateIndexRules(ctx *PathContext, isRoutineScan bool) (isVi
 // User permission checking happens in the API layer (FileInfoFaster)
 func (idx *Index) GetFileInfo(req FileInfoRequest) (*iteminfo.FileInfo, error) {
 	// 1. Resolve path context (single stat call)
-	ctx, err := idx.resolvePathContext(req.IndexPath, req.FollowSymlinks)
+	ctx, err := idx.resolvePathContext(req.IndexPath, req.FollowSymlinks, req.BoundIndexPath)
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +694,7 @@ func (idx *Index) GetFsInfoCore(indexPath string, opts Options) (*iteminfo.FileI
 	realPath := filepath.Join(idx.Path, indexPath)
 	if opts.FollowSymlinks {
 		var err error
-		realPath, err = filepath.EvalSymlinks(realPath)
+		realPath, err = idx.resolveSymlinksContained(realPath, "/")
 		if err != nil {
 			return nil, err
 		}
@@ -995,10 +1050,24 @@ func (idx *Index) GetDirInfo(dirInfo *os.File, stat os.FileInfo, indexPath strin
 }
 
 func (idx *Index) GetRealPath(relativePath ...string) (string, bool, error) {
+	return idx.getRealPathInternal("/", false, relativePath...)
+}
+
+// GetRealPathScoped resolves an index path and rejects symlink targets outside the source and bound prefix.
+func (idx *Index) GetRealPathScoped(boundIndexPath string, relativePath ...string) (string, bool, error) {
+	return idx.getRealPathInternal(boundIndexPath, true, relativePath...)
+}
+
+func (idx *Index) getRealPathInternal(boundIndexPath string, enforceScope bool, relativePath ...string) (string, bool, error) {
 	combined := append([]string{idx.Path}, relativePath...)
 	joinedPath := filepath.Join(combined...)
-	isDir, _ := IsDirCache.Get(joinedPath + ":isdir")
-	cached, ok := RealPathCache.Get(joinedPath)
+	bound := boundIndexPath
+	if enforceScope && bound == "" {
+		bound = "/"
+	}
+	cacheKey := fmt.Sprintf("realpath|scoped=%t|bound=%q|path=%q", enforceScope, bound, joinedPath)
+	isDir, _ := IsDirCache.Get(cacheKey + ":isdir")
+	cached, ok := RealPathCache.Get(cacheKey)
 	if ok && cached != "" {
 		return cached, isDir, nil
 	}
@@ -1007,11 +1076,19 @@ func (idx *Index) GetRealPath(relativePath ...string) (string, bool, error) {
 		return absolutePath, false, fmt.Errorf("could not get real path: %v, %s", joinedPath, err)
 	}
 	realPath, isDir, err := iteminfo.ResolveSymlinks(absolutePath)
-	if err == nil {
-		RealPathCache.Set(joinedPath, realPath)
-		IsDirCache.Set(joinedPath+":isdir", isDir)
+	if err != nil {
+		return realPath, isDir, err
 	}
-	return realPath, isDir, err
+	if enforceScope {
+		if err := idx.ensureResolvedContained(realPath, boundIndexPath); err != nil {
+			return "", false, err
+		}
+	} else if err := idx.ensureResolvedContained(realPath, "/"); err != nil {
+		return "", false, err
+	}
+	RealPathCache.Set(cacheKey, realPath)
+	IsDirCache.Set(cacheKey+":isdir", isDir)
+	return realPath, isDir, nil
 }
 
 func (idx *Index) RefreshFileInfo(opts utils.FileOptions) error {

--- a/backend/indexing/iteminfo/utils.go
+++ b/backend/indexing/iteminfo/utils.go
@@ -105,6 +105,35 @@ func (info *FileInfo) SortItems() {
 	})
 }
 
+// PathWithinRoot reports whether path is equal to or under root after resolving symlinks.
+func PathWithinRoot(root, path string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("invalid root path: %w", err)
+	}
+	rootReal, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return fmt.Errorf("could not resolve root path: %w", err)
+	}
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+	pathReal, err := filepath.EvalSymlinks(pathAbs)
+	if err != nil {
+		return fmt.Errorf("could not resolve path: %w", err)
+	}
+	rel, err := filepath.Rel(rootReal, pathReal)
+	if err != nil {
+		return fmt.Errorf("path outside root: %w", err)
+	}
+	sep := string(filepath.Separator)
+	if rel == ".." || strings.HasPrefix(rel, ".."+sep) {
+		return fmt.Errorf("path escapes root")
+	}
+	return nil
+}
+
 // ResolveSymlinks resolves symlinks in the given path and returns
 // Uses Go's filepath.EvalSymlinks which properly detects circular symlinks.
 func ResolveSymlinks(path string) (string, bool, error) {

--- a/backend/indexing/iteminfo/utils.go
+++ b/backend/indexing/iteminfo/utils.go
@@ -106,6 +106,7 @@ func (info *FileInfo) SortItems() {
 }
 
 // PathWithinRoot reports whether path is equal to or under root after resolving symlinks.
+// It is intended for validation only; use OpenContained for atomic file opens within a root.
 func PathWithinRoot(root, path string) error {
 	rootAbs, err := filepath.Abs(root)
 	if err != nil {
@@ -132,6 +133,21 @@ func PathWithinRoot(root, path string) error {
 		return fmt.Errorf("path escapes root")
 	}
 	return nil
+}
+
+// OpenContained opens relPath relative to rootDir without following symlinks that escape rootDir.
+// Prefer this over PathWithinRoot followed by os.Open to avoid TOCTOU races.
+func OpenContained(rootDir, relPath string) (*os.File, error) {
+	rel := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(relPath, "/")))
+	if rel == "." || rel == "" || strings.HasPrefix(rel, "..") {
+		return nil, fmt.Errorf("path escapes root")
+	}
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	return root.Open(rel)
 }
 
 // ResolveSymlinks resolves symlinks in the given path and returns

--- a/backend/indexing/iteminfo/utils_contained_test.go
+++ b/backend/indexing/iteminfo/utils_contained_test.go
@@ -1,0 +1,41 @@
+package iteminfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenContained_RejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	scopeDir := filepath.Join(root, "scope")
+	if err := os.MkdirAll(scopeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(root, "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(scopeDir, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := OpenContained(scopeDir, "escape")
+	if err == nil {
+		t.Fatal("expected symlink escape to be rejected")
+	}
+}
+
+func TestOpenContained_OpensInScopeFile(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "allowed.txt")
+	if err := os.WriteFile(inside, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := OpenContained(root, "allowed.txt")
+	if err != nil {
+		t.Fatalf("expected in-scope open to succeed: %v", err)
+	}
+	file.Close()
+}

--- a/backend/indexing/symlink_containment_test.go
+++ b/backend/indexing/symlink_containment_test.go
@@ -173,3 +173,54 @@ func TestGetFileInfo_RejectsSymlinkEscapeWithBound(t *testing.T) {
 		t.Fatalf("expected ErrPathEscapesScope from GetFileInfo, got %v", err)
 	}
 }
+
+func TestGetFileInfo_RejectsDirectorySymlinkOutsideUserScope(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	otherDir := filepath.Join(sourceRoot, "otheruser")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "leaked.txt"), []byte("leaked"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.Symlink(otherDir, filepath.Join(userDir, "escape_dir")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := idx.GetFileInfo(FileInfoRequest{
+		IndexPath:      "/user1/escape_dir/",
+		FollowSymlinks: true,
+		BoundIndexPath: userScope,
+		Expand:         true,
+	})
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope for directory symlink outside scope, got %v", err)
+	}
+}
+
+func TestOpenScopedPath_RejectsEscapeOutsideUserScope(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	_, _, err := idx.OpenScopedPath(userScope, "/user1/secret_link")
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope from OpenScopedPath, got %v", err)
+	}
+}
+
+func TestOpenScopedPath_OpensInScopeFile(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	file, info, err := idx.OpenScopedPath(userScope, "/user1/allowed.txt")
+	if err != nil {
+		t.Fatalf("expected in-scope open to succeed: %v", err)
+	}
+	defer file.Close()
+	if info.IsDir() {
+		t.Fatal("expected file, got directory")
+	}
+}

--- a/backend/indexing/symlink_containment_test.go
+++ b/backend/indexing/symlink_containment_test.go
@@ -1,0 +1,175 @@
+package indexing
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	liberrors "github.com/gtsteffaniak/filebrowser/backend/common/errors"
+	"github.com/gtsteffaniak/filebrowser/backend/common/settings"
+	"github.com/gtsteffaniak/filebrowser/backend/indexing/iteminfo"
+)
+
+func setupSymlinkEscapeFixture(t *testing.T) (sourceRoot, userScope string) {
+	t.Helper()
+	root := t.TempDir()
+	sourceRoot = filepath.Join(root, "srv")
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outsideSecret := filepath.Join(root, "secret-outside.txt")
+	if err := os.WriteFile(outsideSecret, []byte("ROOT_DB_PASSWORD=supersecret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideSecret, filepath.Join(userDir, "secret_link")); err != nil {
+		t.Fatal(err)
+	}
+	sibling := filepath.Join(root, "outside-sibling.txt")
+	if err := os.WriteFile(sibling, []byte("outside sibling"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(sibling, filepath.Join(userDir, "sibling_link")); err != nil {
+		t.Fatal(err)
+	}
+	inside := filepath.Join(userDir, "allowed.txt")
+	if err := os.WriteFile(inside, []byte("allowed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return sourceRoot, "/user1"
+}
+
+func symlinkTestIndex(sourceRoot string) *Index {
+	return &Index{Source: settings.Source{Path: sourceRoot}}
+}
+
+func TestPathWithinRoot(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "inner", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(inside), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(inside, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(filepath.Dir(root), "outside.txt")
+	if err := os.WriteFile(outside, []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := iteminfo.PathWithinRoot(root, inside); err != nil {
+		t.Fatalf("expected inside path to be allowed: %v", err)
+	}
+	if err := iteminfo.PathWithinRoot(root, outside); err == nil {
+		t.Fatal("expected outside path to be rejected")
+	}
+}
+
+func TestGetRealPath_RejectsEscapeOutsideSource(t *testing.T) {
+	sourceRoot, _ := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	_, _, err := idx.GetRealPath("/user1/secret_link")
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope, got %v", err)
+	}
+	_, _, err = idx.GetRealPath("/user1/sibling_link")
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope for sibling link, got %v", err)
+	}
+}
+
+func TestGetRealPathScoped_RejectsEscapeOutsideUserScope(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	insideSource := filepath.Join(sourceRoot, "secret-in-source.txt")
+	if err := os.WriteFile(insideSource, []byte("in source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.Symlink(insideSource, filepath.Join(userDir, "in_source_link")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := idx.GetRealPathScoped(userScope, "/user1/in_source_link")
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope for in-source escape, got %v", err)
+	}
+}
+
+func TestGetRealPathScoped_AllowsInScopeTarget(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.Symlink("allowed.txt", filepath.Join(userDir, "good_link")); err != nil {
+		t.Fatal(err)
+	}
+
+	realPath, _, err := idx.GetRealPathScoped(userScope, "/user1/good_link")
+	if err != nil {
+		t.Fatalf("expected in-scope symlink to resolve: %v", err)
+	}
+	want := filepath.Join(userDir, "allowed.txt")
+	realPath, err = filepath.EvalSymlinks(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err = filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if realPath != want {
+		t.Fatalf("got real path %q, want %q", realPath, want)
+	}
+}
+
+func TestGetRealPathScoped_CacheKeyDoesNotCollideWithUnscoped(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	insideSource := filepath.Join(sourceRoot, "secret-in-source.txt")
+	if err := os.WriteFile(insideSource, []byte("in source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	userDir := filepath.Join(sourceRoot, "user1")
+	if err := os.WriteFile(filepath.Join(userDir, "foo"), []byte("legitimate"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyKey := filepath.Join(sourceRoot, "user1", "foo") + ":bound:" + "/user1"
+	RealPathCache.Set(legacyKey, insideSource)
+	IsDirCache.Set(legacyKey+":isdir", false)
+
+	realPath, _, err := idx.GetRealPathScoped(userScope, "/user1/foo")
+	if err != nil {
+		t.Fatalf("scoped in-scope file should resolve: %v", err)
+	}
+	want := filepath.Join(userDir, "foo")
+	want, err = filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realPath, err = filepath.EvalSymlinks(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if realPath != want {
+		t.Fatalf("scoped lookup returned %q, want in-scope file %q", realPath, want)
+	}
+}
+
+func TestGetFileInfo_RejectsSymlinkEscapeWithBound(t *testing.T) {
+	sourceRoot, userScope := setupSymlinkEscapeFixture(t)
+	idx := symlinkTestIndex(sourceRoot)
+
+	_, err := idx.GetFileInfo(FileInfoRequest{
+		IndexPath:      "/user1/secret_link",
+		FollowSymlinks: true,
+		BoundIndexPath: userScope,
+	})
+	if !errors.Is(err, liberrors.ErrPathEscapesScope) {
+		t.Fatalf("expected ErrPathEscapesScope from GetFileInfo, got %v", err)
+	}
+}


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a high-severity security issue where symlinks could escape permitted source, user, or shared-folder boundaries.
  * Out-of-scope file access is now rejected with a forbidden response.
  * Invalid or missing access scopes are handled safely.

* **Tests**
  * Added coverage for valid symlinks, blocked escapes, scoped access, and path-resolution edge cases.

* **Documentation**
  * Documented the security fix in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->