### PR TITLE
fixed install app bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to this project will be documented in this file. For commit guidelines, please refer to [Standard Version](https://github.com/conventional-changelog/standard-version).
 
-## v1.5.2-stable
+## v1.5.4-stable
+
+ **New Features**:
+ - Added aption to globally disable the "Install App" message via `frontend.disablePWAInstall`
+
+ **BugFixes**:
+ - "install app" message reappears after being cleared on device.
+
+## v1.5.3-stable
 
  **BugFixes**:
  - windows backslash inserted into directory URLs causing malformed paths and path escapes from parent (#2815) (#2816)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. For commit 
 ## v1.5.4-stable
 
  **New Features**:
- - Added aption to globally disable the "Install App" message via `frontend.disablePWAInstall`
+ - Added option to globally disable the "Install App" message via `frontend.disablePWAInstall`
 
  **BugFixes**:
  - "install app" message reappears after being cleared on device.

--- a/backend/common/settings/structs.go
+++ b/backend/common/settings/structs.go
@@ -291,6 +291,7 @@ type Frontend struct {
 	LoginIcon             string         `json:"loginIcon"`           // path to an image file for the login page icon
 	LoginButtonText       string         `json:"loginButtonText"`     // text to display on the login button
 	OIDCLoginButtonText   string         `json:"oidcLoginButtonText"` // text to display on the OIDC login button
+	DisablePWAInstall     bool           `json:"disablePWAInstall"`   // disable the PWA install button in the sidebar
 }
 
 type StylingConfig struct {

--- a/backend/http/static.go
+++ b/backend/http/static.go
@@ -245,6 +245,7 @@ func handleWithStaticData(w http.ResponseWriter, r *http.Request, d *requestCont
 		"loginButtonText":        config.Frontend.LoginButtonText,
 		"passkeyAvailable":       config.Auth.Methods.PasskeyAuth.Enabled,
 		"passkeyLoginButtonText": config.Auth.Methods.PasskeyAuth.LoginButtonText,
+		"disablePWAInstall":      config.Frontend.DisablePWAInstall,
 	}
 
 	// Marshal each variable to JSON strings for direct template usage

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -5761,6 +5761,10 @@ const docTemplate = `{
                     "description": "disable the nav buttons in the sidebar",
                     "type": "boolean"
                 },
+                "disablePWAInstall": {
+                    "description": "disable the PWA install button in the sidebar",
+                    "type": "boolean"
+                },
                 "disableUsedPercentage": {
                     "description": "disable used percentage for the sources in the sidebar",
                     "type": "boolean"

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -5750,6 +5750,10 @@
                     "description": "disable the nav buttons in the sidebar",
                     "type": "boolean"
                 },
+                "disablePWAInstall": {
+                    "description": "disable the PWA install button in the sidebar",
+                    "type": "boolean"
+                },
                 "disableUsedPercentage": {
                     "description": "disable used percentage for the sources in the sidebar",
                     "type": "boolean"

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -767,6 +767,9 @@ definitions:
       disableNavButtons:
         description: disable the nav buttons in the sidebar
         type: boolean
+      disablePWAInstall:
+        description: disable the PWA install button in the sidebar
+        type: boolean
       disableUsedPercentage:
         description: disable used percentage for the sources in the sidebar
         type: boolean

--- a/frontend/public/config.generated.yaml
+++ b/frontend/public/config.generated.yaml
@@ -159,6 +159,7 @@ frontend:
   loginIcon: ""                           # path to an image file for the login page icon
   loginButtonText: ""                     # text to display on the login button
   oidcLoginButtonText: ""                 # text to display on the OIDC login button
+  disablePWAInstall: false                # disable the PWA install button in the sidebar
 userDefaults:
   sidebar:                                # New organized structure
     disableQuickToggles: false            # disable the quick toggles in the sidebar

--- a/frontend/src/components/sidebar/Sidebar.vue
+++ b/frontend/src/components/sidebar/Sidebar.vue
@@ -57,19 +57,12 @@ export default {
       resizeStartX: 0,
       resizeStartWidth: 0,
       previousSidebarSize: null, // Remember the previous width when switching from desktop to mobile.
-      pwaInstallDismissed: false,
+      pwaInstallDismissed: localStorage.getItem("pwaInstallDismissed") === "true",
     };
   },
   mounted() {
     // Ensure the sidebar is initialized correctly
     mutations.setSeenUpdate(localStorage.getItem("seenUpdate"));
-    this.pwaInstallDismissed =
-      localStorage.getItem("pwaInstallDismissed") === "true" ||
-      sessionStorage.getItem("pwaInstallDismissed") === "true";
-    if (this.pwaInstallDismissed) {
-      localStorage.setItem("pwaInstallDismissed", "true");
-      sessionStorage.removeItem("pwaInstallDismissed");
-    }
     // Add keyboard event listener for Ctrl+B to toggle sidebar
     this.handleKeydown = (event) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'b') {
@@ -193,7 +186,6 @@ export default {
     dismissPwaInstall() {
       this.pwaInstallDismissed = true;
       localStorage.setItem("pwaInstallDismissed", "true");
-      sessionStorage.removeItem("pwaInstallDismissed");
     },
   },
 };

--- a/frontend/src/components/sidebar/Sidebar.vue
+++ b/frontend/src/components/sidebar/Sidebar.vue
@@ -57,12 +57,19 @@ export default {
       resizeStartX: 0,
       resizeStartWidth: 0,
       previousSidebarSize: null, // Remember the previous width when switching from desktop to mobile.
-      pwaInstallDismissed: sessionStorage.getItem("pwaInstallDismissed") === "true",
+      pwaInstallDismissed: false,
     };
   },
   mounted() {
     // Ensure the sidebar is initialized correctly
     mutations.setSeenUpdate(localStorage.getItem("seenUpdate"));
+    this.pwaInstallDismissed =
+      localStorage.getItem("pwaInstallDismissed") === "true" ||
+      sessionStorage.getItem("pwaInstallDismissed") === "true";
+    if (this.pwaInstallDismissed) {
+      localStorage.setItem("pwaInstallDismissed", "true");
+      sessionStorage.removeItem("pwaInstallDismissed");
+    }
     // Add keyboard event listener for Ctrl+B to toggle sidebar
     this.handleKeydown = (event) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'b') {
@@ -121,7 +128,7 @@ export default {
       );
     },
     showPwaInstall() {
-      return installAvailable.value && !this.pwaInstallDismissed && !this.isSettings;
+      return installAvailable.value && !this.pwaInstallDismissed && !this.isSettings && !globalVars.disablePWAInstall;
     },
   },
   methods: {
@@ -178,11 +185,15 @@ export default {
       mutations.setSeenUpdate(globalVars.updateAvailable);
     },
     async installPwa() {
-      await promptInstall();
+      const accepted = await promptInstall();
+      if (accepted) {
+        this.dismissPwaInstall();
+      }
     },
     dismissPwaInstall() {
       this.pwaInstallDismissed = true;
-      sessionStorage.setItem("pwaInstallDismissed", "true");
+      localStorage.setItem("pwaInstallDismissed", "true");
+      sessionStorage.removeItem("pwaInstallDismissed");
     },
   },
 };


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global option to disable the progressive web app installation button.
  - Installation prompts now remain dismissed across browser sessions.
  - The prompt is dismissed only after installation is accepted.

- **Bug Fixes**
  - Prevented the install-app message from reappearing after dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->