### PR TITLE
feat: Add Format JSON feature to Editor toolbar

### DIFF
--- a/frontend/src/components/files/EditorToolbar.vue
+++ b/frontend/src/components/files/EditorToolbar.vue
@@ -352,11 +352,12 @@ export default {
       const editor = this.editor;
       if (!editor) return;
       try {
-        const parsed = JSON.parse(editor.getValue());
+        const textToFormat = editor.getValue();
+        const parsed = JSON.parse(textToFormat);
         const next = state.editor.jsonFormatted
           ? JSON.stringify(parsed)
           : JSON.stringify(parsed, null, 2);
-        editor.setValue(next, -1);
+        if (next !== textToFormat) editor.setValue(next, -1);
         mutations.setEditorJsonFormatted(!state.editor.jsonFormatted);
         notify.showSuccessToast(this.$t("general.formatJSONSuccess"));
       } catch (e) {

--- a/frontend/src/components/files/EditorToolbar.vue
+++ b/frontend/src/components/files/EditorToolbar.vue
@@ -140,6 +140,7 @@ import { eventBus } from "@/store/eventBus";
 import { removeLastDir } from "@/utils/url.js";
 import { expandBeforeEnter, expandEnter, expandLeave } from "@/utils/expandTransition";
 import { copyToClipboard } from "@/utils/clipboard.js";
+import { notify } from "@/notify";
 
 interface AnchorRange {
   start: Ace.Anchor;
@@ -250,12 +251,12 @@ export default {
         { id: "redo", icon: "redo", title: this.$t("editor.md.redo"), action: () => this.redo(), disabled: !this.canRedo, sticky: true },
         { id: "find", icon: "search", title: this.$t("general.search"), action: () => this.openFind() },
       ];
-      const isJson = state.req?.name?.toLowerCase().endsWith('.json');
+      const isJson = state.req.type === "application/json"
       if (isJson && getters.sourcePermissions().modify) {
         alwaysAvailable.push({
-          id: "formatJSON", 
-          icon: "data_object", 
-          title: this.$t("general.formatJSON"), 
+          id: "formatJSON",
+          icon: "data_object",
+          title: this.$t("general.formatJSON"),
           action: () => this.formatJSON(),
         });
       }
@@ -347,10 +348,21 @@ export default {
     focusEditor() {
       if (this.editor) this.editor.focus();
     },
-    async formatJSON() {
-      if (state.editor.formatJSONHandler) {
-        await state.editor.formatJSONHandler();
+    formatJSON() {
+      const editor = this.editor;
+      if (!editor) return;
+      try {
+        const parsed = JSON.parse(editor.getValue());
+        const next = state.editor.jsonFormatted
+          ? JSON.stringify(parsed)
+          : JSON.stringify(parsed, null, 2);
+        editor.setValue(next, -1);
+        mutations.setEditorJsonFormatted(!state.editor.jsonFormatted);
+        notify.showSuccessToast(this.$t("general.formatJSONSuccess"));
+      } catch (e) {
+        notify.showErrorToast(this.$t("general.invalidJSON", { message: e instanceof Error ? e.message : String(e) }));
       }
+      this.focusEditor();
     },
     undo() {
       const editor = this.editor;

--- a/frontend/src/components/files/EditorToolbar.vue
+++ b/frontend/src/components/files/EditorToolbar.vue
@@ -256,7 +256,7 @@ export default {
         alwaysAvailable.push({
           id: "formatJSON",
           icon: "data_object",
-          title: this.$t("general.formatJSON"),
+          title: this.$t("editor.json.formatJSON"),
           action: () => this.formatJSON(),
         });
       }
@@ -359,9 +359,9 @@ export default {
           : JSON.stringify(parsed, null, 2);
         if (next !== textToFormat) editor.setValue(next, -1);
         mutations.setEditorJsonFormatted(!state.editor.jsonFormatted);
-        notify.showSuccessToast(this.$t("general.formatJSONSuccess"));
+        notify.showSuccessToast(this.$t("editor.json.formatJSONSuccess"));
       } catch (e) {
-        notify.showErrorToast(this.$t("general.invalidJSON", { message: e instanceof Error ? e.message : String(e) }));
+        notify.showErrorToast(this.$t("editor.json.invalidJSON", { message: e instanceof Error ? e.message : String(e) }));
       }
       this.focusEditor();
     },

--- a/frontend/src/components/files/EditorToolbar.vue
+++ b/frontend/src/components/files/EditorToolbar.vue
@@ -250,6 +250,15 @@ export default {
         { id: "redo", icon: "redo", title: this.$t("editor.md.redo"), action: () => this.redo(), disabled: !this.canRedo, sticky: true },
         { id: "find", icon: "search", title: this.$t("general.search"), action: () => this.openFind() },
       ];
+      const isJson = state.req?.name?.toLowerCase().endsWith('.json');
+      if (isJson && getters.sourcePermissions().modify) {
+        alwaysAvailable.push({
+          id: "formatJSON", 
+          icon: "data_object", 
+          title: this.$t("general.formatJSON"), 
+          action: () => this.formatJSON(),
+        });
+      }
       if (!this.isMarkdown) {
         return [
           ...alwaysAvailable,
@@ -337,6 +346,11 @@ export default {
     expandLeave,
     focusEditor() {
       if (this.editor) this.editor.focus();
+    },
+    async formatJSON() {
+      if (state.editor.formatJSONHandler) {
+        await state.editor.formatJSONHandler();
+      }
     },
     undo() {
       const editor = this.editor;

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -614,10 +614,7 @@
     "limit": "الحد الأقصى{suffix}",
     "remove": "إزالة{suffix}",
     "saved": "تم الحفظ{suffix}",
-    "removed": "تم حذفه{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "تم حذفه{suffix}"
   },
   "access": {
     "rules": "قواعد الوصول",
@@ -813,6 +810,11 @@
       "alignCenter": "محاذاة إلى المنتصف",
       "justify": "ضبط",
       "fontColor": "لون الخط"
+    },
+    "json": {
+      "formatJSON": "تنسيق JSON",
+      "formatJSONSuccess": "تم تنسيق JSON بنجاح",
+      "invalidJSON": "JSON غير صالح: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -614,7 +614,10 @@
     "limit": "الحد الأقصى{suffix}",
     "remove": "إزالة{suffix}",
     "saved": "تم الحفظ{suffix}",
-    "removed": "تم حذفه{suffix}"
+    "removed": "تم حذفه{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "قواعد الوصول",

--- a/frontend/src/i18n/bg.json
+++ b/frontend/src/i18n/bg.json
@@ -167,7 +167,10 @@
     "limit": "Лимит{suffix}",
     "remove": "Премахни{suffix}",
     "saved": "Запазено{suffix}",
-    "removed": "Премахнато{suffix}"
+    "removed": "Премахнато{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "buttons": {
     "copySuccess": "Копирано в клипборда!",

--- a/frontend/src/i18n/bg.json
+++ b/frontend/src/i18n/bg.json
@@ -167,10 +167,7 @@
     "limit": "Лимит{suffix}",
     "remove": "Премахни{suffix}",
     "saved": "Запазено{suffix}",
-    "removed": "Премахнато{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Премахнато{suffix}"
   },
   "buttons": {
     "copySuccess": "Копирано в клипборда!",
@@ -833,6 +830,11 @@
       "alignCenter": "Центриране",
       "justify": "Двустранно подравняване",
       "fontColor": "Цвят на шрифта"
+    },
+    "json": {
+      "formatJSON": "Формат JSON",
+      "formatJSONSuccess": "Форматирането в JSON беше успешно",
+      "invalidJSON": "Невалиден JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/cz.json
+++ b/frontend/src/i18n/cz.json
@@ -710,10 +710,7 @@
     "limit": "Limit{suffix}",
     "remove": "Odstranit{suffix}",
     "saved": "Uloženo{suffix}",
-    "removed": "Odstraněno{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Odstraněno{suffix}"
   },
   "access": {
     "rules": "Pravidla přístupu",
@@ -813,6 +810,11 @@
       "alignCenter": "Zarovnat na střed",
       "justify": "Zarovnat do bloku",
       "fontColor": "Barva písma"
+    },
+    "json": {
+      "formatJSON": "Formát JSON",
+      "formatJSONSuccess": "Formátování do JSON proběhlo úspěšně",
+      "invalidJSON": "Neplatný JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/cz.json
+++ b/frontend/src/i18n/cz.json
@@ -710,7 +710,10 @@
     "limit": "Limit{suffix}",
     "remove": "Odstranit{suffix}",
     "saved": "Uloženo{suffix}",
-    "removed": "Odstraněno{suffix}"
+    "removed": "Odstraněno{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Pravidla přístupu",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -614,7 +614,10 @@
     "limit": "Grenzwert{suffix}",
     "remove": "Entfernen{suffix}",
     "saved": "Gespeichert{suffix}",
-    "removed": "Entfernt{suffix}"
+    "removed": "Entfernt{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Zugangsregeln",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -614,10 +614,7 @@
     "limit": "Grenzwert{suffix}",
     "remove": "Entfernen{suffix}",
     "saved": "Gespeichert{suffix}",
-    "removed": "Entfernt{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Entfernt{suffix}"
   },
   "access": {
     "rules": "Zugangsregeln",
@@ -813,6 +810,11 @@
       "alignCenter": "Zentrieren",
       "justify": "Blocksatz",
       "fontColor": "Schriftfarbe"
+    },
+    "json": {
+      "formatJSON": "JSON-Format",
+      "formatJSONSuccess": "JSON wurde erfolgreich formatiert",
+      "invalidJSON": "Ungültiges JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -614,7 +614,10 @@
     "limit": "Όριο{suffix}",
     "remove": "Κατάργηση{suffix}",
     "saved": "Αποθηκεύτηκε{suffix}",
-    "removed": "Διαγράφηκε{suffix}"
+    "removed": "Διαγράφηκε{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Κανόνες πρόσβασης",

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -614,10 +614,7 @@
     "limit": "Όριο{suffix}",
     "remove": "Κατάργηση{suffix}",
     "saved": "Αποθηκεύτηκε{suffix}",
-    "removed": "Διαγράφηκε{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Διαγράφηκε{suffix}"
   },
   "access": {
     "rules": "Κανόνες πρόσβασης",
@@ -813,6 +810,11 @@
       "alignCenter": "Στοίχιση στο κέντρο",
       "justify": "Πλήρης στοίχιση",
       "fontColor": "Χρώμα γραμματοσειράς"
+    },
+    "json": {
+      "formatJSON": "Μορφή JSON",
+      "formatJSONSuccess": "Η μορφοποίηση σε JSON ολοκληρώθηκε με επιτυχία",
+      "invalidJSON": "Μη έγκυρο JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -167,10 +167,7 @@
     "clearSelection": "Clear selection",
     "interval": "Interval{suffix}",
     "none": "None",
-    "enforce": "Enforce{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "enforce": "Enforce{suffix}"
   },
   "buttons": {
     "copySuccess": "Copied to clipboard!",
@@ -853,6 +850,11 @@
       "alignCenter": "Align center",
       "justify": "Justify",
       "fontColor": "Font color"
+    },
+    "json": {
+      "formatJSON": "Format JSON",
+      "formatJSONSuccess": "JSON formatted successfully",
+      "invalidJSON": "Invalid JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -167,7 +167,10 @@
     "clearSelection": "Clear selection",
     "interval": "Interval{suffix}",
     "none": "None",
-    "enforce": "Enforce{suffix}"
+    "enforce": "Enforce{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "buttons": {
     "copySuccess": "Copied to clipboard!",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -614,10 +614,7 @@
     "limit": "Límite{suffix}",
     "remove": "Eliminar{suffix}",
     "saved": "Guardado{suffix}",
-    "removed": "Eliminado{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Eliminado{suffix}"
   },
   "access": {
     "rules": "Reglas de acceso",
@@ -813,6 +810,11 @@
       "alignCenter": "Alinear al centro",
       "justify": "Justificar",
       "fontColor": "Color de fuente"
+    },
+    "json": {
+      "formatJSON": "Formato JSON",
+      "formatJSONSuccess": "El formato JSON se ha generado correctamente",
+      "invalidJSON": "JSON no válido: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -614,7 +614,10 @@
     "limit": "Límite{suffix}",
     "remove": "Eliminar{suffix}",
     "saved": "Guardado{suffix}",
-    "removed": "Eliminado{suffix}"
+    "removed": "Eliminado{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Reglas de acceso",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -614,7 +614,10 @@
     "limit": "Limite{suffix}",
     "remove": "Supprimer{suffix}",
     "saved": "Enregistré{suffix}",
-    "removed": "Supprimé{suffix}"
+    "removed": "Supprimé{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Règles d'accès",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -614,10 +614,7 @@
     "limit": "Limite{suffix}",
     "remove": "Supprimer{suffix}",
     "saved": "Enregistré{suffix}",
-    "removed": "Supprimé{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Supprimé{suffix}"
   },
   "access": {
     "rules": "Règles d'accès",
@@ -813,6 +810,11 @@
       "alignCenter": "Centrer",
       "justify": "Justifier",
       "fontColor": "Couleur de la police"
+    },
+    "json": {
+      "formatJSON": "Format JSON",
+      "formatJSONSuccess": "Le formatage JSON s'est déroulé avec succès",
+      "invalidJSON": "JSON non valide : {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -614,10 +614,7 @@
     "limit": "גבול{suffix}",
     "remove": "הסר{suffix}",
     "saved": "נשמר{suffix}",
-    "removed": "הוסר{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "הוסר{suffix}"
   },
   "access": {
     "rules": "כללי גישה",
@@ -813,6 +810,11 @@
       "alignCenter": "יישור למרכז",
       "justify": "יישור דו-צדדי",
       "fontColor": "צבע גופן"
+    },
+    "json": {
+      "formatJSON": "פורמט JSON",
+      "formatJSONSuccess": "הפורמט JSON הומר בהצלחה",
+      "invalidJSON": "JSON לא תקין: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -614,7 +614,10 @@
     "limit": "גבול{suffix}",
     "remove": "הסר{suffix}",
     "saved": "נשמר{suffix}",
-    "removed": "הוסר{suffix}"
+    "removed": "הוסר{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "כללי גישה",

--- a/frontend/src/i18n/hu.json
+++ b/frontend/src/i18n/hu.json
@@ -614,7 +614,10 @@
     "limit": "Határ{suffix}",
     "remove": "Eltávolítás{suffix}",
     "saved": "Elmentve{suffix}",
-    "removed": "Eltávolítva{suffix}"
+    "removed": "Eltávolítva{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Hozzáférési szabályok",

--- a/frontend/src/i18n/hu.json
+++ b/frontend/src/i18n/hu.json
@@ -614,10 +614,7 @@
     "limit": "Határ{suffix}",
     "remove": "Eltávolítás{suffix}",
     "saved": "Elmentve{suffix}",
-    "removed": "Eltávolítva{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Eltávolítva{suffix}"
   },
   "access": {
     "rules": "Hozzáférési szabályok",
@@ -813,6 +810,11 @@
       "alignCenter": "Középre igazítás",
       "justify": "Sorkizárt",
       "fontColor": "Betűszín"
+    },
+    "json": {
+      "formatJSON": "JSON formázása",
+      "formatJSONSuccess": "A JSON formázása sikeresen megtörtént",
+      "invalidJSON": "Érvénytelen JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/it.json
+++ b/frontend/src/i18n/it.json
@@ -167,10 +167,7 @@
     "limit": "Limite{suffix}",
     "remove": "Rimuovi{suffix}",
     "saved": "Salvato{suffix}",
-    "removed": "Rimosso{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Rimosso{suffix}"
   },
   "buttons": {
     "copySuccess": "Copiato negli appunti!",
@@ -822,6 +819,11 @@
       "alignCenter": "Allinea al centro",
       "justify": "Giustifica",
       "fontColor": "Colore del carattere"
+    },
+    "json": {
+      "formatJSON": "Formato JSON",
+      "formatJSONSuccess": "Formattazione JSON completata con successo",
+      "invalidJSON": "JSON non valido: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/it.json
+++ b/frontend/src/i18n/it.json
@@ -167,7 +167,10 @@
     "limit": "Limite{suffix}",
     "remove": "Rimuovi{suffix}",
     "saved": "Salvato{suffix}",
-    "removed": "Rimosso{suffix}"
+    "removed": "Rimosso{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "buttons": {
     "copySuccess": "Copiato negli appunti!",

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -614,10 +614,7 @@
     "limit": "上限{suffix}",
     "remove": "削除{suffix}",
     "saved": "保存済み{suffix}",
-    "removed": "削除済み{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "削除済み{suffix}"
   },
   "access": {
     "rules": "アクセスルール",
@@ -813,6 +810,11 @@
       "alignCenter": "中央揃え",
       "justify": "両端揃え",
       "fontColor": "フォントの色"
+    },
+    "json": {
+      "formatJSON": "JSON形式",
+      "formatJSONSuccess": "JSON形式への変換に成功しました",
+      "invalidJSON": "無効なJSON：{message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -614,7 +614,10 @@
     "limit": "上限{suffix}",
     "remove": "削除{suffix}",
     "saved": "保存済み{suffix}",
-    "removed": "削除済み{suffix}"
+    "removed": "削除済み{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "アクセスルール",

--- a/frontend/src/i18n/ko.json
+++ b/frontend/src/i18n/ko.json
@@ -614,10 +614,7 @@
     "limit": "한도{suffix}",
     "remove": "제거{suffix}",
     "saved": "저장됨{suffix}",
-    "removed": "삭제됨{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "삭제됨{suffix}"
   },
   "access": {
     "rules": "액세스 규칙",
@@ -813,6 +810,11 @@
       "alignCenter": "가운데 정렬",
       "justify": "양쪽 정렬",
       "fontColor": "글꼴 색상"
+    },
+    "json": {
+      "formatJSON": "JSON 형식",
+      "formatJSONSuccess": "JSON 형식으로 성공적으로 변환되었습니다.",
+      "invalidJSON": "잘못된 JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/ko.json
+++ b/frontend/src/i18n/ko.json
@@ -614,7 +614,10 @@
     "limit": "한도{suffix}",
     "remove": "제거{suffix}",
     "saved": "저장됨{suffix}",
-    "removed": "삭제됨{suffix}"
+    "removed": "삭제됨{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "액세스 규칙",

--- a/frontend/src/i18n/nl-be.json
+++ b/frontend/src/i18n/nl-be.json
@@ -710,10 +710,7 @@
     "limit": "Limiet{suffix}",
     "remove": "Verwijderen{suffix}",
     "saved": "Opgeslagen{suffix}",
-    "removed": "Verwijderd{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Verwijderd{suffix}"
   },
   "access": {
     "rules": "Toegangsregels",
@@ -813,6 +810,11 @@
       "alignCenter": "Centreren",
       "justify": "Uitvullen",
       "fontColor": "Letterkleur"
+    },
+    "json": {
+      "formatJSON": "JSON-formaat",
+      "formatJSONSuccess": "JSON succesvol opgemaakt",
+      "invalidJSON": "Ongeldige JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/nl-be.json
+++ b/frontend/src/i18n/nl-be.json
@@ -710,7 +710,10 @@
     "limit": "Limiet{suffix}",
     "remove": "Verwijderen{suffix}",
     "saved": "Opgeslagen{suffix}",
-    "removed": "Verwijderd{suffix}"
+    "removed": "Verwijderd{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Toegangsregels",

--- a/frontend/src/i18n/nl.json
+++ b/frontend/src/i18n/nl.json
@@ -167,7 +167,10 @@
     "limit": "Limiet{suffix}",
     "remove": "Verwijderen{suffix}",
     "saved": "Opgeslagen{suffix}",
-    "removed": "Verwijderd{suffix}"
+    "removed": "Verwijderd{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "buttons": {
     "copySuccess": "Gekopieerd naar klembord!",

--- a/frontend/src/i18n/nl.json
+++ b/frontend/src/i18n/nl.json
@@ -167,10 +167,7 @@
     "limit": "Limiet{suffix}",
     "remove": "Verwijderen{suffix}",
     "saved": "Opgeslagen{suffix}",
-    "removed": "Verwijderd{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Verwijderd{suffix}"
   },
   "buttons": {
     "copySuccess": "Gekopieerd naar klembord!",
@@ -822,6 +819,11 @@
       "alignCenter": "Centreren",
       "justify": "Uitvullen",
       "fontColor": "Letterkleur"
+    },
+    "json": {
+      "formatJSON": "JSON-formaat",
+      "formatJSONSuccess": "JSON is succesvol opgemaakt",
+      "invalidJSON": "Ongeldige JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/pl.json
+++ b/frontend/src/i18n/pl.json
@@ -614,10 +614,7 @@
     "limit": "Limit{suffix}",
     "remove": "Usuń{suffix}",
     "saved": "Zapisano{suffix}",
-    "removed": "Usunięto{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Usunięto{suffix}"
   },
   "access": {
     "rules": "Zasady dostępu",
@@ -813,6 +810,11 @@
       "alignCenter": "Wyśrodkuj",
       "justify": "Wyjustuj",
       "fontColor": "Kolor czcionki"
+    },
+    "json": {
+      "formatJSON": "Format JSON",
+      "formatJSONSuccess": "Formatowanie JSON przebiegło pomyślnie",
+      "invalidJSON": "Nieprawidłowy plik JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/pl.json
+++ b/frontend/src/i18n/pl.json
@@ -614,7 +614,10 @@
     "limit": "Limit{suffix}",
     "remove": "Usuń{suffix}",
     "saved": "Zapisano{suffix}",
-    "removed": "Usunięto{suffix}"
+    "removed": "Usunięto{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Zasady dostępu",

--- a/frontend/src/i18n/pt-br.json
+++ b/frontend/src/i18n/pt-br.json
@@ -614,10 +614,7 @@
     "limit": "Limite{suffix}",
     "remove": "Remover{suffix}",
     "saved": "Salvo{suffix}",
-    "removed": "Removido{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Removido{suffix}"
   },
   "access": {
     "rules": "Regras de acesso",
@@ -813,6 +810,11 @@
       "alignCenter": "Alinhar ao centro",
       "justify": "Justificar",
       "fontColor": "Cor da fonte"
+    },
+    "json": {
+      "formatJSON": "Formato JSON",
+      "formatJSONSuccess": "Formatação em JSON concluída com sucesso",
+      "invalidJSON": "JSON inválido: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/pt-br.json
+++ b/frontend/src/i18n/pt-br.json
@@ -614,7 +614,10 @@
     "limit": "Limite{suffix}",
     "remove": "Remover{suffix}",
     "saved": "Salvo{suffix}",
-    "removed": "Removido{suffix}"
+    "removed": "Removido{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Regras de acesso",

--- a/frontend/src/i18n/pt.json
+++ b/frontend/src/i18n/pt.json
@@ -710,10 +710,7 @@
     "limit": "Limite{suffix}",
     "remove": "Remover{suffix}",
     "saved": "Guardado{suffix}",
-    "removed": "Removido{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Removido{suffix}"
   },
   "access": {
     "rules": "Regras de acesso",
@@ -813,6 +810,11 @@
       "alignCenter": "Alinhar ao centro",
       "justify": "Justificar",
       "fontColor": "Cor da fonte"
+    },
+    "json": {
+      "formatJSON": "Formato JSON",
+      "formatJSONSuccess": "O JSON foi formatado com sucesso",
+      "invalidJSON": "JSON inválido: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/pt.json
+++ b/frontend/src/i18n/pt.json
@@ -710,7 +710,10 @@
     "limit": "Limite{suffix}",
     "remove": "Remover{suffix}",
     "saved": "Guardado{suffix}",
-    "removed": "Removido{suffix}"
+    "removed": "Removido{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Regras de acesso",

--- a/frontend/src/i18n/ro.json
+++ b/frontend/src/i18n/ro.json
@@ -614,10 +614,7 @@
     "limit": "Limită{suffix}",
     "remove": "Eliminare{suffix}",
     "saved": "Salvat{suffix}",
-    "removed": "Eliminat{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Eliminat{suffix}"
   },
   "access": {
     "rules": "Reguli de acces",
@@ -813,6 +810,11 @@
       "alignCenter": "Aliniere la centru",
       "justify": "Aliniere între margini",
       "fontColor": "Culoarea fontului"
+    },
+    "json": {
+      "formatJSON": "Format JSON",
+      "formatJSONSuccess": "Formatarea JSON s-a realizat cu succes",
+      "invalidJSON": "JSON nevalid: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/ro.json
+++ b/frontend/src/i18n/ro.json
@@ -614,7 +614,10 @@
     "limit": "Limită{suffix}",
     "remove": "Eliminare{suffix}",
     "saved": "Salvat{suffix}",
-    "removed": "Eliminat{suffix}"
+    "removed": "Eliminat{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Reguli de acces",

--- a/frontend/src/i18n/ru.json
+++ b/frontend/src/i18n/ru.json
@@ -614,7 +614,10 @@
     "limit": "Предел{suffix}",
     "remove": "Удалить{suffix}",
     "saved": "Сохранено{suffix}",
-    "removed": "Удалено{suffix}"
+    "removed": "Удалено{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Правила доступа",

--- a/frontend/src/i18n/ru.json
+++ b/frontend/src/i18n/ru.json
@@ -614,10 +614,7 @@
     "limit": "Предел{suffix}",
     "remove": "Удалить{suffix}",
     "saved": "Сохранено{suffix}",
-    "removed": "Удалено{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Удалено{suffix}"
   },
   "access": {
     "rules": "Правила доступа",
@@ -813,6 +810,11 @@
       "alignCenter": "Выравнивание по центру",
       "justify": "Выравнивание по ширине",
       "fontColor": "Цвет шрифта"
+    },
+    "json": {
+      "formatJSON": "Формат JSON",
+      "formatJSONSuccess": "Форматирование в JSON прошло успешно",
+      "invalidJSON": "Недопустимый JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/sk.json
+++ b/frontend/src/i18n/sk.json
@@ -614,7 +614,10 @@
     "limit": "Limit{suffix}",
     "remove": "Odstrániť{suffix}",
     "saved": "Uložené{suffix}",
-    "removed": "Odstránené{suffix}"
+    "removed": "Odstránené{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Pravidlá prístupu",

--- a/frontend/src/i18n/sk.json
+++ b/frontend/src/i18n/sk.json
@@ -614,10 +614,7 @@
     "limit": "Limit{suffix}",
     "remove": "Odstrániť{suffix}",
     "saved": "Uložené{suffix}",
-    "removed": "Odstránené{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Odstránené{suffix}"
   },
   "access": {
     "rules": "Pravidlá prístupu",
@@ -813,6 +810,11 @@
       "alignCenter": "Zarovnať na stred",
       "justify": "Zarovnať do bloku",
       "fontColor": "Farba písma"
+    },
+    "json": {
+      "formatJSON": "Formát JSON",
+      "formatJSONSuccess": "Formátovanie JSON prebehlo úspešne",
+      "invalidJSON": "Neplatný JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/sv-se.json
+++ b/frontend/src/i18n/sv-se.json
@@ -710,7 +710,10 @@
     "limit": "Gräns{suffix}",
     "remove": "Ta bort{suffix}",
     "saved": "Sparat{suffix}",
-    "removed": "Borttagen{suffix}"
+    "removed": "Borttagen{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Regler för åtkomst",

--- a/frontend/src/i18n/sv-se.json
+++ b/frontend/src/i18n/sv-se.json
@@ -710,10 +710,7 @@
     "limit": "Gräns{suffix}",
     "remove": "Ta bort{suffix}",
     "saved": "Sparat{suffix}",
-    "removed": "Borttagen{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Borttagen{suffix}"
   },
   "access": {
     "rules": "Regler för åtkomst",
@@ -813,6 +810,11 @@
       "alignCenter": "Centrera",
       "justify": "Kantutjämna",
       "fontColor": "Typsnittsfärg"
+    },
+    "json": {
+      "formatJSON": "JSON-format",
+      "formatJSONSuccess": "JSON-formateringen lyckades",
+      "invalidJSON": "Ogiltig JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -614,7 +614,10 @@
     "limit": "Sınır{suffix}",
     "remove": "Kaldır{suffix}",
     "saved": "Kaydedildi{suffix}",
-    "removed": "Kaldırıldı{suffix}"
+    "removed": "Kaldırıldı{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Erişim kuralları",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -614,10 +614,7 @@
     "limit": "Sınır{suffix}",
     "remove": "Kaldır{suffix}",
     "saved": "Kaydedildi{suffix}",
-    "removed": "Kaldırıldı{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Kaldırıldı{suffix}"
   },
   "access": {
     "rules": "Erişim kuralları",
@@ -813,6 +810,11 @@
       "alignCenter": "Ortala",
       "justify": "İki yana yasla",
       "fontColor": "Yazı tipi rengi"
+    },
+    "json": {
+      "formatJSON": "JSON biçimi",
+      "formatJSONSuccess": "JSON biçimlendirme başarıyla tamamlandı",
+      "invalidJSON": "Geçersiz JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/ua.json
+++ b/frontend/src/i18n/ua.json
@@ -710,10 +710,7 @@
     "limit": "Обмеження{suffix}",
     "remove": "Видалити{suffix}",
     "saved": "Збережено{suffix}",
-    "removed": "Видалено{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "Видалено{suffix}"
   },
   "access": {
     "rules": "Правила доступу",
@@ -813,6 +810,11 @@
       "alignCenter": "Вирівняти по центру",
       "justify": "Вирівняти по ширині",
       "fontColor": "Колір шрифту"
+    },
+    "json": {
+      "formatJSON": "Формат JSON",
+      "formatJSONSuccess": "Форматування у форматі JSON завершено успішно",
+      "invalidJSON": "Неправильний JSON: {message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/ua.json
+++ b/frontend/src/i18n/ua.json
@@ -710,7 +710,10 @@
     "limit": "Обмеження{suffix}",
     "remove": "Видалити{suffix}",
     "saved": "Збережено{suffix}",
-    "removed": "Видалено{suffix}"
+    "removed": "Видалено{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "Правила доступу",

--- a/frontend/src/i18n/zh-cn.json
+++ b/frontend/src/i18n/zh-cn.json
@@ -710,7 +710,10 @@
     "limit": "极限{suffix}",
     "remove": "删除{suffix}",
     "saved": "已保存{suffix}",
-    "removed": "已删除{suffix}"
+    "removed": "已删除{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "访问规则",

--- a/frontend/src/i18n/zh-cn.json
+++ b/frontend/src/i18n/zh-cn.json
@@ -710,10 +710,7 @@
     "limit": "极限{suffix}",
     "remove": "删除{suffix}",
     "saved": "已保存{suffix}",
-    "removed": "已删除{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "已删除{suffix}"
   },
   "access": {
     "rules": "访问规则",
@@ -813,6 +810,11 @@
       "alignCenter": "居中对齐",
       "justify": "两端对齐",
       "fontColor": "字体颜色"
+    },
+    "json": {
+      "formatJSON": "JSON 格式",
+      "formatJSONSuccess": "JSON 格式化成功",
+      "invalidJSON": "无效的 JSON：{message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/zh-tw.json
+++ b/frontend/src/i18n/zh-tw.json
@@ -710,10 +710,7 @@
     "limit": "上限{suffix}",
     "remove": "移除{suffix}",
     "saved": "已儲存{suffix}",
-    "removed": "已移除{suffix}",
-    "formatJSON": "Format JSON",
-    "formatJSONSuccess": "JSON formatted successfully",
-    "invalidJSON": "Invalid JSON: {message}"
+    "removed": "已移除{suffix}"
   },
   "access": {
     "rules": "存取規則",
@@ -813,6 +810,11 @@
       "alignCenter": "居中對齊",
       "justify": "對齊",
       "fontColor": "字體顏色"
+    },
+    "json": {
+      "formatJSON": "JSON 格式",
+      "formatJSONSuccess": "JSON 格式化成功",
+      "invalidJSON": "無效的 JSON：{message}"
     }
   },
   "player": {

--- a/frontend/src/i18n/zh-tw.json
+++ b/frontend/src/i18n/zh-tw.json
@@ -710,7 +710,10 @@
     "limit": "上限{suffix}",
     "remove": "移除{suffix}",
     "saved": "已儲存{suffix}",
-    "removed": "已移除{suffix}"
+    "removed": "已移除{suffix}",
+    "formatJSON": "Format JSON",
+    "formatJSONSuccess": "JSON formatted successfully",
+    "invalidJSON": "Invalid JSON: {message}"
   },
   "access": {
     "rules": "存取規則",

--- a/frontend/src/store/mutations.ts
+++ b/frontend/src/store/mutations.ts
@@ -58,6 +58,10 @@ export const mutations = {
     state.editor.saveHandler = handler;
     emitStateChanged();
   },
+  setEditorFormatJSONHandler: (handler) => {
+    state.editor.formatJSONHandler = handler;
+    emitStateChanged();
+  },
   setEditorStats: (stats) => {
     if (JSON.stringify(state.editor.stats) === JSON.stringify(stats)) return;
     state.editor.stats = stats;

--- a/frontend/src/store/mutations.ts
+++ b/frontend/src/store/mutations.ts
@@ -58,8 +58,9 @@ export const mutations = {
     state.editor.saveHandler = handler;
     emitStateChanged();
   },
-  setEditorFormatJSONHandler: (handler) => {
-    state.editor.formatJSONHandler = handler;
+  setEditorJsonFormatted: (value) => {
+    if (value === state.editor.jsonFormatted) return;
+    state.editor.jsonFormatted = value;
     emitStateChanged();
   },
   setEditorStats: (stats) => {

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -36,6 +36,7 @@ export const state: StoreState = reactive({
     instance: null,
     dirty: false,
     saveHandler: null,
+    formatJSONHandler: null,
     stats: {
       lines: 0,
       words: 0,

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -36,7 +36,7 @@ export const state: StoreState = reactive({
     instance: null,
     dirty: false,
     saveHandler: null,
-    formatJSONHandler: null,
+    jsonFormatted: false,
     stats: {
       lines: 0,
       words: 0,

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -277,6 +277,7 @@ export interface StoreState {
     instance: unknown;
     dirty: boolean;
     saveHandler: (() => Promise<void>) | null;
+    formatJSONHandler: (() => Promise<void>) | null;
     stats: {
       lines: number | null;
       words: number | null;

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -277,7 +277,7 @@ export interface StoreState {
     instance: unknown;
     dirty: boolean;
     saveHandler: (() => Promise<void>) | null;
-    formatJSONHandler: (() => Promise<void>) | null;
+    jsonFormatted: boolean;
     stats: {
       lines: number | null;
       words: number | null;

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -499,9 +499,10 @@ export default {
         editorInstance.on('change', () => {
           if (this.editor !== editorInstance) return;
           if (this.suppressDirtyTracking) return;
-          if (!this.isDirty) {
-            this.isDirty = true;
-            mutations.setEditorDirty(true);
+          const dirty = editorInstance.getValue() !== this.savedContent;
+          if (this.isDirty !== dirty) {
+            this.isDirty = dirty;
+            mutations.setEditorDirty(dirty);
           }
           this.scheduleStatsUpdate();
           (this.$refs.splitView as InstanceType<typeof MarkdownSplitView> | undefined)?.handleEditorChange();

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -207,6 +207,7 @@ export default {
         this.originalReq = newReq;
         this.isDirty = false; // Reset dirty flag for new file
         mutations.setEditorDirty(false);
+        mutations.setEditorJsonFormatted(false);
         mutations.resetEditorScrollRatio(newReq.path);
 
         // Lock saves temporarily

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -331,7 +331,6 @@ export default {
     // Clear dirty state and save handler when leaving editor
     mutations.setEditorDirty(false);
     mutations.setEditorSaveHandler(null);
-    mutations.setEditorFormatJSONHandler(null);
     mutations.setEditorStats({ lines: 0, words: 0, chars: 0 });
   },
   unmounted() {
@@ -362,7 +361,6 @@ export default {
 
     // Register save handler so other components can trigger save
     mutations.setEditorSaveHandler(() => this.handleEditorValueRequest());
-    mutations.setEditorFormatJSONHandler(() => this.formatJSON());
     this.applyFontSize();
     this.setupViewerResizeObserver();
   },
@@ -551,18 +549,6 @@ export default {
         case 'text': return 'ace/mode/text';
         case 'xml': return 'ace/mode/xml';
         default: return `ace/mode/${mode}`;
-      }
-    },
-    async formatJSON() {
-      try {
-        if (!this.editor) return;
-        const textToFormat = this.editor.getValue();
-        const parsed = JSON.parse(textToFormat);
-        const formatted = JSON.stringify(parsed, null, 2);
-        this.editor.setValue(formatted, -1);
-        notify.showSuccessToast(this.$t("general.formatJSONSuccess"));
-      } catch (e) {
-        notify.showErrorToast(this.$t("general.invalidJSON", { message: e instanceof Error ? e.message : String(e) }));
       }
     },
     async handleEditorValueRequest() {

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -562,7 +562,7 @@ export default {
         this.editor.setValue(formatted, -1);
         notify.showSuccessToast(this.$t("general.formatJSONSuccess"));
       } catch (e) {
-        notify.showError(this.$t("general.invalidJSON", { message: (e as Error).message }));
+        notify.showErrorToast(this.$t("general.invalidJSON", { message: e instanceof Error ? e.message : String(e) }));
       }
     },
     async handleEditorValueRequest() {

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -331,6 +331,7 @@ export default {
     // Clear dirty state and save handler when leaving editor
     mutations.setEditorDirty(false);
     mutations.setEditorSaveHandler(null);
+    mutations.setEditorFormatJSONHandler(null);
     mutations.setEditorStats({ lines: 0, words: 0, chars: 0 });
   },
   unmounted() {
@@ -361,6 +362,7 @@ export default {
 
     // Register save handler so other components can trigger save
     mutations.setEditorSaveHandler(() => this.handleEditorValueRequest());
+    mutations.setEditorFormatJSONHandler(() => this.formatJSON());
     this.applyFontSize();
     this.setupViewerResizeObserver();
   },
@@ -549,6 +551,18 @@ export default {
         case 'text': return 'ace/mode/text';
         case 'xml': return 'ace/mode/xml';
         default: return `ace/mode/${mode}`;
+      }
+    },
+    async formatJSON() {
+      try {
+        if (!this.editor) return;
+        const textToFormat = this.editor.getValue();
+        const parsed = JSON.parse(textToFormat);
+        const formatted = JSON.stringify(parsed, null, 2);
+        this.editor.setValue(formatted, -1);
+        notify.showSuccessToast(this.$t("general.formatJSONSuccess"));
+      } catch (e) {
+        notify.showError(this.$t("general.invalidJSON", { message: (e as Error).message }));
       }
     },
     async handleEditorValueRequest() {


### PR DESCRIPTION
## Add "Format JSON" button for .json files opened in an editor.

**Description**
As requested in #2566, this PR implements a small fully frontend sided JSON beautifier or formatter feature in the frontend. It uses the vanilla Javascript JSON API, which is already thoroughly tested, so adding further testing here is unnecessary. 

- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR. \n -> Linting and tests showed 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added JSON formatting controls to the editor toolbar.
  - JSON files can be formatted with compact or two-space indentation.
  - Formatting is available only when editing is permitted.
  - Added success and invalid-JSON notifications, with focus restored to the editor.

- **Bug Fixes**
  - JSON formatting status now resets when switching files.
  - Restoring original content now correctly clears the editor’s unsaved-changes status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->