### PR TITLE
Add sorting to file destination picker

### DIFF
--- a/frontend/src/components/files/FileList.vue
+++ b/frontend/src/components/files/FileList.vue
@@ -24,56 +24,10 @@
     </div>
 
     <!-- Sortable Column Header (opt-in via sortable prop, e.g. destination pickers) -->
-    <div
+    <ListingHeader
       v-if="sortable && !loading"
-      class="listing-item-header card"
-      :class="{ 'dark-mode': isDarkMode, 'desktop-view': !isMobile }"
-    >
-      <p
-        :class="{ active: nameSorted }"
-        class="name"
-        role="button"
-        tabindex="0"
-        @click="sortColumn('name')"
-        @keydown.enter.prevent="sortColumn('name')"
-        @keydown.space.prevent="sortColumn('name')"
-        :title="$t('files.sortByName')"
-        :aria-label="$t('files.sortByName')"
-      >
-        <span>{{ $t("general.name") }}</span>
-        <i v-if="nameSorted" class="material-symbols">{{ nameIcon }}</i>
-      </p>
-
-      <p
-        :class="{ active: sizeSorted }"
-        class="size"
-        role="button"
-        tabindex="0"
-        @click="sortColumn('size')"
-        @keydown.enter.prevent="sortColumn('size')"
-        @keydown.space.prevent="sortColumn('size')"
-        :title="$t('files.sortBySize')"
-        :aria-label="$t('files.sortBySize')"
-      >
-        <i v-if="sizeSorted" class="material-symbols">{{ sizeIcon }}</i>
-        <span>{{ $t("general.size") }}</span>
-      </p>
-
-      <p
-        :class="{ active: modifiedSorted }"
-        class="modified"
-        role="button"
-        tabindex="0"
-        @click="sortColumn('modified')"
-        @keydown.enter.prevent="sortColumn('modified')"
-        @keydown.space.prevent="sortColumn('modified')"
-        :title="$t('files.sortByLastModified')"
-        :aria-label="$t('files.sortByLastModified')"
-      >
-        <i v-if="modifiedSorted" class="material-symbols">{{ modifiedIcon }}</i>
-        <span>{{ $t("files.lastModified") }}</span>
-      </p>
-    </div>
+      use-picker-sorting
+    />
 
     <!-- File List -->
     <div v-if="!loading" class="listing-items list">
@@ -109,6 +63,7 @@
 import { state, mutations, getters } from "@/store";
 import { url } from "@/utils";
 import { resourcesApi } from "@/api";
+import ListingHeader from "@/components/files/ListingHeader.vue";
 import ListingItem from "@/components/files/ListingItem.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import ExpandDropdown from "@/components/settings/ExpandDropdown.vue";
