### PR TITLE
fix(resources): return 400 when path or source is missing

### DIFF
--- a/backend/internal/adapters/fs/files/files.go
+++ b/backend/internal/adapters/fs/files/files.go
@@ -131,10 +131,10 @@ func checkPermissionsImpl(opts utils.FileOptions, user *users.User, s *Service) 
 		return "", "", fmt.Errorf("user not provided")
 	}
 	if opts.Path == "" {
-		return "", "", fmt.Errorf("path not provided")
+		return "", "", fmt.Errorf("%w: path not provided", errors.ErrInvalidRequestParams)
 	}
 	if opts.Source == "" {
-		return "", "", fmt.Errorf("source not provided")
+		return "", "", fmt.Errorf("%w: source not provided", errors.ErrInvalidRequestParams)
 	}
 
 	// Get index

--- a/backend/internal/web/resource_params_test.go
+++ b/backend/internal/web/resource_params_test.go
@@ -1,0 +1,34 @@
+package web
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
+)
+
+func TestCheckPermissionsMissingParamsStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts utils.FileOptions
+	}{
+		{name: "missing path", opts: utils.FileOptions{Source: "default"}},
+		{name: "missing source", opts: utils.FileOptions{Path: "/"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := files.CheckPermissions(tt.opts, &users.User{})
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if status := ErrToStatus(err); status != http.StatusBadRequest {
+				t.Fatalf("status=%d err=%v, want %d", status, err, http.StatusBadRequest)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes [#2801 — `GET /api/resources` returns 500 when `path` is empty or omitted](https://github.com/gtsteffaniak/filebrowser/issues/2801).

## Problem

An empty or omitted resource `path` reached the shared permission guard, which returned a plain error. `ErrToStatus` could not classify it and fell back to HTTP 500. A missing `source` followed the same path.

## Fix

Wrap both missing-parameter errors with the existing `ErrInvalidRequestParams` sentinel. Every resource caller still uses the same guard, while `ErrToStatus` now maps these malformed requests to HTTP 400.

## Deliberately not done

The issue's separate observations about users, cached permissions, and event logging are unrelated and remain unchanged.

## User impact

API clients now receive a client-error status for malformed resource requests instead of mistaking them for server failures.

## Verification

- `go test ./internal/web -run '^TestCheckPermissionsMissingParamsStatus$' -count=1` — passed.
- GitHub Actions — all 22 repository checks passed, including backend/frontend tests and Playwright across the configured authentication modes.
- `git diff --check` — passed.

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.