### PR TITLE
fix windows slash regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. For commit 
 ## v1.5.2-stable
 
  **BugFixes**:
+ - Windows: fix backslash duplication in navigation URLs, folder sizes showing 4 KB, and download/preview failures (#2815, #2816)
  - root download of a shared directory returns HTTP 500 (#2807) (#2810) (#2821) (#2818)
  - OnlyOffice is inaccessible if share has optional password (#2811)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. For commit 
 ## v1.5.2-stable
 
  **BugFixes**:
- - Windows: fix backslash duplication in navigation URLs, folder sizes showing 4 KB, and download/preview failures (#2815, #2816)
+ - windows backslash inserted into directory URLs causing malformed paths and path escapes from parent (#2815) (#2816)
  - root download of a shared directory returns HTTP 500 (#2807) (#2810) (#2821) (#2818)
  - OnlyOffice is inaccessible if share has optional password (#2811)
 

--- a/backend/common/utils/file.go
+++ b/backend/common/utils/file.go
@@ -10,7 +10,7 @@ import (
 	"hash"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/gtsteffaniak/filebrowser/backend/common/errors"
@@ -69,22 +69,22 @@ type FileOptions struct {
 // SanitizeUserPath prevents path traversal attacks by cleaning and validating user input.
 // Rule 1: Do Not Use User Input in File Paths (without validation)
 func SanitizeUserPath(userPath string) (string, error) {
-	clean := filepath.Clean(userPath)
+	clean := path.Clean(userPath)
 
-	// Split the path into segments to check for path traversal attempts
-	// We check if ".." appears as a complete path segment (not just in a filename)
-	segments := strings.Split(clean, string(filepath.Separator))
+	// Split the path into segments to check for path traversal attempts.
+	// We check if ".." appears as a complete path segment (not just in a filename).
+	segments := strings.Split(clean, "/")
 
 	for _, segment := range segments {
-		// Check if any segment is exactly ".." (path traversal attempt)
-		// This catches any ".." that filepath.Clean couldn't resolve (i.e., escape attempts)
+		// Check if any segment is exactly ".." (path traversal attempt).
+		// This catches any ".." that path.Clean couldn't resolve (i.e., escape attempts).
 		if segment == ".." {
 			return "", fmt.Errorf("invalid path: path traversal detected")
 		}
 	}
 
 	if clean == "." {
-		return "", fmt.Errorf("invalid path: path must standard index path")
+		return "", fmt.Errorf("invalid path: path must be a standard index path")
 	}
 
 	return clean, nil

--- a/backend/common/utils/file.go
+++ b/backend/common/utils/file.go
@@ -69,6 +69,7 @@ type FileOptions struct {
 // SanitizeUserPath prevents path traversal attacks by cleaning and validating user input.
 // Rule 1: Do Not Use User Input in File Paths (without validation)
 func SanitizeUserPath(userPath string) (string, error) {
+	userPath = strings.ReplaceAll(userPath, `\`, `/`)
 	clean := path.Clean(userPath)
 
 	// Split the path into segments to check for path traversal attempts.

--- a/backend/common/utils/file_test.go
+++ b/backend/common/utils/file_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeUserPath_indexPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"root slash", "/", "/", false},
+		{"nested", "/foo/bar", "/foo/bar", false},
+		{"traversal segment", "..", "", true},
+		{"resolved traversal", "/../secret", "/secret", false},
+		{"empty", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SanitizeUserPath(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("SanitizeUserPath(%q) expected error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SanitizeUserPath(%q) unexpected error: %v", tt.input, err)
+			}
+			if strings.Contains(got, `\`) {
+				t.Errorf("SanitizeUserPath(%q) = %q contains backslash", tt.input, got)
+			}
+			if got != tt.want {
+				t.Errorf("SanitizeUserPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/common/utils/file_test.go
+++ b/backend/common/utils/file_test.go
@@ -17,6 +17,9 @@ func TestSanitizeUserPath_indexPaths(t *testing.T) {
 		{"traversal segment", "..", "", true},
 		{"resolved traversal", "/../secret", "/secret", false},
 		{"empty", "", "", true},
+		{"backslash traversal", `..\secret`, "", true},
+		{"backslash double traversal", `..\..\secret`, "", true},
+		{"backslash path normalized", `\foo\bar`, "/foo/bar", false},
 	}
 
 	for _, tt := range tests {

--- a/backend/http/middleware.go
+++ b/backend/http/middleware.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -58,7 +57,6 @@ func withHashFileHelper(fn handleFunc) handleFunc {
 		if err != nil && inputPath != "" {
 			return http.StatusBadRequest, err
 		}
-		path = filepath.ToSlash(path)
 
 		// Get the file link by hash
 		link, err := store.Share.GetByHash(hash)


### PR DESCRIPTION
Windows: fix backslash duplication in navigation URLs, folder sizes showing 4 KB, and download/preview failures (#2815, #2816)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicated backslashes in Windows navigation URLs.
  * Prevented malformed navigation paths and unintended parent-directory escapes.
  * Improved cross-platform path handling for file and folder navigation.
  * Updated invalid-path messaging to clarify accepted path formats.

* **Tests**
  * Added coverage for standard paths, traversal attempts, root and empty paths, backslash traversal, and path normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->