### PR TITLE
finalize changelog for v1.5.2-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file. For commit 
 ## v1.5.2-stable
 
  **Security**:
- - [High] Share create/update could set delete/modify/create flags beyond the owner's permissions; POST /api/share with hash could update another user's share (GHSA-x79q-5hqm-x839)
- - [Moderate] Authenticated upload and pause endpoints checked access rules on scope-relative paths, bypassing per-folder DENY rules (GHSA-cw65-p35p-633w)
- - [Moderate] Logout did not invalidate session JWTs with equivalent Base64URL spellings (GHSA-8m35-wcjh-95q7)
- - [Moderate] PATCH /api/share could re-point a share outside the owner's scope (GHSA-wfjp-qhvc-69wp) @maximeborges
- - [High] Public upload ACL check used scope-stripped path, bypassing per-folder DENY rules (GHSA-qv53-4557-m65h) @hypnguyen1209
- - [Moderate] Absolute paths in API path/file parameters could bypass user scope and read files outside the source mount (GHSA-rqqq-wv83-rp74)
- - [High] Symlink following on read paths no longer escapes source or user/share scope (GHSA-mgqf-5mf5-prfj)
- - [Moderate] Stored XSS via unsanitized DOCX hyperlink in DocViewer (GHSA-9wm6-jcjh-3m8c) -- thanks @karen93shieh
- - [Moderate] Revoked JWTs could still authenticate on public-share and withOrWithoutUser routes until natural expiry, bypassing logout and Api-permission revocation on that surface (GHSA-4wmj-rq3c-m65v)
+ - [High] Symlink following on read paths no longer escapes source or user/share scope (GHSA-mgqf-5mf5-prfj) -- thanks @je-lv @KasperBuilds
+ - [High] Share create/update could set delete/modify/create flags beyond the owner's permissions; POST /api/share with hash could update another user's share (GHSA-x79q-5hqm-x839) -- thanks @pant0m
+ - [High] PATCH /api/share could re-point a share outside the owner's scope (GHSA-wfjp-qhvc-69wp) -- thanks @maximeborges
+ - [High] Public upload ACL check used scope-stripped path, bypassing per-folder DENY rules (GHSA-qv53-4557-m65h) -- thanks @hypnguyen1209
+ - [Moderate] Absolute paths in API path/file parameters could bypass user scope and read files outside the source mount (GHSA-rqqq-wv83-rp74) -- thanks @Wei-Leo
+ - [Moderate] Authenticated upload and pause endpoints checked access rules on scope-relative paths, bypassing per-folder DENY rules (GHSA-cw65-p35p-633w) -- thanks @5ud0er
+ - [Moderate] Logout did not invalidate session JWTs with equivalent Base64URL spellings (GHSA-8m35-wcjh-95q7) -- thanks @corbanvilla @soh3e @dderpym (This vulnerability was discovered as part of a U.C. Berkeley security research project by: Corban Villa, Sohee Kim, and Austin Chu)
+ - [Moderate] Stored XSS via unsanitized DOCX hyperlink in DocViewer (GHSA-9wm6-jcjh-3m8c) -- thanks @karen93shieh @je-lv @EclipsSec
+ - [Moderate] Revoked JWTs could still authenticate on public-share and withOrWithoutUser routes until natural expiry, bypassing logout and Api-permission revocation on that surface (GHSA-4wmj-rq3c-m65v) -- thanks @hypnguyen1209
 
 ## v1.5.5
 

--- a/backend/http/middleware_test.go
+++ b/backend/http/middleware_test.go
@@ -46,6 +46,18 @@ func setupTestEnv(t *testing.T) {
 	mockFileInfoFaster(t) // Mock FileInfoFasterFunc for this test
 }
 
