### PR TITLE
Add optional Unicode normalization for new file and directory names

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -35,6 +35,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
+	golang.org/x/text v0.41.0
 	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.49.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -292,7 +293,6 @@ require (
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260820142414-ca536658362e // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/text v0.41.0 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.8.1 // indirect

--- a/backend/internal/utils/normalization.go
+++ b/backend/internal/utils/normalization.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"path"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// NormalizeFinalSegment applies a Unicode normalization form to the FINAL
+// path segment — the name being created or renamed — per the configured
+// server.filesystem.filenameNormalization (#2823).
+//
+// Only the final segment is touched: parent directories already exist with
+// whatever form they were created in, and re-normalizing a full path would
+// stop it from matching an existing NFD-named directory on disk. macOS
+// uploads arrive as NFD while the macOS SMB client sends NFC, which makes
+// NFD-named files openable in Finder listings but unreadable over SMB; an
+// explicit form lets deployments align new names with their consumers.
+//
+// form is one of "none" (default — no change), "nfc", or "nfd"; anything
+// else is treated as "none".
+func NormalizeFinalSegment(p, form string) string {
+	if form != "nfc" && form != "nfd" {
+		return p
+	}
+	dir, base := path.Split(p)
+	if base == "" || base == "/" {
+		return p
+	}
+	normalized := base
+	if form == "nfc" {
+		normalized = norm.NFC.String(base)
+	} else {
+		normalized = norm.NFD.String(base)
+	}
+	if normalized == base {
+		return p
+	}
+	return dir + normalized
+}

--- a/backend/internal/utils/normalization_test.go
+++ b/backend/internal/utils/normalization_test.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// nfdName is "blää.txt" with the umlauts in decomposed (NFD) form — the byte
+// sequence macOS browsers send for uploads.
+const nfdName = "bla\u0308a\u0308.txt"
+
+func TestNormalizeFinalSegment(t *testing.T) {
+	nfcName := norm.NFC.String(nfdName)
+	if nfcName == nfdName {
+		t.Fatal("test fixture must be decomposed form")
+	}
+
+	cases := []struct {
+		name, in, form, want string
+	}{
+		{"nfc form converts NFD filename to NFC", "/uploads/" + nfdName, "nfc", "/uploads/" + nfcName},
+		{"nfd form converts NFC filename to NFD", "/uploads/" + nfcName, "nfd", "/uploads/" + nfdName},
+		{"none form is a no-op", "/uploads/" + nfdName, "none", "/uploads/" + nfdName},
+		{"unset form is a no-op", "/uploads/" + nfdName, "", "/uploads/" + nfdName},
+		{"unknown form is a no-op", "/uploads/" + nfdName, "NFKC", "/uploads/" + nfdName},
+		{"parent segment is never rewritten", "/" + nfdName + "/readme.txt", "nfc", "/" + nfdName + "/readme.txt"},
+		{"root is untouched", "/", "nfc", "/"},
+		{"ascii-only names are unchanged", "/plain/name.txt", "nfc", "/plain/name.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeFinalSegment(tc.in, tc.form); got != tc.want {
+				t.Errorf("NormalizeFinalSegment(%q, %q) = %q, want %q", tc.in, tc.form, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeFinalSegmentRoundTripOnDisk pins the original motivation
+// (#2823): with nfc configured, a name that arrives decomposed must land on
+// disk composed, byte-for-byte — which is what the macOS SMB client asks for.
+func TestNormalizeFinalSegmentRoundTripOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	onDisk := filepath.Join(dir, NormalizeFinalSegment(nfdName, "nfc"))
+
+	if err := os.WriteFile(onDisk, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(entries))
+	}
+	if !norm.NFC.IsNormalString(entries[0].Name()) {
+		t.Errorf("on-disk name %q is not NFC", entries[0].Name())
+	}
+}

--- a/backend/internal/web/resource.go
+++ b/backend/internal/web/resource.go
@@ -687,6 +687,9 @@ func ResourcePostHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 		return http.StatusBadRequest, err
 	}
 	path = cleanPath
+	// Apply the configured Unicode normalization form to the name being
+	// created (final segment only — parents keep their on-disk form).
+	path = utils.NormalizeFinalSegment(path, settings.Config.Server.Filesystem.FilenameNormalization)
 
 	idx := indexing.GetIndex(source)
 	if idx == nil {
@@ -1237,6 +1240,11 @@ func ResourcePatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (i
 			continue
 		}
 		cleanToPath, err := utils.SanitizePath(clientToPath)
+		if err == nil {
+			// The destination name is what gets created on disk: apply the
+			// configured Unicode normalization form to its final segment.
+			cleanToPath = utils.NormalizeFinalSegment(cleanToPath, settings.Config.Server.Filesystem.FilenameNormalization)
+		}
 		if err != nil {
 			item.Message = fmt.Sprintf("invalid toPath: %v", err)
 			response.Failed = append(response.Failed, moveCopyWithClientPaths(item, clientFromPath, clientToPath))

--- a/backend/pkg/settings/config.go
+++ b/backend/pkg/settings/config.go
@@ -739,6 +739,9 @@ func ValidateConfig(config Settings) error {
 
 	// Register custom validator for file permissions
 	err := validate.RegisterValidation("file_permission", validateFilePermission)
+	if err == nil {
+		err = validate.RegisterValidation("filename_normalization", validateFilenameNormalization)
+	}
 	if err != nil {
 		return fmt.Errorf("could not register file_permission validator: %v", err)
 	}
@@ -767,6 +770,16 @@ func validateFilePermission(fl validator.FieldLevel) bool {
 	}
 
 	return true
+}
+// validateFilenameNormalization accepts the empty string (unset) and the
+	// supported Unicode normalization forms for new file/directory names.
+func validateFilenameNormalization(fl validator.FieldLevel) bool {
+	switch fl.Field().String() {
+	case "", "none", "nfc", "nfd":
+		return true
+	default:
+		return false
+	}
 }
 
 func loadEnvConfig() {
@@ -859,6 +872,7 @@ func SetDefaults(generate bool) Settings {
 			Filesystem: Filesystem{
 				CreateFilePermission:      "644",
 				CreateDirectoryPermission: "755",
+				FilenameNormalization:     "none",
 			},
 		},
 		Auth: Auth{

--- a/backend/pkg/settings/structs.go
+++ b/backend/pkg/settings/structs.go
@@ -92,8 +92,13 @@ type Database struct {
 }
 
 type Filesystem struct {
-	CreateFilePermission      string `json:"createFilePermission" validate:"required,file_permission"`      // Unix permissions like 644, 755, 2755 (default: 644)
-	CreateDirectoryPermission string `json:"createDirectoryPermission" validate:"required,file_permission"` // Unix permissions like 755, 2755, 1777 (default: 755)
+	CreateFilePermission      string `json:"createFilePermission" validate:"required,file_permission"`      // Unix permissions like 644, 755, 2775 (default: 644)
+	CreateDirectoryPermission string `json:"createDirectoryPermission" validate:"required,file_permission"` // Unix permissions like 755, 1777, 2775 (default: 755)
+	// FilenameNormalization normalizes the name of newly created / renamed
+	// files and directories: none (default), nfc, or nfd. macOS uploads
+	// arrive NFD while the macOS SMB client asks for NFC, so aligning new
+	// names with the share's consumers keeps uploaded files usable over SMB.
+	FilenameNormalization string `json:"filenameNormalization" validate:"omitempty,filename_normalization"` // none | nfc | nfd (default: none)
 }
 
 // Index SQL startup integrity modes (IndexSqlConfig.StartupIntegrityCheck).


### PR DESCRIPTION
Implements #2823.

## What

`server.filesystem.filenameNormalization: none | nfc | nfd` (default `none` — no behavior change for existing installs) normalizes the names of newly created / renamed files and directories to the configured Unicode form.

## Why

macOS browsers upload files with **NFD** filenames (`File.name` returns the raw on-disk bytes; verified in the issue that this holds for Safari and Chromium, because the chunked upload path takes the name from `File.name`), while the macOS SMB client normalizes to **NFC** before putting names on the wire. Samba and the common Linux filesystems match names byte-for-byte — so a file uploaded through FileBrowser into an SMB-exported directory shows up in Finder's listing but cannot be opened, edited, or deleted. Same mismatch hits scripts, indexers, and sync tools that treat paths as strings.

## How

- `utils.NormalizeFinalSegment(path, form)` applies NFC/NFD (via `golang.org/x/text`, already in the module graph) to the **final segment only** — the name being created or renamed. Parent segments keep their on-disk form: re-normalizing a full path would stop a destination inside an existing NFD-named directory from resolving.
- Wired at the two write seams: `ResourcePostHandler` (create directory / upload, after `SanitizePath`) and `ResourcePatchHandler` (move/copy/rename destination, after `SanitizePath`). The public share handlers (`publicUploadHandler`, `publicPatchHandler`) delegate to these, so share uploads get the same treatment.
- Config: `Filesystem.FilenameNormalization` with a `filename_normalization` validator (empty / `none` / `nfc` / `nfd`), defaulting to `none` in `SetDefaults`.

## Testing

`internal/utils/normalization_test.go`:

- NFD→NFC and NFC→NFD conversion, `none`/unset/unknown forms as no-ops, the parent-segment-never-rewritten guarantee, root, and ASCII-only names;
- an on-disk round trip: with `nfc` configured, a decomposed `blää.txt` lands composed, byte-for-byte (`norm.NFC.IsNormalString` on the real directory entry).

`go build ./...` and `go vet` clean. The one failing `pkg/settings` test on this machine (`TestGenerateConfigYaml_StringQuoting`) panics identically on unmodified `main` — a pre-existing Windows-specific test issue, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Unicode filename normalization for created, moved, copied, and renamed resources.
  * Supports `none`, NFC, and NFD normalization modes, with `none` enabled by default.
  * Normalization applies only to the final filename segment and preserves parent paths.
  * Added configuration validation for supported normalization modes.

* **Bug Fixes**
  * Improved handling of Unicode filenames for more consistent filesystem behavior.
  * Invalid or unspecified normalization settings leave filenames unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->