### PR TITLE
fix: v2.0.2 onlyoffice password shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For commit 
  **Bugfixes**:
  - Wrong extension in the 'new database was created popup (#2817) (#2824)
  - External subtitles fail to load on public video shares due to authenticated subtitle endpoint (#2822) (#2827)
+ - OnlyOffice is inaccessible on password-protected shares (#2811)
 
 ## v2.0.1
 

--- a/backend/internal/web/onlyOffice.go
+++ b/backend/internal/web/onlyOffice.go
@@ -213,11 +213,13 @@ func onlyofficeClientConfigGetHandler(w http.ResponseWriter, r *http.Request, d 
 		return http.StatusForbidden, err
 	}
 
+	shareToken := shareTokenForOnlyOffice(d)
+
 	// Build view URL that OnlyOffice server will use to fetch the file
-	documentURL := buildOnlyOfficeViewURL(r, source, providedPath, d.FileInfo.Hash, viewToken, d.Token)
+	documentURL := buildOnlyOfficeViewURL(r, source, providedPath, d.FileInfo.Hash, viewToken, d.Token, shareToken)
 
 	// Build callback URL for OnlyOffice to notify us of changes
-	callbackURL := buildOnlyOfficeCallbackURL(r, source, providedPath, d.FileInfo.Hash, d.Token)
+	callbackURL := buildOnlyOfficeCallbackURL(r, source, providedPath, d.FileInfo.Hash, d.Token, shareToken)
 
 	// Build OnlyOffice client configuration
 	clientConfig := map[string]interface{}{
@@ -296,14 +298,26 @@ func joinOnlyOfficeAPIURL(baseURL, apiPath string) string {
 	return base + "/" + path
 }
 
+// shareTokenForOnlyOffice returns the share download token for OnlyOffice server URLs.
+// Only password-protected shares have a token; callers must already have passed share auth.
+func shareTokenForOnlyOffice(d *Context) string {
+	if d.Share.Hash == "" || d.Share.PasswordHash == "" || d.Share.Token == "" {
+		return ""
+	}
+	return d.Share.Token
+}
+
 // buildOnlyOfficeViewURL constructs the view URL that OnlyOffice server uses to fetch the document.
-func buildOnlyOfficeViewURL(r *http.Request, source, path, hash, viewToken, authToken string) string {
+func buildOnlyOfficeViewURL(r *http.Request, source, path, hash, viewToken, authToken, shareToken string) string {
 	baseURL := onlyOfficeFileBrowserBaseURL(r)
 	params := url.Values{}
 	params.Set("file", path)
 	params.Set("viewToken", viewToken)
 	if hash != "" {
 		params.Set("hash", hash)
+		if shareToken != "" {
+			params.Set("token", shareToken)
+		}
 		return joinOnlyOfficeAPIURL(baseURL, "public/api/resources/view") + "?" + params.Encode()
 	}
 	params.Set("source", source)
@@ -312,7 +326,7 @@ func buildOnlyOfficeViewURL(r *http.Request, source, path, hash, viewToken, auth
 }
 
 // buildOnlyOfficeCallbackURL constructs the callback URL that OnlyOffice server will use to notify us of changes
-func buildOnlyOfficeCallbackURL(r *http.Request, source, path, hash, token string) string {
+func buildOnlyOfficeCallbackURL(r *http.Request, source, path, hash, authToken, shareToken string) string {
 	baseURL := onlyOfficeFileBrowserBaseURL(r)
 
 	params := url.Values{}
@@ -320,14 +334,17 @@ func buildOnlyOfficeCallbackURL(r *http.Request, source, path, hash, token strin
 		// Share callback URL - use public API and don't expose source, use path relative to share
 		params.Set("hash", hash)
 		params.Set("path", path)
-		params.Set("auth", token)
+		params.Set("auth", authToken)
+		if shareToken != "" {
+			params.Set("token", shareToken)
+		}
 		return joinOnlyOfficeAPIURL(baseURL, "public/api/office/callback") + "?" + params.Encode()
 	}
 
 	// Regular callback URL - include source for non-share requests
 	params.Set("source", source)
 	params.Set("path", path)
-	params.Set("auth", token)
+	params.Set("auth", authToken)
 	return joinOnlyOfficeAPIURL(baseURL, "api/office/callback") + "?" + params.Encode()
 }
 

--- a/backend/internal/web/onlyOffice_test.go
+++ b/backend/internal/web/onlyOffice_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
@@ -60,17 +61,94 @@ func TestBuildOnlyOfficeViewURL(t *testing.T) {
 	settings.Config.Http.BaseURL = "/testing/"
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	got := buildOnlyOfficeViewURL(req, "Downloads", "/doc.docx", "", "view-token", "session.jwt.token")
+	got := buildOnlyOfficeViewURL(req, "Downloads", "/doc.docx", "", "view-token", "session.jwt.token", "")
 	want := "http://filebrowser:8080/testing/api/resources/view?auth=session.jwt.token&file=%2Fdoc.docx&source=Downloads&viewToken=view-token"
 	if got != want {
 		t.Fatalf("buildOnlyOfficeViewURL() = %q, want %q", got, want)
 	}
 
-	shareGot := buildOnlyOfficeViewURL(req, "Downloads", "/doc.docx", "share-hash", "view-token", "session.jwt.token")
+	shareGot := buildOnlyOfficeViewURL(req, "Downloads", "/doc.docx", "share-hash", "view-token", "session.jwt.token", "")
 	shareWant := "http://filebrowser:8080/testing/public/api/resources/view?file=%2Fdoc.docx&hash=share-hash&viewToken=view-token"
 	if shareGot != shareWant {
 		t.Fatalf("buildOnlyOfficeViewURL(share) = %q, want %q", shareGot, shareWant)
 	}
+}
+
+func TestBuildOnlyOfficeShareURLs(t *testing.T) {
+	origHTTP := settings.Config.Http
+	t.Cleanup(func() { settings.Config.Http = origHTTP })
+	settings.Config.Http.BaseURL = "/files/"
+	settings.Config.Http.InternalUrl = ""
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/files/public/api/office/config?hash=abc", nil)
+
+	t.Run("share view URL includes share token", func(t *testing.T) {
+		got := buildOnlyOfficeViewURL(req, "source", "/doc.docx", "shareHash", "view-token", "jwt-token", "share-download-token")
+		parsed, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse view URL: %v", err)
+		}
+		q := parsed.Query()
+		if q.Get("hash") != "shareHash" {
+			t.Errorf("hash = %q, want shareHash", q.Get("hash"))
+		}
+		if q.Get("viewToken") != "view-token" {
+			t.Errorf("viewToken = %q, want view-token", q.Get("viewToken"))
+		}
+		if q.Get("token") != "share-download-token" {
+			t.Errorf("token = %q, want share-download-token", q.Get("token"))
+		}
+		if q.Get("file") != "/doc.docx" {
+			t.Errorf("file = %q, want /doc.docx", q.Get("file"))
+		}
+	})
+
+	t.Run("share view URL omits token when empty", func(t *testing.T) {
+		got := buildOnlyOfficeViewURL(req, "source", "/doc.docx", "shareHash", "view-token", "jwt-token", "")
+		parsed, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse view URL: %v", err)
+		}
+		if parsed.Query().Get("token") != "" {
+			t.Errorf("expected no token param, got %q", parsed.Query().Get("token"))
+		}
+	})
+
+	t.Run("non-share view URL unchanged", func(t *testing.T) {
+		got := buildOnlyOfficeViewURL(req, "my-source", "/doc.docx", "", "view-token", "jwt-token", "share-download-token")
+		if strings.Contains(got, "token=") {
+			t.Errorf("non-share URL should not include share token: %q", got)
+		}
+		if !strings.Contains(got, "source=my-source") {
+			t.Errorf("expected source in URL, got %q", got)
+		}
+	})
+
+	t.Run("share callback URL includes share token", func(t *testing.T) {
+		got := buildOnlyOfficeCallbackURL(req, "source", "/doc.docx", "shareHash", "jwt-token", "share-download-token")
+		parsed, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse callback URL: %v", err)
+		}
+		q := parsed.Query()
+		if q.Get("token") != "share-download-token" {
+			t.Errorf("token = %q, want share-download-token", q.Get("token"))
+		}
+		if q.Get("auth") != "jwt-token" {
+			t.Errorf("auth = %q, want jwt-token", q.Get("auth"))
+		}
+	})
+
+	t.Run("share callback URL omits token when empty", func(t *testing.T) {
+		got := buildOnlyOfficeCallbackURL(req, "source", "/doc.docx", "shareHash", "jwt-token", "")
+		parsed, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse callback URL: %v", err)
+		}
+		if parsed.Query().Get("token") != "" {
+			t.Errorf("expected no token param, got %q", parsed.Query().Get("token"))
+		}
+	})
 }
 
 func TestJoinOnlyOfficeAPIURL(t *testing.T) {

--- a/frontend/src/api/office.js
+++ b/frontend/src/api/office.js
@@ -1,4 +1,5 @@
 import { notify } from '@/notify'
+import { state } from '@/store'
 import { getApiPath, getPublicApiPath } from '@/utils/url.js'
 import { fetchURL } from './utils'
 
@@ -8,7 +9,16 @@ export async function getConfig(req) {
     const params = {
       path: req.path,
       ...(req.hash && { hash: req.hash }),
-      ...(req.source && { source: req.source })
+      ...(req.source && { source: req.source }),
+      ...(req.hash && state.shareInfo?.token && { token: state.shareInfo.token }),
+    }
+
+    const headers = {}
+    if (req.hash) {
+      const sharePassword = localStorage.getItem(`sharepass:${req.hash}`)
+      if (sharePassword) {
+        headers['X-SHARE-PASSWORD'] = sharePassword
+      }
     }
     
     let apiPath
@@ -18,7 +28,7 @@ export async function getConfig(req) {
       apiPath = getApiPath('office/config', params)
     }
     
-    const res = await fetchURL(apiPath)
+    const res = await fetchURL(apiPath, { headers })
     return await res.json()
   } catch (err) {
     notify.showError(err.message || 'Error fetching OnlyOffice configuration')


### PR DESCRIPTION
fix: OnlyOffice is inaccessible on password-protected shares (#2811)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed OnlyOffice access for password-protected shares.
  - Share links now securely include the required access token when opening documents or handling callbacks.
  - Improved authentication handling for shared documents while preserving existing behavior for other links.
- **Tests**
  - Added coverage for tokenized, tokenless, and standard OnlyOffice URLs.
- **Documentation**
  - Added a changelog entry for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->