### PR TITLE
fix(preview): stop opening PDFs in the text editor

### DIFF
--- a/backend/internal/utils/textfile.go
+++ b/backend/internal/utils/textfile.go
@@ -3,14 +3,12 @@ package utils
 import (
 	"net/http"
 	"os"
-	"strings"
 	"unicode/utf8"
 )
 
 // IsTextFile checks if a file is viewable/editable as text (like with cat or a text editor).
 // It returns true if the file appears to be text, false if it's likely binary.
 // This function uses simple heuristics:
-// - No binary format signature (PDF, images, archives, ...)
 // - Valid UTF-8 encoding
 // - Not full of null bytes (which indicate binary data)
 func IsTextFile(realPath string) (bool, error) {
@@ -30,9 +28,9 @@ func IsTextFile(realPath string) (bool, error) {
 	if len(content) > sampleSize {
 		sample = content[:sampleSize]
 	}
-	// Check 1: Reject a binary format signature. A PDF with a long ASCII text
-	// layer looks like text for far more than sampleSize bytes.
-	if mimeType := http.DetectContentType(sample); !strings.HasPrefix(mimeType, "text/") && mimeType != "image/svg+xml" {
+	// Check 1: Reject PDFs. A PDF with a long ASCII text layer looks like text
+	// for far more than sampleSize bytes.
+	if http.DetectContentType(sample) == "application/pdf" {
 		return false, nil
 	}
 

--- a/backend/internal/utils/textfile.go
+++ b/backend/internal/utils/textfile.go
@@ -1,13 +1,16 @@
 package utils
 
 import (
+	"net/http"
 	"os"
+	"strings"
 	"unicode/utf8"
 )
 
 // IsTextFile checks if a file is viewable/editable as text (like with cat or a text editor).
 // It returns true if the file appears to be text, false if it's likely binary.
 // This function uses simple heuristics:
+// - No binary format signature (PDF, images, archives, ...)
 // - Valid UTF-8 encoding
 // - Not full of null bytes (which indicate binary data)
 func IsTextFile(realPath string) (bool, error) {
@@ -27,7 +30,13 @@ func IsTextFile(realPath string) (bool, error) {
 	if len(content) > sampleSize {
 		sample = content[:sampleSize]
 	}
-	// Check 1: Count null bytes - binary files typically have many nulls
+	// Check 1: Reject a binary format signature. A PDF with a long ASCII text
+	// layer looks like text for far more than sampleSize bytes.
+	if mimeType := http.DetectContentType(sample); !strings.HasPrefix(mimeType, "text/") && mimeType != "image/svg+xml" {
+		return false, nil
+	}
+
+	// Check 2: Count null bytes - binary files typically have many nulls
 	nullCount := 0
 	for _, b := range sample {
 		if b == 0x00 {
@@ -42,7 +51,7 @@ func IsTextFile(realPath string) (bool, error) {
 		}
 	}
 
-	// Check 2: Validate UTF-8 encoding
+	// Check 3: Validate UTF-8 encoding
 	// Trim sample to last complete UTF-8 rune to avoid false negatives
 	trimmedSample := sample
 	for len(trimmedSample) > 0 {

--- a/backend/internal/utils/textfile_test.go
+++ b/backend/internal/utils/textfile_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsTextFile(t *testing.T) {
+	t.Parallel()
+
+	asciiPageStream := strings.Repeat("BT /Ft0 1 Tf <00430044004500460047> Tj ET\n", 300)
+
+	tests := []struct {
+		name    string
+		content []byte
+		want    bool
+	}{
+		{name: "empty", content: nil, want: true},
+		{name: "plain text", content: []byte("hello\nworld\n"), want: true},
+		{name: "utf-8 text", content: []byte("café ☕\n"), want: true},
+		{name: "svg", content: []byte(`<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>`), want: true},
+		{name: "binary with null bytes", content: append([]byte("GIF89a"), make([]byte, 64)...), want: false},
+		{
+			name:    "pdf with an ascii text layer larger than the sample",
+			content: append([]byte("%PDF-1.3\n"+asciiPageStream), 0xFF, 0xD8, 0xFF, 0xE0),
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "sample")
+			if err := os.WriteFile(path, tt.content, 0o600); err != nil {
+				t.Fatalf("writing sample: %v", err)
+			}
+
+			got, err := IsTextFile(path)
+			if err != nil {
+				t.Fatalf("IsTextFile: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("IsTextFile(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes [#2841 — Some Adobe Scan PDF files open as raw text](https://github.com/gtsteffaniak/filebrowser/issues/2841).

## Problem

`IsTextFile` sampled only the first 8 KB for null bytes and valid UTF-8. Adobe Scan can place a long ASCII OCR stream before the embedded image, so a valid PDF was classified as text and routed to the ACE editor as raw PDF source.

## Fix

Reject samples that the standard library identifies as `application/pdf` before applying the existing null-byte and UTF-8 heuristics. The check is deliberately PDF-only, preserving the previous behavior for other UTF-8 files.

## Deliberately not done

No general binary MIME denylist was added; the reported failure is PDF-specific, and a broader gate changes the editable-text contract for formats such as PostScript.

## User impact

Scanned PDFs with long OCR layers now follow the PDF-viewer path instead of opening as raw text.

## Verification

- `go test ./internal/utils -count=1` — passed.
- `go tool golangci-lint run ./internal/utils` — 0 issues.
- `git diff --check` — passed.

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of binary files by recognizing common binary file signatures.
  * Preserved support for plain text, UTF-8 content, and SVG files.
  * Better handles PDF files that contain embedded readable text.

* **Tests**
  * Added coverage for empty files, text, SVG, binary data, and PDF files.
  * Added validation for accurate classification of files with mixed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->