### PR TITLE
fix windows backslash gaps in v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. For commit 
 ## v2.0.2
 
  **Bugfixes**:
+ - Windows: fix backslash duplication in navigation URLs, folder sizes showing 4 KB, and download/preview failures (#2815, #2816)
  - Wrong extension in the 'new database was created popup (#2817) (#2824)
  - External subtitles fail to load on public video shares due to authenticated subtitle endpoint (#2822) (#2827)
 

--- a/backend/internal/utils/file.go
+++ b/backend/internal/utils/file.go
@@ -69,6 +69,7 @@ type FileOptions struct {
 // SanitizePath cleans and validates a path or path-like filter (index paths, globs, etc.)
 // to block traversal. Rule 1: Do Not Use Untrusted Input in File Paths (without validation).
 func SanitizePath(inputPath string) (string, error) {
+	inputPath = strings.ReplaceAll(inputPath, `\`, `/`)
 	clean := path.Clean(inputPath)
 
 	// Split the path into segments to check for path traversal attempts.

--- a/backend/internal/utils/indexpath.go
+++ b/backend/internal/utils/indexpath.go
@@ -34,10 +34,6 @@ func ParseSanitizedIndexPath(userPath string, isDir bool) (IndexPath, error) {
 }
 
 func parseIndexPath(path string, isDir bool, strict bool) (IndexPath, error) {
-	if strict && strings.Contains(path, `\`) {
-		return IndexPath{}, fmt.Errorf("invalid path: backslashes not allowed")
-	}
-
 	inner := strings.Trim(path, "/")
 	if inner == "" {
 		return IndexPath{IsDir: isDir}, nil

--- a/backend/internal/utils/indexpath_test.go
+++ b/backend/internal/utils/indexpath_test.go
@@ -53,6 +53,9 @@ func TestSanitizePath_indexPaths(t *testing.T) {
 		{"traversal segment", "..", "", true},
 		{"resolved traversal", "/../secret", "/secret", false},
 		{"empty", "", "", true},
+		{"backslash traversal", `..\secret`, "", true},
+		{"backslash double traversal", `..\..\secret`, "", true},
+		{"backslash path normalized", `\foo\bar`, "/foo/bar", false},
 	}
 
 	for _, tt := range tests {
@@ -108,6 +111,14 @@ func TestParseSanitizedIndexPath(t *testing.T) {
 	}
 	if got.String() != "/secret/" {
 		t.Errorf("got %q want /secret/", got.String())
+	}
+
+	got, err = ParseSanitizedIndexPath(`\foo\bar\`, true)
+	if err != nil {
+		t.Fatalf("unexpected error for backslash path: %v", err)
+	}
+	if got.String() != "/foo/bar/" {
+		t.Errorf("got %q want /foo/bar/", got.String())
 	}
 }
 


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows navigation URLs containing duplicated backslashes.
  * Corrected folder size calculations that incorrectly reported 4 KB.
  * Resolved download and preview failures on Windows.
  * Improved handling of Windows-style paths while maintaining traversal protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->