### PR TITLE
oidc always request groups claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,8 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v2.0.2
 
- **Notes**:
- - OIDC: `groupsClaim` now defaults to `groups` for all authentication methods that share `adminGroup` / `userGroups` options (OIDC, JWT, LDAP, proxy). When the ID token omits the groups claim, FileBrowser falls back to the UserInfo endpoint if `adminGroup` or `userGroups` is configured (fixes PocketID and similar providers when the `groups` scope is included).
-
  **Bugfixes**:
+ - OIDC: `groupsClaim` value is always included in requested scopes and falls back to the UserInfo endpoint when the ID token omits the groups claim.
  - Windows: fix backslash duplication in navigation URLs, folder sizes showing 4 KB, and download/preview failures (#2815, #2816)
  - Wrong extension in the 'new database was created popup (#2817) (#2824)
  - External subtitles fail to load on public video shares due to authenticated subtitle endpoint (#2822) (#2827)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v2.0.2
 
+ **Notes**:
+ - OIDC: `groupsClaim` now defaults to `groups` for all authentication methods that share `adminGroup` / `userGroups` options (OIDC, JWT, LDAP, proxy). When the ID token omits the groups claim, FileBrowser falls back to the UserInfo endpoint if `adminGroup` or `userGroups` is configured (fixes PocketID and similar providers when the `groups` scope is included).
+
  **Bugfixes**:
  - Windows: fix backslash duplication in navigation URLs, folder sizes showing 4 KB, and download/preview failures (#2815, #2816)
  - Wrong extension in the 'new database was created popup (#2817) (#2824)

--- a/backend/internal/web/auth.go
+++ b/backend/internal/web/auth.go
@@ -14,9 +14,9 @@ import (
 	"github.com/golang-jwt/jwt/v4/request"
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/gtsteffaniak/filebrowser/backend/internal/auth"
-	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/activity"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/auth"
 	activitydb "github.com/gtsteffaniak/filebrowser/backend/internal/database/activity"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/share"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
@@ -228,7 +228,7 @@ func sessionCookieDomain(r *http.Request) string {
 // @Success 200 {object} map[string]string "{"logoutUrl": "http://..."}"
 // @Router /api/auth/logout [post]
 func logoutHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, error) {
-	if err := state.RevokeToken( d.Token); err != nil {
+	if err := state.RevokeToken(d.Token); err != nil {
 		logger.Errorf("Failed to revoke token on logout: %v", err)
 	}
 

--- a/backend/internal/web/ldap.go
+++ b/backend/internal/web/ldap.go
@@ -66,11 +66,7 @@ func authenticateLDAP(username, password string) ([]string, map[string]string, e
 		logger.Debugf("ldap: no service account bind (userPassword empty)")
 	}
 
-	// Build list of attributes to fetch
-	groupAttr := c.GroupsClaim
-	if groupAttr == "" {
-		groupAttr = "groups"
-	}
+	groupAttr := settings.ResolveGroupsClaim(c.GroupsClaim)
 	attributes := []string{"dn", groupAttr}
 	if c.UserIdentifier != "" {
 		attributes = append(attributes, c.UserIdentifier)

--- a/backend/internal/web/ldap.go
+++ b/backend/internal/web/ldap.go
@@ -69,7 +69,7 @@ func authenticateLDAP(username, password string) ([]string, map[string]string, e
 	// Build list of attributes to fetch
 	groupAttr := c.GroupsClaim
 	if groupAttr == "" {
-		groupAttr = "memberOf"
+		groupAttr = "groups"
 	}
 	attributes := []string{"dn", groupAttr}
 	if c.UserIdentifier != "" {

--- a/backend/internal/web/oidc.go
+++ b/backend/internal/web/oidc.go
@@ -272,6 +272,11 @@ func oidcCallbackHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 				// Even if parsing succeeded, if essential claims are missing, use UserInfo
 				if _, ok := userdata.Claims[oidcCfg.UserIdentifier]; ok {
 					claimsFromIDToken = true
+					needsGroups := oidcCfg.AdminGroup != "" || len(oidcCfg.UserGroups) > 0
+					if needsGroups && len(userdata.Groups) == 0 {
+						logger.Debugf("OIDC: ID token missing groups claim (adminGroup/userGroups configured); fetching UserInfo")
+						claimsFromIDToken = false
+					}
 				}
 			}
 		}

--- a/backend/pkg/settings/auth.go
+++ b/backend/pkg/settings/auth.go
@@ -149,6 +149,7 @@ func ValidateLdapAuth() error {
 	if ldapCfg.UserFilter == "" {
 		ldapCfg.UserFilter = "(&(cn=%s)(objectClass=user))"
 	}
+	applyAuthCommonDefaults(&ldapCfg.AuthCommon)
 	if err := verifyLdapConnection(); err != nil {
 		logger.Fatalf("LDAP connection check failed: %v", err)
 	}
@@ -158,9 +159,7 @@ func ValidateLdapAuth() error {
 // ValidateOidcAuth processes the OIDC callback and retrieves user identity
 func validateOidcAuth() error {
 	oidcCfg := &Config.Auth.Methods.OidcAuth // Use a pointer to modify the original config
-	if oidcCfg.GroupsClaim == "" {
-		oidcCfg.GroupsClaim = "groups"
-	}
+	applyAuthCommonDefaults(&oidcCfg.AuthCommon)
 	if oidcCfg.UserIdentifier == "" {
 		oidcCfg.UserIdentifier = "preferred_username"
 	}
@@ -289,9 +288,7 @@ func ValidateJwtAuth() error {
 	if jwtCfg.Algorithm == "" {
 		jwtCfg.Algorithm = "HS256"
 	}
-	if jwtCfg.GroupsClaim == "" {
-		jwtCfg.GroupsClaim = "groups"
-	}
+	applyAuthCommonDefaults(&jwtCfg.AuthCommon)
 	if jwtCfg.UserIdentifier == "" {
 		jwtCfg.UserIdentifier = "sub"
 	}

--- a/backend/pkg/settings/auth_groups.go
+++ b/backend/pkg/settings/auth_groups.go
@@ -2,9 +2,15 @@ package settings
 
 const defaultGroupsClaim = "groups"
 
+// ResolveGroupsClaim returns the configured groups claim or the shared default when empty.
+func ResolveGroupsClaim(claim string) string {
+	if claim == "" {
+		return defaultGroupsClaim
+	}
+	return claim
+}
+
 // applyAuthCommonDefaults sets shared defaults for external auth methods that support group claims.
 func applyAuthCommonDefaults(c *AuthCommon) {
-	if c.GroupsClaim == "" {
-		c.GroupsClaim = defaultGroupsClaim
-	}
+	c.GroupsClaim = ResolveGroupsClaim(c.GroupsClaim)
 }

--- a/backend/pkg/settings/auth_groups.go
+++ b/backend/pkg/settings/auth_groups.go
@@ -1,0 +1,10 @@
+package settings
+
+const defaultGroupsClaim = "groups"
+
+// applyAuthCommonDefaults sets shared defaults for external auth methods that support group claims.
+func applyAuthCommonDefaults(c *AuthCommon) {
+	if c.GroupsClaim == "" {
+		c.GroupsClaim = defaultGroupsClaim
+	}
+}

--- a/backend/pkg/settings/auth_groups_test.go
+++ b/backend/pkg/settings/auth_groups_test.go
@@ -15,3 +15,12 @@ func TestApplyAuthCommonDefaults(t *testing.T) {
 		t.Fatalf("custom groupsClaim = %q, want memberOf", custom.GroupsClaim)
 	}
 }
+
+func TestResolveGroupsClaim(t *testing.T) {
+	if got := ResolveGroupsClaim(""); got != "groups" {
+		t.Fatalf("ResolveGroupsClaim(\"\") = %q, want groups", got)
+	}
+	if got := ResolveGroupsClaim("memberOf"); got != "memberOf" {
+		t.Fatalf("ResolveGroupsClaim(memberOf) = %q, want memberOf", got)
+	}
+}

--- a/backend/pkg/settings/auth_groups_test.go
+++ b/backend/pkg/settings/auth_groups_test.go
@@ -1,0 +1,17 @@
+package settings
+
+import "testing"
+
+func TestApplyAuthCommonDefaults(t *testing.T) {
+	empty := AuthCommon{}
+	applyAuthCommonDefaults(&empty)
+	if empty.GroupsClaim != "groups" {
+		t.Fatalf("default groupsClaim = %q, want groups", empty.GroupsClaim)
+	}
+
+	custom := AuthCommon{GroupsClaim: "memberOf"}
+	applyAuthCommonDefaults(&custom)
+	if custom.GroupsClaim != "memberOf" {
+		t.Fatalf("custom groupsClaim = %q, want memberOf", custom.GroupsClaim)
+	}
+}

--- a/backend/pkg/settings/config.go
+++ b/backend/pkg/settings/config.go
@@ -515,6 +515,7 @@ func setupAuth(generate bool) {
 		Config.Auth.AuthMethods = append(Config.Auth.AuthMethods, "password")
 	}
 	if Config.Auth.Methods.ProxyAuth.Enabled {
+		applyAuthCommonDefaults(&Config.Auth.Methods.ProxyAuth.AuthCommon)
 		Config.Auth.AuthMethods = append(Config.Auth.AuthMethods, "proxy")
 	}
 	if Config.Auth.Methods.NoAuth {


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized group-claim handling across OIDC, JWT, LDAP, and proxy authentication.
  * OIDC authentication now retrieves group information from the UserInfo endpoint when it is missing from the ID token and group-based authorization is configured.

* **Bug Fixes**
  * Ensured the configured group claim is included in authentication scopes.
  * Improved consistency of group-based authorization across authentication methods.

* **Documentation**
  * Updated release notes to clarify group-claim and UserInfo fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->