### PR TITLE
fixed raw preview for raf embedded images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. For commit 
 ## v2.0.3
 
  **Bugfixes**:
+ - Fixed Fuji `.raf` thumbnail preview by extracting the camera-embedded JPEG from the RAF header (regression for files where TIFF-based raw extraction does not apply).
+ - Image previews for unsupported decodable formats now return HTTP 415 immediately instead of attempting JPEG decode and returning HTTP 500.
  - OIDC: preserve the verified ID-token user identifier when falling back to the UserInfo endpoint for missing groups, so login no longer fails with HTTP 500 when UserInfo returns groups but omits the configured identifier.
  - LDAP: restore `memberOf` as the default `groupsClaim` when unset, fixing group-based admin and login authorization for existing LDAP configs after the v2.0.2 default changed to `groups`.
 

--- a/backend/internal/imagemeta/embedded.go
+++ b/backend/internal/imagemeta/embedded.go
@@ -56,6 +56,8 @@ func ExtractEmbeddedPreview(ctx context.Context, path string) ([]byte, error) {
 	switch {
 	case ext == ".cr3":
 		data, err = extimagemeta.PreviewCR3(f)
+	case ext == ".raf":
+		data, err = extractRAFEmbeddedPreview(f)
 	case isRawImageExtension(ext):
 		data, err = extractTIFFEmbeddedPreview(f)
 	case isHEICExtension(ext):

--- a/backend/internal/imagemeta/raf_preview.go
+++ b/backend/internal/imagemeta/raf_preview.go
@@ -1,0 +1,68 @@
+//go:build !386 && !arm
+
+package imagemeta
+
+import (
+	"encoding/binary"
+	"io"
+	"os"
+)
+
+const (
+	rafMagicLen       = 16
+	rafMagic          = "FUJIFILMCCD-RAW"
+	rafJPEGOffsetPos  = 0x54
+	rafJPEGLengthPos  = 0x58
+	rafHeaderMinBytes = 0x5C
+)
+
+// extractRAFEmbeddedPreview reads the camera-embedded JPEG from a Fuji RAF file.
+// Offset and length are stored as big-endian uint32 at 0x54 and 0x58 in the RAF header directory.
+func extractRAFEmbeddedPreview(f *os.File) ([]byte, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() < rafHeaderMinBytes {
+		return nil, nil
+	}
+
+	header := make([]byte, rafHeaderMinBytes)
+	n, err := f.ReadAt(header, 0)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if n < rafHeaderMinBytes {
+		return nil, nil
+	}
+	if !isRAFMagic(header[:rafMagicLen]) {
+		return nil, nil
+	}
+
+	offset := binary.BigEndian.Uint32(header[rafJPEGOffsetPos:rafJPEGLengthPos])
+	length := binary.BigEndian.Uint32(header[rafJPEGLengthPos:rafHeaderMinBytes])
+	if offset == 0 || length == 0 {
+		return nil, nil
+	}
+	if int64(offset)+int64(length) > info.Size() {
+		return nil, nil
+	}
+
+	data, err := readFileRange(f, offset, length)
+	if err != nil || len(data) == 0 || !IsJPEG(data) {
+		return nil, nil
+	}
+	return data, nil
+}
+
+func isRAFMagic(b []byte) bool {
+	if len(b) < len(rafMagic) {
+		return false
+	}
+	for i := 0; i < len(rafMagic); i++ {
+		if b[i] != rafMagic[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/imagemeta/raf_preview.go
+++ b/backend/internal/imagemeta/raf_preview.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	rafMagicLen       = 16
-	rafMagic          = "FUJIFILMCCD-RAW"
+	rafMagic          = "FUJIFILMCCD-RAW "
 	rafJPEGOffsetPos  = 0x54
 	rafJPEGLengthPos  = 0x58
 	rafHeaderMinBytes = 0x5C

--- a/backend/internal/imagemeta/raf_preview_test.go
+++ b/backend/internal/imagemeta/raf_preview_test.go
@@ -39,7 +39,7 @@ func TestExtractRAFEmbeddedPreviewSynthetic(t *testing.T) {
 
 func TestExtractRAFEmbeddedPreviewIgnoresInvalidMagic(t *testing.T) {
 	data := make([]byte, 256)
-	copy(data[:8], []byte("NOTARAF "))
+	copy(data[:rafMagicLen], []byte("FUJIFILMCCD-RAW!"))
 	path := filepath.Join(t.TempDir(), "bad.raf")
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)

--- a/backend/internal/imagemeta/raf_preview_test.go
+++ b/backend/internal/imagemeta/raf_preview_test.go
@@ -1,0 +1,94 @@
+//go:build !386 && !arm
+
+package imagemeta
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractRAFEmbeddedPreviewSynthetic(t *testing.T) {
+	jpeg := []byte{0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0xff, 0xd9}
+	const jpegOffset = uint32(0x94)
+
+	data := make([]byte, int(jpegOffset)+len(jpeg))
+	copy(data[:rafMagicLen], []byte(rafMagic))
+	binary.BigEndian.PutUint32(data[rafJPEGOffsetPos:rafJPEGLengthPos], jpegOffset)
+	binary.BigEndian.PutUint32(data[rafJPEGLengthPos:rafHeaderMinBytes], uint32(len(jpeg)))
+	copy(data[jpegOffset:], jpeg)
+
+	path := filepath.Join(t.TempDir(), "sample.raf")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ExtractEmbeddedPreview(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !IsJPEG(got) {
+		t.Fatalf("expected JPEG preview, got %d bytes", len(got))
+	}
+	if len(got) != len(jpeg) {
+		t.Fatalf("preview size = %d, want %d", len(got), len(jpeg))
+	}
+}
+
+func TestExtractRAFEmbeddedPreviewIgnoresInvalidMagic(t *testing.T) {
+	data := make([]byte, 256)
+	copy(data[:8], []byte("NOTARAF "))
+	path := filepath.Join(t.TempDir(), "bad.raf")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ExtractEmbeddedPreview(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("ExtractEmbeddedPreview() = %v, want nil", got)
+	}
+}
+
+func TestExtractRAFEmbeddedPreviewDSCF1276(t *testing.T) {
+	path := "/Users/steffag/Downloads/DSCF1276.RAF"
+	if _, err := os.Stat(path); err != nil {
+		t.Skip(path)
+	}
+
+	got, err := ExtractEmbeddedPreview(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !IsJPEG(got) {
+		t.Fatalf("expected JPEG preview, got %d bytes", len(got))
+	}
+	if len(got) < 100 {
+		t.Fatalf("preview size = %d, want >= 100", len(got))
+	}
+}
+
+func TestExtractRAFEmbeddedPreviewRejectsOutOfBoundsOffset(t *testing.T) {
+	jpeg := []byte{0xff, 0xd8, 0xff, 0xd9}
+	data := make([]byte, 256)
+	copy(data[:rafMagicLen], []byte(rafMagic))
+	binary.BigEndian.PutUint32(data[rafJPEGOffsetPos:rafJPEGLengthPos], 200)
+	binary.BigEndian.PutUint32(data[rafJPEGLengthPos:rafHeaderMinBytes], uint32(len(jpeg)))
+
+	path := filepath.Join(t.TempDir(), "oob.raf")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ExtractEmbeddedPreview(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("ExtractEmbeddedPreview() = %v, want nil", got)
+	}
+}

--- a/backend/internal/preview/preview.go
+++ b/backend/internal/preview/preview.go
@@ -271,10 +271,13 @@ func (s *Service) generateRawPreview(ctx context.Context, file iteminfo.Extended
 
 	case previewTypeImage:
 		ext := strings.ToLower(filepath.Ext(file.Name))
-		if iteminfo.IsRawImage(ext) && s.ffmpegService != nil {
-			if bytes, err := s.convertImageWithFFmpeg(ctx, file.RealPath, previewSize); err == nil && len(bytes) >= minPreviewSize {
-				return bytes, nil
+		if iteminfo.IsRawImage(ext) {
+			if s.ffmpegService != nil {
+				if bytes, err := s.convertImageWithFFmpeg(ctx, file.RealPath, previewSize); err == nil && len(bytes) >= minPreviewSize {
+					return bytes, nil
+				}
 			}
+			return nil, ErrUnsupportedFormat
 		}
 		return s.generateImagePreview(ctx, file, previewSize)
 
@@ -369,6 +372,13 @@ func (s *Service) generateImagePreview(ctx context.Context, file iteminfo.Extend
 	if err != nil {
 		return nil, err
 	}
+
+	ext := strings.ToLower(filepath.Ext(file.Name))
+	format, err := s.FormatFromExtension(ext)
+	if err != nil {
+		return nil, err
+	}
+	options.Format = format
 
 	imageBytes, err := s.CreatePreview(ctx, f, file.Size, options)
 	if err != nil {

--- a/backend/internal/preview/preview.go
+++ b/backend/internal/preview/preview.go
@@ -273,8 +273,12 @@ func (s *Service) generateRawPreview(ctx context.Context, file iteminfo.Extended
 		ext := strings.ToLower(filepath.Ext(file.Name))
 		if iteminfo.IsRawImage(ext) {
 			if s.ffmpegService != nil {
-				if bytes, err := s.convertImageWithFFmpeg(ctx, file.RealPath, previewSize); err == nil && len(bytes) >= minPreviewSize {
-					return bytes, nil
+				previewBytes, err := s.convertImageWithFFmpeg(ctx, file.RealPath, previewSize)
+				if err == nil && len(previewBytes) >= minPreviewSize {
+					return previewBytes, nil
+				}
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
 				}
 			}
 			return nil, ErrUnsupportedFormat

--- a/backend/internal/preview/preview_raw_test.go
+++ b/backend/internal/preview/preview_raw_test.go
@@ -77,7 +77,8 @@ func TestGenerateImagePreviewUsesPNGFormat(t *testing.T) {
 	dir := t.TempDir()
 	svc := NewPreviewGenerator(1, dir)
 
-	// 1x1 red PNG
+	// 1x1 red PNG; pad past maxSizeForOriginal (256KB) so we exercise format selection.
+	const maxSizeForOriginal = 256 * 1024
 	pngBytes := []byte{
 		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
 		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
@@ -89,8 +90,10 @@ func TestGenerateImagePreviewUsesPNGFormat(t *testing.T) {
 		0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
 		0x44, 0xae, 0x42, 0x60, 0x82,
 	}
+	payload := make([]byte, maxSizeForOriginal+1)
+	copy(payload, pngBytes)
 	path := filepath.Join(dir, "pixel.png")
-	if err := os.WriteFile(path, pngBytes, 0o600); err != nil {
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -98,7 +101,7 @@ func TestGenerateImagePreviewUsesPNGFormat(t *testing.T) {
 		FileInfo: iteminfo.FileInfo{
 			ItemInfo: iteminfo.ItemInfo{
 				Name:    "pixel.png",
-				Size:    int64(len(pngBytes)),
+				Size:    int64(len(payload)),
 				ModTime: time.Now(),
 				Type:    "image/png",
 			},
@@ -110,7 +113,7 @@ func TestGenerateImagePreviewUsesPNGFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) == 0 {
-		t.Fatal("expected non-empty preview bytes")
+	if len(got) < 8 || string(got[:8]) != "\x89PNG\r\n\x1a\n" {
+		t.Fatalf("expected PNG signature, got %x", got[:min(8, len(got))])
 	}
 }

--- a/backend/internal/preview/preview_raw_test.go
+++ b/backend/internal/preview/preview_raw_test.go
@@ -1,0 +1,116 @@
+package preview
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
+)
+
+func TestGenerateRawPreviewRawWithoutEmbeddedReturnsUnsupported(t *testing.T) {
+	data := make([]byte, 256)
+	copy(data[:16], []byte("FUJIFILMCCD-RAW "))
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.raf")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewPreviewGenerator(1, dir)
+	file := iteminfo.ExtendedFileInfo{
+		FileInfo: iteminfo.FileInfo{
+			ItemInfo: iteminfo.ItemInfo{
+				Name:    "empty.raf",
+				Size:    int64(len(data)),
+				ModTime: time.Now(),
+				Type:    "image/x-fuji-raf",
+			},
+		},
+		RealPath: path,
+	}
+
+	_, err := svc.generateRawPreview(context.Background(), file, "small", "", 0, "hash")
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("generateRawPreview() err = %v, want ErrUnsupportedFormat", err)
+	}
+	if strings.Contains(err.Error(), "SOI") {
+		t.Fatalf("generateRawPreview() should fail fast, got JPEG decode error: %v", err)
+	}
+}
+
+func TestGenerateImagePreviewUnsupportedExtensionReturnsUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clip.mov")
+	// Must exceed maxSizeForOriginal (256KB) so we don't short-circuit to raw bytes.
+	payload := make([]byte, 256*1024+1)
+	copy(payload, []byte("not a video"))
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewPreviewGenerator(1, dir)
+	file := iteminfo.ExtendedFileInfo{
+		FileInfo: iteminfo.FileInfo{
+			ItemInfo: iteminfo.ItemInfo{
+				Name:    "clip.mov",
+				Size:    int64(len(payload)),
+				ModTime: time.Now(),
+				Type:    "video/quicktime",
+			},
+		},
+		RealPath: path,
+	}
+
+	_, err := svc.generateImagePreview(context.Background(), file, "small")
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("generateImagePreview() err = %v, want ErrUnsupportedFormat", err)
+	}
+}
+
+func TestGenerateImagePreviewUsesPNGFormat(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewPreviewGenerator(1, dir)
+
+	// 1x1 red PNG
+	pngBytes := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+		0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+		0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+		0x00, 0x03, 0x01, 0x01, 0x00, 0x18, 0xdd, 0x8d,
+		0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+		0x44, 0xae, 0x42, 0x60, 0x82,
+	}
+	path := filepath.Join(dir, "pixel.png")
+	if err := os.WriteFile(path, pngBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	file := iteminfo.ExtendedFileInfo{
+		FileInfo: iteminfo.FileInfo{
+			ItemInfo: iteminfo.ItemInfo{
+				Name:    "pixel.png",
+				Size:    int64(len(pngBytes)),
+				ModTime: time.Now(),
+				Type:    "image/png",
+			},
+		},
+		RealPath: path,
+	}
+
+	got, err := svc.generateImagePreview(context.Background(), file, "small")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected non-empty preview bytes")
+	}
+}

--- a/backend/internal/web/http.go
+++ b/backend/internal/web/http.go
@@ -18,6 +18,7 @@ import (
 	libErrors "github.com/gtsteffaniak/filebrowser/backend/internal/errors"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/share"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/preview"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/indexing/iteminfo"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/gtsteffaniak/go-cache/cache"
@@ -139,6 +140,8 @@ func ErrToStatus(err error) int {
 		return http.StatusBadRequest
 	case errors.Is(err, libErrors.ErrIsDirectory):
 		return http.StatusMethodNotAllowed
+	case errors.Is(err, preview.ErrUnsupportedFormat):
+		return http.StatusUnsupportedMediaType
 	default:
 		return http.StatusInternalServerError
 	}

--- a/backend/internal/web/http_preview_test.go
+++ b/backend/internal/web/http_preview_test.go
@@ -1,0 +1,24 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/preview"
+)
+
+func TestErrToStatusUnsupportedPreviewFormat(t *testing.T) {
+	status := ErrToStatus(preview.ErrUnsupportedFormat)
+	if status != http.StatusUnsupportedMediaType {
+		t.Fatalf("ErrToStatus() = %d, want %d", status, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestErrToStatusWrapsUnsupportedPreviewFormat(t *testing.T) {
+	err := errors.Join(errors.New("preview failed"), preview.ErrUnsupportedFormat)
+	status := ErrToStatus(err)
+	if status != http.StatusUnsupportedMediaType {
+		t.Fatalf("ErrToStatus() = %d, want %d", status, http.StatusUnsupportedMediaType)
+	}
+}


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fuji RAF files now display embedded JPEG thumbnail previews correctly.
  - Unsupported image and video formats now return a clear “Unsupported Media Type” response instead of a server error.
  - RAW files without usable previews are handled gracefully, avoiding misleading image-decoding errors.
  - Preview output now preserves the appropriate format for supported image files.
- **Tests**
  - Added coverage for RAF preview extraction, unsupported formats, image preview generation, and HTTP error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->