### PR TITLE
fix onlyoffice share with passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. For commit 
 
  **BugFixes**:
  - root download of a shared directory returns HTTP 500 (#2807) (#2810) (#2821) (#2818)
+ - OnlyOffice is inaccessible if share has optional password (#2811)
+
 ## v1.5.2-stable
 
  **Security**:

--- a/backend/http/onlyOffice.go
+++ b/backend/http/onlyOffice.go
@@ -205,11 +205,16 @@ func onlyofficeClientConfigGetHandler(w http.ResponseWriter, r *http.Request, d 
 	// Send initial log event with detailed path information
 	sendOnlyOfficeLogEvent(logContext, "INFO", "config", fmt.Sprintf("OnlyOffice session started for document: %s ", path))
 
+	shareToken := ""
+	if d.share != nil {
+		shareToken = d.share.Token
+	}
+
 	// Build download URL that OnlyOffice server will use
-	downloadURL := buildOnlyOfficeDownloadURL(r, source, providedPath, d.fileInfo.Hash, d.token)
+	downloadURL := buildOnlyOfficeDownloadURL(r, source, providedPath, d.fileInfo.Hash, d.token, shareToken)
 
 	// Build callback URL for OnlyOffice to notify us of changes
-	callbackURL := buildOnlyOfficeCallbackURL(r, source, providedPath, d.fileInfo.Hash, d.token)
+	callbackURL := buildOnlyOfficeCallbackURL(r, source, providedPath, d.fileInfo.Hash, d.token, shareToken)
 
 	// Build OnlyOffice client configuration
 	clientConfig := map[string]interface{}{
@@ -255,7 +260,7 @@ func onlyofficeClientConfigGetHandler(w http.ResponseWriter, r *http.Request, d 
 }
 
 // buildOnlyOfficeDownloadURL constructs the download URL that OnlyOffice server will use to fetch the file
-func buildOnlyOfficeDownloadURL(r *http.Request, source, path, hash, token string) string {
+func buildOnlyOfficeDownloadURL(r *http.Request, source, path, hash, authToken, shareToken string) string {
 	// Determine base URL (internal URL takes priority for OnlyOffice server communication)
 	var baseURL string
 	if config.Server.InternalUrl != "" {
@@ -290,16 +295,23 @@ func buildOnlyOfficeDownloadURL(r *http.Request, source, path, hash, token strin
 
 	escapedPath := url.QueryEscape(path)
 	downloadURL := fmt.Sprintf("%s/api/resources/download?file=%s&auth=%s&source=%s",
-		strings.TrimSuffix(baseURL, "/"), escapedPath, token, url.QueryEscape(source))
+		strings.TrimSuffix(baseURL, "/"), escapedPath, authToken, url.QueryEscape(source))
 	if hash != "" {
-		downloadURL = fmt.Sprintf("%s/public/api/resources/download?file=%s&auth=%s&hash=%s",
-			strings.TrimSuffix(baseURL, "/"), escapedPath, token, hash)
+		params := url.Values{}
+		params.Set("file", path)
+		params.Set("auth", authToken)
+		params.Set("hash", hash)
+		if shareToken != "" {
+			params.Set("token", shareToken)
+		}
+		downloadURL = fmt.Sprintf("%s/public/api/resources/download?%s",
+			strings.TrimSuffix(baseURL, "/"), params.Encode())
 	}
 	return downloadURL
 }
 
 // buildOnlyOfficeCallbackURL constructs the callback URL that OnlyOffice server will use to notify us of changes
-func buildOnlyOfficeCallbackURL(r *http.Request, source, path, hash, token string) string {
+func buildOnlyOfficeCallbackURL(r *http.Request, source, path, hash, authToken, shareToken string) string {
 	// Determine base URL (internal URL takes priority for OnlyOffice server communication)
 	var baseURL string
 	if config.Server.InternalUrl != "" {
@@ -338,7 +350,10 @@ func buildOnlyOfficeCallbackURL(r *http.Request, source, path, hash, token strin
 		params := url.Values{}
 		params.Set("hash", hash)
 		params.Set("path", path) // This should be the path relative to the share, not the full filesystem path
-		params.Set("auth", token)
+		params.Set("auth", authToken)
+		if shareToken != "" {
+			params.Set("token", shareToken)
+		}
 
 		callbackURL = fmt.Sprintf("%s/public/api/office/callback?%s",
 			strings.TrimSuffix(baseURL, "/"), params.Encode())
@@ -347,7 +362,7 @@ func buildOnlyOfficeCallbackURL(r *http.Request, source, path, hash, token strin
 		params := url.Values{}
 		params.Set("source", source)
 		params.Set("path", path)
-		params.Set("auth", token)
+		params.Set("auth", authToken)
 
 		callbackURL = fmt.Sprintf("%s/api/office/callback?%s",
 			strings.TrimSuffix(baseURL, "/"), params.Encode())

--- a/backend/http/onlyOffice_test.go
+++ b/backend/http/onlyOffice_test.go
@@ -2,7 +2,9 @@ package http
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/gtsteffaniak/filebrowser/backend/adapters/fs/files"
@@ -13,6 +15,86 @@ import (
 	"github.com/gtsteffaniak/filebrowser/backend/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/indexing/iteminfo"
 )
+
+func TestBuildOnlyOfficeShareURLs(t *testing.T) {
+	setupTestEnv(t)
+	origBaseURL := config.Server.BaseURL
+	origInternalURL := config.Server.InternalUrl
+	t.Cleanup(func() {
+		config.Server.BaseURL = origBaseURL
+		config.Server.InternalUrl = origInternalURL
+	})
+	config.Server.BaseURL = "/files/"
+	config.Server.InternalUrl = ""
+
+	req := httptestNewRequest(t, "http://example.com/files/public/api/office/config?hash=abc")
+
+	t.Run("share download URL includes share token", func(t *testing.T) {
+		got := buildOnlyOfficeDownloadURL(req, "source", "/doc.docx", "shareHash", "jwt-token", "share-download-token")
+		parsed, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse download URL: %v", err)
+		}
+		q := parsed.Query()
+		if q.Get("hash") != "shareHash" {
+			t.Errorf("hash = %q, want shareHash", q.Get("hash"))
+		}
+		if q.Get("auth") != "jwt-token" {
+			t.Errorf("auth = %q, want jwt-token", q.Get("auth"))
+		}
+		if q.Get("token") != "share-download-token" {
+			t.Errorf("token = %q, want share-download-token", q.Get("token"))
+		}
+		if q.Get("file") != "/doc.docx" {
+			t.Errorf("file = %q, want /doc.docx", q.Get("file"))
+		}
+	})
+
+	t.Run("share download URL omits token when empty", func(t *testing.T) {
+		got := buildOnlyOfficeDownloadURL(req, "source", "/doc.docx", "shareHash", "jwt-token", "")
+		parsed, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse download URL: %v", err)
+		}
+		if parsed.Query().Get("token") != "" {
+			t.Errorf("expected no token param, got %q", parsed.Query().Get("token"))
+		}
+	})
+
+	t.Run("non-share download URL unchanged", func(t *testing.T) {
+		got := buildOnlyOfficeDownloadURL(req, "my-source", "/doc.docx", "", "jwt-token", "share-download-token")
+		if strings.Contains(got, "token=") {
+			t.Errorf("non-share URL should not include share token: %q", got)
+		}
+		if !strings.Contains(got, "source=my-source") {
+			t.Errorf("expected source in URL, got %q", got)
+		}
+	})
+
+	t.Run("share callback URL includes share token", func(t *testing.T) {
+		got := buildOnlyOfficeCallbackURL(req, "source", "/doc.docx", "shareHash", "jwt-token", "share-download-token")
+		parsed, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse callback URL: %v", err)
+		}
+		q := parsed.Query()
+		if q.Get("token") != "share-download-token" {
+			t.Errorf("token = %q, want share-download-token", q.Get("token"))
+		}
+		if q.Get("auth") != "jwt-token" {
+			t.Errorf("auth = %q, want jwt-token", q.Get("auth"))
+		}
+	})
+}
+
+func httptestNewRequest(t *testing.T, rawURL string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, rawURL, http.NoBody)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	return req
+}
 
 func TestResolveOnlyOfficeDownloadURL(t *testing.T) {
 	orig := config.Integrations.OnlyOffice

--- a/frontend/src/api/office.js
+++ b/frontend/src/api/office.js
@@ -1,4 +1,5 @@
 import { notify } from '@/notify'
+import { state } from '@/store'
 import { getApiPath, getPublicApiPath } from '@/utils/url.js'
 import { fetchURL } from './utils'
 
@@ -8,7 +9,16 @@ export async function getConfig(req) {
     const params = {
       path: req.path,
       ...(req.hash && { hash: req.hash }),
-      ...(req.source && { source: req.source })
+      ...(req.source && { source: req.source }),
+      ...(req.hash && state.shareInfo?.token && { token: state.shareInfo.token }),
+    }
+
+    const headers = {}
+    if (req.hash) {
+      const sharePassword = localStorage.getItem(`sharepass:${req.hash}`)
+      if (sharePassword) {
+        headers['X-SHARE-PASSWORD'] = sharePassword
+      }
     }
     
     let apiPath
@@ -18,7 +28,7 @@ export async function getConfig(req) {
       apiPath = getApiPath('office/config', params)
     }
     
-    const res = await fetchURL(apiPath)
+    const res = await fetchURL(apiPath, { headers })
     return await res.json()
   } catch (err) {
     notify.showError(err.message || 'Error fetching OnlyOffice configuration')


### PR DESCRIPTION
OnlyOffice is inaccessible if share has optional password (#2811)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue preventing OnlyOffice from opening files shared with an optional password.
  - Shared OnlyOffice sessions now correctly authenticate using the share password and access token.
  - Improved download and callback handling for password-protected shares.
  - Existing non-shared OnlyOffice access continues to work as expected.
- **Tests**
  - Added coverage for password-protected share access, regular links, and callback authentication.
- **Documentation**
  - Added a v1.5.2 stable changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->