@@ -117,6 +72,7 @@ import { sortedItems } from "@/utils/sort.js";
 export default {
   name: "file-list",
   components: {
+    ListingHeader,
     ListingItem,
     LoadingSpinner,
     ExpandDropdown,
@@ -203,35 +159,9 @@ export default {
     };
   },
   computed: {
+    /** Sorting config used by sortEntries; follows the picker sort when sortable. */
     pickerSort() {
       return this.sortable ? getters.pickerSorting() : getters.sorting();
-    },
-    nameSorted() {
-      return this.pickerSort.by === "name";
-    },
-    sizeSorted() {
-      return this.pickerSort.by === "size";
-    },
-    modifiedSorted() {
-      return this.pickerSort.by === "modified";
-    },
-    nameIcon() {
-      if (this.nameSorted && !this.pickerSort.asc) {
-        return "arrow_upward";
-      }
-      return "arrow_downward";
-    },
-    sizeIcon() {
-      if (this.sizeSorted && this.pickerSort.asc) {
-        return "arrow_downward";
-      }
-      return "arrow_upward";
-    },
-    modifiedIcon() {
-      if (this.modifiedSorted && this.pickerSort.asc) {
-        return "arrow_downward";
-      }
-      return "arrow_upward";
     },
     isDarkMode() {
       return getters.isDarkMode();
@@ -282,6 +212,12 @@ export default {
     currentSource(newSource) {
       if (newSource && newSource !== this.source) {
         this.resetToSource(newSource);
+      }
+    },
+    // Re-sort local items when the picker header changes the sort config
+    pickerSort() {
+      if (this.sortable) {
+        this.resortItems();
       }
     },
   },
@@ -448,18 +384,6 @@ export default {
         ...sortedItems(dirs, sorting.by, sorting.asc),
         ...sortedItems(files, sorting.by, sorting.asc),
       ];
-    },
-    sortColumn(field) {
-      let asc = false;
-      if (
-        (field === "name" && this.nameIcon === "arrow_upward") ||
-        (field === "size" && this.sizeIcon === "arrow_upward") ||
-        (field === "modified" && this.modifiedIcon === "arrow_upward")
-      ) {
-        asc = true;
-      }
-      mutations.updatePickerSortConfig({ field, asc });
-      this.resortItems();
     },
     resortItems() {
       const parentEntry = this.items.find((item) => item.name === "..");
@@ -671,84 +595,6 @@ export default {
   align-items: center;
   justify-content: center;
   padding: 2em 0;
-}
-
-/* Sortable header (mirrors ListingHeader.vue styles) */
-.listing-item-header {
-  display: flex;
-  background: white;
-  border: 1px solid rgba(0, 0, 0, .1);
-  padding: .85em;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-left-radius: 1em;
-  border-top-right-radius: 1em;
-  margin-bottom: 0 !important;
-  justify-content: space-between;
-}
-
-.listing-item-header.dark-mode {
-  border-color: var(--divider) !important;
-  background: var(--surfacePrimary) !important;
-  user-select: none;
-}
-
-.listing-item-header p {
-  margin: 0;
-  cursor: pointer;
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  width: 100%;
-}
-
-.listing-item-header span {
-  vertical-align: middle;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
-
-.listing-item-header .name {
-  flex: 1;
-}
-
-.listing-item-header .size,
-.listing-item-header .modified {
-  flex: 1;
-  justify-content: flex-end;
-  text-align: end;
-}
-
-.listing-item-header.desktop-view .size {
-  width: 12%;
-  min-width: 80px;
-  flex: 0 0 auto;
-}
-
-.listing-item-header.desktop-view .modified {
-  width: 18%;
-  min-width: fit-content;
-  flex: 0 0 auto;
-}
-
-.listing-item-header i {
-  font-size: 1.5em;
-  vertical-align: middle;
-  margin-left: .2em;
-  opacity: 0;
-  transition: .1s ease all;
-  flex-shrink: 0;
-}
-
-.listing-item-header p:hover i,
-.listing-item-header .active i {
-  opacity: 1;
-}
-
-.listing-item-header .active {
-  font-weight: bold;
 }
 
 </style>

--- a/frontend/src/components/files/FileList.vue
+++ b/frontend/src/components/files/FileList.vue
@@ -23,8 +23,60 @@
       <LoadingSpinner size="small" mode="placeholder" />
     </div>
 
+    <!-- Sortable Column Header (opt-in via sortable prop, e.g. destination pickers) -->
+    <div
+      v-if="sortable && !loading"
+      class="listing-item-header card"
+      :class="{ 'dark-mode': isDarkMode, 'desktop-view': !isMobile }"
+    >
+      <p
+        :class="{ active: nameSorted }"
+        class="name"
+        role="button"
+        tabindex="0"
+        @click="sortColumn('name')"
+        @keydown.enter.prevent="sortColumn('name')"
+        @keydown.space.prevent="sortColumn('name')"
+        :title="$t('files.sortByName')"
+        :aria-label="$t('files.sortByName')"
+      >
+        <span>{{ $t("general.name") }}</span>
+        <i v-if="nameSorted" class="material-symbols">{{ nameIcon }}</i>
+      </p>
+
+      <p
+        :class="{ active: sizeSorted }"
+        class="size"
+        role="button"
+        tabindex="0"
+        @click="sortColumn('size')"
+        @keydown.enter.prevent="sortColumn('size')"
+        @keydown.space.prevent="sortColumn('size')"
+        :title="$t('files.sortBySize')"
+        :aria-label="$t('files.sortBySize')"
+      >
+        <i v-if="sizeSorted" class="material-symbols">{{ sizeIcon }}</i>
+        <span>{{ $t("general.size") }}</span>
+      </p>
+
+      <p
+        :class="{ active: modifiedSorted }"
+        class="modified"
+        role="button"
+        tabindex="0"
+        @click="sortColumn('modified')"
+        @keydown.enter.prevent="sortColumn('modified')"
+        @keydown.space.prevent="sortColumn('modified')"
+        :title="$t('files.sortByLastModified')"
+        :aria-label="$t('files.sortByLastModified')"
+      >
+        <i v-if="modifiedSorted" class="material-symbols">{{ modifiedIcon }}</i>
+        <span>{{ $t("files.lastModified") }}</span>
+      </p>
+    </div>
+
     <!-- File List -->
-    <div v-else class="listing-items list">
+    <div v-if="!loading" class="listing-items list">
       <ListingItem
         v-for="(item, index) in items"
         :key="item.path"
@@ -116,6 +168,11 @@ export default {
       type: Boolean,
       default: false, // If true, only files (not folders) can be selected
     },
+    /** When true, show a clickable Name/Size/Modified header that sorts the listing (uses pickerSorting). */
+    sortable: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: function () {
     const initialSource = this.browseSource || state.req.source;
@@ -146,6 +203,42 @@ export default {
     };
   },
   computed: {
+    pickerSort() {
+      return this.sortable ? getters.pickerSorting() : getters.sorting();
+    },
+    nameSorted() {
+      return this.pickerSort.by === "name";
+    },
+    sizeSorted() {
+      return this.pickerSort.by === "size";
+    },
+    modifiedSorted() {
+      return this.pickerSort.by === "modified";
+    },
+    nameIcon() {
+      if (this.nameSorted && !this.pickerSort.asc) {
+        return "arrow_upward";
+      }
+      return "arrow_downward";
+    },
+    sizeIcon() {
+      if (this.sizeSorted && this.pickerSort.asc) {
+        return "arrow_downward";
+      }
+      return "arrow_upward";
+    },
+    modifiedIcon() {
+      if (this.modifiedSorted && this.pickerSort.asc) {
+        return "arrow_downward";
+      }
+      return "arrow_upward";
+    },
+    isDarkMode() {
+      return getters.isDarkMode();
+    },
+    isMobile() {
+      return state.isMobile;
+    },
     sourcePath() {
       return { source: this.source, path: this.path };
     },
@@ -329,16 +422,13 @@ export default {
             source: item.source || req.source,
             type: item.type,
             pinned: !!item.pinned,
+            size: item.size,
+            modified: item.modified,
+            metadata: item.metadata,
             originalItem: item,
           });
         }
-        const sorting = getters.sorting();
-        const dirs = entries.filter((item) => item.type === "directory");
-        const files = entries.filter((item) => item.type !== "directory");
-        this.items = [
-          ...sortedItems(dirs, sorting.by, sorting.asc),
-          ...sortedItems(files, sorting.by, sorting.asc),
-        ];
+        this.items = this.sortEntries(entries);
       }
 
       if (this.path !== "/" && this.showFolders) {
@@ -349,6 +439,33 @@ export default {
           type: "directory",
         });
       }
+    },
+    sortEntries(entries) {
+      const sorting = this.pickerSort;
+      const dirs = entries.filter((item) => item.type === "directory");
+      const files = entries.filter((item) => item.type !== "directory");
+      return [
+        ...sortedItems(dirs, sorting.by, sorting.asc),
+        ...sortedItems(files, sorting.by, sorting.asc),
+      ];
+    },
+    sortColumn(field) {
+      let asc = false;
+      if (
+        (field === "name" && this.nameIcon === "arrow_upward") ||
+        (field === "size" && this.sizeIcon === "arrow_upward") ||
+        (field === "modified" && this.modifiedIcon === "arrow_upward")
+      ) {
+        asc = true;
+      }
+      mutations.updatePickerSortConfig({ field, asc });
+      this.resortItems();
+    },
+    resortItems() {
+      const parentEntry = this.items.find((item) => item.name === "..");
+      const rest = this.items.filter((item) => item.name !== "..");
+      const sorted = this.sortEntries(rest);
+      this.items = parentEntry ? [parentEntry, ...sorted] : sorted;
     },
     next: function (event) {
       // Retrieves the URL of the directory the user
@@ -554,6 +671,84 @@ export default {
   align-items: center;
   justify-content: center;
   padding: 2em 0;
+}
+
+/* Sortable header (mirrors ListingHeader.vue styles) */
+.listing-item-header {
+  display: flex;
+  background: white;
+  border: 1px solid rgba(0, 0, 0, .1);
+  padding: .85em;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-left-radius: 1em;
+  border-top-right-radius: 1em;
+  margin-bottom: 0 !important;
+  justify-content: space-between;
+}
+
+.listing-item-header.dark-mode {
+  border-color: var(--divider) !important;
+  background: var(--surfacePrimary) !important;
+  user-select: none;
+}
+
+.listing-item-header p {
+  margin: 0;
+  cursor: pointer;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.listing-item-header span {
+  vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.listing-item-header .name {
+  flex: 1;
+}
+
+.listing-item-header .size,
+.listing-item-header .modified {
+  flex: 1;
+  justify-content: flex-end;
+  text-align: end;
+}
+
+.listing-item-header.desktop-view .size {
+  width: 12%;
+  min-width: 80px;
+  flex: 0 0 auto;
+}
+
+.listing-item-header.desktop-view .modified {
+  width: 18%;
+  min-width: 110px;
+  flex: 0 0 auto;
+}
+
+.listing-item-header i {
+  font-size: 1.5em;
+  vertical-align: middle;
+  margin-left: .2em;
+  opacity: 0;
+  transition: .1s ease all;
+  flex-shrink: 0;
+}
+
+.listing-item-header p:hover i,
+.listing-item-header .active i {
+  opacity: 1;
+}
+
+.listing-item-header .active {
+  font-weight: bold;
 }
 
 </style>

--- a/frontend/src/components/files/FileList.vue
+++ b/frontend/src/components/files/FileList.vue
@@ -729,7 +729,7 @@ export default {
 
 .listing-item-header.desktop-view .modified {
   width: 18%;
-  min-width: 110px;
+  min-width: fit-content;
   flex: 0 0 auto;
 }
 

--- a/frontend/src/components/files/ListingHeader.vue
+++ b/frontend/src/components/files/ListingHeader.vue
@@ -74,6 +74,11 @@ export default {
       type: Boolean,
       default: false,
     },
+    /** When true, sort via pickerSorting (destination pickers) instead of the main listing sort. */
+    usePickerSorting: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     isMobile() {
@@ -82,20 +87,23 @@ export default {
     isDarkMode() {
       return getters.isDarkMode();
     },
+    sortConfig() {
+      return this.usePickerSorting ? getters.pickerSorting() : getters.sorting();
+    },
     nameSorted() {
-      return getters.sorting().by === "name";
+      return this.sortConfig.by === "name";
     },
     sizeSorted() {
-      return getters.sorting().by === "size";
+      return this.sortConfig.by === "size";
     },
     modifiedSorted() {
-      return getters.sorting().by === "modified";
+      return this.sortConfig.by === "modified";
     },
     durationSorted() {
-      return getters.sorting().by === "duration";
+      return this.sortConfig.by === "duration";
     },
     ascOrdered() {
-      return getters.sorting().asc;
+      return this.sortConfig.asc;
     },
     galleryView() {
       return getters.viewMode() === "gallery";
@@ -125,6 +133,9 @@ export default {
       return "arrow_upward";
     },
     quickDownloadEnabled() {
+      if (this.usePickerSorting) {
+        return false;
+      }
       if (state.isMobile) {
         return false
       }
@@ -146,6 +157,10 @@ export default {
         asc = true;
       }
       // Commit the updateSort mutation
+      if (this.usePickerSorting) {
+        mutations.updatePickerSortConfig({ field, asc });
+        return;
+      }
       mutations.updateListingSortConfig({ field, asc });
       mutations.updateListingItems();
     },
@@ -206,7 +221,7 @@ span {
 
 .desktop-view .modified {
   width: 18%;
-  min-width: 110px;
+  min-width: fit-content;
   flex: 0 0 auto;
   justify-content: flex-end;
   text-align: right;

--- a/frontend/src/components/files/ListingHeader.vue
+++ b/frontend/src/components/files/ListingHeader.vue
@@ -6,6 +6,8 @@
       role="button"
       tabindex="0"
       @click="sort('name')"
+      @keydown.enter.prevent="sort('name')"
+      @keydown.space.prevent="sort('name')"
       :title="$t('files.sortByName')"
       :aria-label="$t('files.sortByName')"
     >
@@ -19,6 +21,8 @@
       role="button"
       tabindex="0"
       @click="sort('size')"
+      @keydown.enter.prevent="sort('size')"
+      @keydown.space.prevent="sort('size')"
       :title="$t('files.sortBySize')"
       :aria-label="$t('files.sortBySize')"
     >
@@ -32,6 +36,8 @@
       role="button"
       tabindex="0"
       @click="sort('modified')"
+      @keydown.enter.prevent="sort('modified')"
+      @keydown.space.prevent="sort('modified')"
       :title="$t('files.sortByLastModified')"
       :aria-label="$t('files.sortByLastModified')"
     >
@@ -46,6 +52,8 @@
       role="button"
       tabindex="0"
       @click="sort('duration')"
+      @keydown.enter.prevent="sort('duration')"
+      @keydown.space.prevent="sort('duration')"
       :title="$t('files.sortByDuration')"
       :aria-label="$t('files.sortByDuration')"
     >

--- a/frontend/src/components/prompts/Archive.vue
+++ b/frontend/src/components/prompts/Archive.vue
@@ -11,6 +11,7 @@
           :browse-path="currentPath"
           :show-folders="true"
           :show-files="false"
+          :sortable="true"
           @update:selected="updateDestination"
         />
       </template>

--- a/frontend/src/components/prompts/MoveCopy.vue
+++ b/frontend/src/components/prompts/MoveCopy.vue
@@ -20,6 +20,7 @@
       <file-list
         ref="fileList"
         :hide-path-chrome="!isShareContext"
+        :sortable="true"
         @update:selected="updateDestination"
       >
       </file-list>

--- a/frontend/src/components/prompts/Unarchive.vue
+++ b/frontend/src/components/prompts/Unarchive.vue
@@ -12,6 +12,7 @@
           :browse-source="itemSource"
           :show-folders="true"
           :show-files="false"
+          :sortable="true"
           @update:selected="updateDestination"
         />
       </template>

--- a/frontend/src/store/getters.ts
+++ b/frontend/src/store/getters.ts
@@ -112,7 +112,7 @@ export const getters = {
   },
   /** Sort config for destination picker dialogs (copy/move/archive), independent of the main listing sort. */
   pickerSorting: () => {
-    return state.pickerSorting || getters.sorting() || { by: "name", asc: true };
+    return state.pickerSorting || { by: "name", asc: true };
   },
   previewType: () => getTypeInfo(state.req.type).simpleType,
   /** Audio/video preview uses folder listing nav links unless a multi-item playback queue is active. */

--- a/frontend/src/store/getters.ts
+++ b/frontend/src/store/getters.ts
@@ -110,6 +110,10 @@ export const getters = {
   sorting: () => {
     return getters.displayPreference()?.sorting || state.user?.sorting || { by: "name", asc: true };
   },
+  /** Sort config for destination picker dialogs (copy/move/archive), independent of the main listing sort. */
+  pickerSorting: () => {
+    return state.pickerSorting || getters.sorting() || { by: "name", asc: true };
+  },
   previewType: () => getTypeInfo(state.req.type).simpleType,
   /** Audio/video preview uses folder listing nav links unless a multi-item playback queue is active. */
   isPreviewPlaybackQueueNavMode: () => {

--- a/frontend/src/store/mutations.ts
+++ b/frontend/src/store/mutations.ts
@@ -800,8 +800,9 @@ export const mutations = {
     state.pickerSorting = { by: field, asc };
     try {
       localStorage.setItem("pickerSorting", JSON.stringify(state.pickerSorting));
-    } catch (_error) {
-      // ignore storage errors (e.g. private mode)
+    } catch (error) {
+      // localStorage can throw in private mode; log but don't block sorting
+      console.error('Failed to save picker sorting:', error);
     }
     emitStateChanged();
   },

--- a/frontend/src/store/mutations.ts
+++ b/frontend/src/store/mutations.ts
@@ -796,6 +796,15 @@ export const mutations = {
     mutations.updateDisplayPreferences({ sorting: { by: field, asc: asc } });
     emitStateChanged();
   },
+  updatePickerSortConfig: ({ field, asc }) => {
+    state.pickerSorting = { by: field, asc };
+    try {
+      localStorage.setItem("pickerSorting", JSON.stringify(state.pickerSorting));
+    } catch (_error) {
+      // ignore storage errors (e.g. private mode)
+    }
+    emitStateChanged();
+  },
   updateListingItems: () => {
     mutations.replaceRequest(state.req);
     emitStateChanged();

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -238,7 +238,9 @@ function loadPickerSorting() {
     ) {
       return { by: parsed.by, asc: parsed.asc };
     }
-  } catch (_) { /* ignore */ }
+  } catch (error) {
+    console.error('Failed to load picker sorting:', error);
+  }
   return null;
 }
 

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -105,6 +105,7 @@ export const state: StoreState = reactive({
   },
   previewRaw: "",
   oldReq: {},
+  pickerSorting: loadPickerSorting(),
   clipboard: {
     key: "",
     items: [],
@@ -219,6 +220,26 @@ function stickyStartup() {
 function eventTheme() {
   const disableEventThemes = localStorage.getItem("disableEventThemes");
   return disableEventThemes === "true"
+}
+
+/**
+ * Loads the destination picker sort preference from localStorage.
+ * @returns {{ by: string, asc: boolean } | null} The saved sort config, or null if unset/invalid
+ */
+function loadPickerSorting() {
+  try {
+    const stored = localStorage.getItem("pickerSorting");
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    if (
+      parsed &&
+      ["name", "size", "modified"].includes(parsed.by) &&
+      typeof parsed.asc === "boolean"
+    ) {
+      return { by: parsed.by, asc: parsed.asc };
+    }
+  } catch (_) { /* ignore */ }
+  return null;
 }
 
 /**

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -304,6 +304,11 @@ export interface StoreState {
   };
   previewRaw: string;
   oldReq: unknown;
+  /** Sort config for destination picker dialogs (copy/move/archive). Independent of the main listing sort. */
+  pickerSorting: {
+    by: string;
+    asc: boolean;
+  } | null;
   clipboard: {
     key: string;
     items: unknown[];

--- a/frontend/tests/playwright/general/file-actions.spec.ts
+++ b/frontend/tests/playwright/general/file-actions.spec.ts
@@ -175,3 +175,52 @@ test("delete nested file prompt", async({ page, checkForErrors }) => {
   await expect(page.locator('.card-content')).toContainText('/folder#hash/file#.sh');
   checkForErrors();
 })
+
+test("copy destination dialog is sortable and remembers sort order", async ({ page, checkForErrors }) => {
+  await page.goto("/files/");
+  await expect(page).toHaveTitle("Graham's Filebrowser - Files - playwright-files");
+  await page.locator('a[aria-label="copyme.txt"]').waitFor({ state: 'visible' });
+  await page.locator('a[aria-label="copyme.txt"]').click({ button: "right" });
+  await page.locator('.selected-count-header').waitFor({ state: 'visible' });
+  await page.locator('button[aria-label="Copy file"]').click();
+
+  const copyPrompt = page.locator('div[aria-label="copy-prompt"]');
+  const header = copyPrompt.locator('.listing-item-header');
+  const firstItem = () => copyPrompt.locator('.listing-item').first();
+
+  await expect(copyPrompt).toBeVisible();
+  await expect(header).toBeVisible();
+  await expect(header.locator('.name')).toBeVisible();
+  await expect(header.locator('.size')).toBeVisible();
+  await expect(header.locator('.modified')).toBeVisible();
+
+  // Default sort is name ascending, so the first folder is "denied"
+  await expect(firstItem()).toHaveAttribute("aria-label", "denied");
+
+  // Click the Name column header to sort descending
+  await header.locator('.name').click();
+  await expect(firstItem()).toHaveAttribute("aria-label", "text-files");
+  await expect(header.locator('.name')).toHaveClass(/active/);
+
+  // Close and reopen the dialog: the sort order is remembered in-session
+  await copyPrompt.locator('.prompt-close').click();
+  await page.locator('a[aria-label="copyme.txt"]').click({ button: "right" });
+  await page.locator('button[aria-label="Copy file"]').click();
+  await expect(copyPrompt).toBeVisible();
+  await expect(firstItem()).toHaveAttribute("aria-label", "text-files");
+
+  // Reload the page: the sort order is persisted in localStorage
+  await page.reload();
+  await page.locator('a[aria-label="copyme.txt"]').waitFor({ state: 'visible' });
+  await page.locator('a[aria-label="copyme.txt"]').click({ button: "right" });
+  await page.locator('.selected-count-header').waitFor({ state: 'visible' });
+  await page.locator('button[aria-label="Copy file"]').click();
+  await expect(copyPrompt).toBeVisible();
+  await expect(firstItem()).toHaveAttribute("aria-label", "text-files");
+
+  // Sorting by Size also works and toggles the active column
+  await copyPrompt.locator('.listing-item-header .size').click();
+  await expect(copyPrompt.locator('.listing-item-header .size')).toHaveClass(/active/);
+  await expect(copyPrompt.locator('.listing-item-header .name')).not.toHaveClass(/active/);
+  checkForErrors();
+})


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [x] A clear description of why it was opened. - Closes https://github.com/gtsteffaniak/filebrowser/issues/2684
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR - Added new playwright test. It and all existing test pass.
- [x] Any additional details for functionality not covered by tests - N/A

**Additional Details**
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sortable Name, Size, and Modified columns to file-selection dialogs.
  * Sorting preferences are remembered when dialogs reopen and persist after page reloads.
  * Sorting in selection dialogs is now independent of the main file listing.
* **Bug Fixes**
  * Improved sorting behavior across copy, move, archive, and unarchive workflows.
  * Refined column layout for better visibility of modified dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->