+func saveTestUser(t *testing.T, user *users.User) *users.User {
+	t.Helper()
+	if err := store.Users.Save(user, false, false); err != nil {
+		t.Fatalf("Save(%s): %v", user.Username, err)
+	}
+	got, err := store.Users.Get(user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
 func mockFileInfoFaster(t *testing.T) {
 	// Backup the original function
 	originalFileInfoFaster := FileInfoFasterFunc
@@ -80,10 +92,10 @@ func TestWithAdminHelper(t *testing.T) {
 		Permissions: users.Permissions{Admin: false}, // Non-admin user
 	}
 	// Save the users to the mock database
-	if err := store.Users.Save(adminUser, true, true); err != nil {
+	if err := store.Users.Save(adminUser, false, false); err != nil {
 		t.Fatal("failed to save admin user:", err)
 	}
-	if err := store.Users.Save(nonAdminUser, true, true); err != nil {
+	if err := store.Users.Save(nonAdminUser, false, false); err != nil {
 		t.Fatal("failed to save non-admin user:", err)
 	}
 	// Test cases for different scenarios
@@ -154,7 +166,7 @@ func TestPublicShare_RejectsRevokedJWT(t *testing.T) {
 			{Name: "srv", Scope: "/"},
 		},
 	}
-	if err := store.Users.Save(victim, true, true); err != nil {
+	if err := store.Users.Save(victim, false, false); err != nil {
 		t.Fatal("failed to create victim user:", err)
 	}
 
@@ -274,7 +286,7 @@ func issueExtractUserTestToken(t *testing.T, duration time.Duration) (*users.Use
 		Username:    "victim",
 		Permissions: users.Permissions{Api: true},
 	}
-	if err := store.Users.Save(user, true, true); err != nil {
+	if err := store.Users.Save(user, false, false); err != nil {
 		t.Fatal("failed to create user:", err)
 	}
 	got, err := store.Users.Get(user.ID)
@@ -282,14 +294,14 @@ func issueExtractUserTestToken(t *testing.T, duration time.Duration) (*users.Use
 		t.Fatal("failed to load user:", err)
 	}
 	got.Permissions = users.Permissions{Api: true}
-	if err := store.Users.Save(got, false, false); err != nil {
+	if err = store.Users.Save(got, false, false); err != nil {
 		t.Fatal("failed to set user permissions:", err)
 	}
 
 	originalAuthKey := settings.Config.Auth.Key
 	settings.Config.Auth.Key = "key"
 	t.Cleanup(func() { settings.Config.Auth.Key = originalAuthKey })
-	if err := store.Settings.Save(&settings.Settings{Auth: settings.Auth{Key: "key"}}); err != nil {
+	if err = store.Settings.Save(&settings.Settings{Auth: settings.Auth{Key: "key"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -314,7 +326,7 @@ func TestPublicShareHandlerAuthentication(t *testing.T) {
 			{Name: "srv", Scope: "/"}, // Root scope on srv source
 		},
 	}
-	if err := store.Users.Save(dummyUser, true, true); err != nil {
+	if err := store.Users.Save(dummyUser, false, false); err != nil {
 		t.Fatal("failed to save dummy user:", err)
 	}
 

--- a/backend/http/middleware_test.go
+++ b/backend/http/middleware_test.go
@@ -46,18 +46,6 @@ func setupTestEnv(t *testing.T) {
 	mockFileInfoFaster(t) // Mock FileInfoFasterFunc for this test
 }
 
-func saveTestUser(t *testing.T, user *users.User) *users.User {
-	t.Helper()
-	if err := store.Users.Save(user, false, false); err != nil {
-		t.Fatalf("Save(%s): %v", user.Username, err)
-	}
-	got, err := store.Users.Get(user.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return got
-}
-
 func mockFileInfoFaster(t *testing.T) {
 	// Backup the original function
 	originalFileInfoFaster := FileInfoFasterFunc

--- a/backend/http/resource_acl_test.go
+++ b/backend/http/resource_acl_test.go
@@ -6,10 +6,25 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gtsteffaniak/filebrowser/backend/common/settings"
 	"github.com/gtsteffaniak/filebrowser/backend/common/utils"
 	"github.com/gtsteffaniak/filebrowser/backend/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/indexing"
 )
+
+func setupResourceACLTestSource(t *testing.T) string {
+	t.Helper()
+	srvRoot := t.TempDir()
+	settings.Config.Server.SourceMap = map[string]*settings.Source{
+		srvRoot: {Path: srvRoot, Name: "srv"},
+	}
+	settings.Config.Server.NameToSource = map[string]*settings.Source{
+		"srv": {Path: srvRoot, Name: "srv"},
+	}
+	indexing.SetTestIndex("srv", srvRoot)
+	t.Cleanup(indexing.ClearTestIndices)
+	return srvRoot
+}
 
 func TestResourcePostACLUsesFullIndexPathKey(t *testing.T) {
 	setupTestEnv(t)
@@ -26,7 +41,7 @@ func TestResourcePostACLUsesFullIndexPathKey(t *testing.T) {
 		ID:       1,
 		Username: "alice",
 	}
-	if err := store.Users.Save(alice, true, true); err != nil {
+	if err := store.Users.Save(alice, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -44,25 +59,22 @@ func TestResourcePostACLUsesFullIndexPathKey(t *testing.T) {
 
 func TestResourcePostHandler_DeniesAuthenticatedUploadToDeniedPath(t *testing.T) {
 	setupTestEnv(t)
-
-	srvRoot := t.TempDir()
-	indexing.SetTestIndex("srv", srvRoot)
-	t.Cleanup(indexing.ClearTestIndices)
+	sourcePath := setupResourceACLTestSource(t)
 
 	alice := &users.User{
 		ID:          1,
 		Username:    "alice",
 		Permissions: users.Permissions{Create: true},
 		Scopes: []users.SourceScope{
-			{Name: "/srv", Scope: "/home/alice"},
+			{Name: sourcePath, Scope: "/home/alice"},
 		},
 	}
-	if err := store.Users.Save(alice, true, true); err != nil {
+	if err := store.Users.Save(alice, false, false); err != nil {
 		t.Fatal(err)
 	}
 
 	deniedFolder := "/home/alice/projects/acme/private"
-	if err := store.Access.DenyUser("/srv", deniedFolder, "alice"); err != nil {
+	if err := store.Access.DenyUser(sourcePath, deniedFolder, "alice"); err != nil {
 		t.Fatalf("DenyUser: %v", err)
 	}
 
@@ -81,23 +93,21 @@ func TestResourcePostHandler_DeniesAuthenticatedUploadToDeniedPath(t *testing.T)
 
 func TestResourcePauseHandler_DeniesAuthenticatedPauseOnDeniedPath(t *testing.T) {
 	setupTestEnv(t)
-
-	indexing.SetTestIndex("srv", t.TempDir())
-	t.Cleanup(indexing.ClearTestIndices)
+	sourcePath := setupResourceACLTestSource(t)
 
 	alice := &users.User{
 		ID:          1,
 		Username:    "alice",
 		Permissions: users.Permissions{Create: true},
 		Scopes: []users.SourceScope{
-			{Name: "/srv", Scope: "/home/alice"},
+			{Name: sourcePath, Scope: "/home/alice"},
 		},
 	}
-	if err := store.Users.Save(alice, true, true); err != nil {
+	if err := store.Users.Save(alice, false, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := store.Access.DenyUser("/srv", "/home/alice/projects/acme/private", "alice"); err != nil {
+	if err := store.Access.DenyUser(sourcePath, "/home/alice/projects/acme/private", "alice"); err != nil {
 		t.Fatalf("DenyUser: %v", err)
 	}
 

--- a/backend/http/share_auth_test.go
+++ b/backend/http/share_auth_test.go
@@ -44,7 +44,7 @@ func setupShareAuthUsers(t *testing.T) (owner, attacker, admin *users.User) {
 	}
 
 	for _, u := range []*users.User{owner, attacker, noDelete, admin} {
-		if err := store.Users.Save(u, true, true); err != nil {
+		if err := store.Users.Save(u, false, false); err != nil {
 			t.Fatalf("Save(%s): %v", u.Username, err)
 		}
 	}
@@ -160,7 +160,7 @@ func TestSharePostCreate_ClampsAllowDeleteWithoutUserDeletePerm(t *testing.T) {
 		Permissions: users.Permissions{Share: true, Delete: false, Create: true},
 		Scopes:      []users.SourceScope{{Name: "/srv", Scope: "/"}},
 	}
-	if err := store.Users.Save(user, true, true); err != nil {
+	if err := store.Users.Save(user, false, false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := store.Users.Get(user.ID)

--- a/backend/http/share_patch_test.go
+++ b/backend/http/share_patch_test.go
@@ -46,7 +46,7 @@ func TestSharePatchHandler_AnchorsPathToOwnerScope(t *testing.T) {
 			{Name: "/srv", Scope: "/public"},
 		},
 	}
-	if err := store.Users.Save(guest, true, true); err != nil {
+	if err := store.Users.Save(guest, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -122,7 +122,7 @@ func TestSharePatchHandler_AdminUpdateUsesOwnerScope(t *testing.T) {
 			{Name: "/srv", Scope: "/public"},
 		},
 	}
-	if err := store.Users.Save(owner, true, true); err != nil {
+	if err := store.Users.Save(owner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -137,7 +137,7 @@ func TestSharePatchHandler_AdminUpdateUsesOwnerScope(t *testing.T) {
 			{Name: "/srv", Scope: "/"},
 		},
 	}
-	if err := store.Users.Save(admin, true, true); err != nil {
+	if err := store.Users.Save(admin, false, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/http/webdav_test.go
+++ b/backend/http/webdav_test.go
@@ -322,13 +322,13 @@ func TestWebDAV_PROPFIND_UserScopes(t *testing.T) {
 	}
 
 	// Save users
-	if err := store.Users.Save(adminUser, true, true); err != nil {
+	if err := store.Users.Save(adminUser, false, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Users.Save(scopedUser, true, true); err != nil {
+	if err := store.Users.Save(scopedUser, false, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Users.Save(restrictedUser, true, true); err != nil {
+	if err := store.Users.Save(restrictedUser, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -464,13 +464,13 @@ func TestWebDAV_WriteOperations(t *testing.T) {
 	}
 
 	// Save users
-	if err := store.Users.Save(fullAccessUser, true, true); err != nil {
+	if err := store.Users.Save(fullAccessUser, false, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Users.Save(readOnlyUser, true, true); err != nil {
+	if err := store.Users.Save(readOnlyUser, false, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Users.Save(scopedUser, true, true); err != nil {
+	if err := store.Users.Save(scopedUser, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -602,10 +602,10 @@ func TestWebDAV_AccessControl(t *testing.T) {
 	}
 
 	// Save users
-	if err := store.Users.Save(user1, true, true); err != nil {
+	if err := store.Users.Save(user1, false, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Users.Save(user2, true, true); err != nil {
+	if err := store.Users.Save(user2, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -708,7 +708,7 @@ func TestWebDAV_IndexingStates(t *testing.T) {
 		},
 	}
 
-	if err := store.Users.Save(user, true, true); err != nil {
+	if err := store.Users.Save(user, false, false); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the v1.5.2 security changelog with contributor acknowledgements.
  * Added a symlink security item and reorganized the listed vulnerabilities.

* **Tests**
  * Improved authentication, sharing, access-control, WebDAV, and indexing test setup.
  * Increased reliability of user persistence and permission-related test scenarios.
  * Standardized temporary test resources and strengthened forbidden-access validation.
  * Preserved existing coverage for access restrictions, sharing permissions, and indexing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->