### PR TITLE
fix: restore upload chunk size 0 to disable chunking (#2734)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. For commit 
 
  **BugFixes**:
  - "install app" message reappears after being cleared on device.
+ - Restored upload chunk size `0` to disable chunking as documented ([#2202](https://github.com/gtsteffaniak/filebrowser/issues/2202)); workaround for iOS 26 multi-chunk upload stalls ([#2734](https://github.com/gtsteffaniak/filebrowser/issues/2734)).
 
 ## v1.5.3-stable
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -686,7 +686,7 @@
     "maxConcurrentUpload": "Max concurrent uploads",
     "maxConcurrentUploadHelp": "The maximum number of concurrent uploads. Higher values typically perform better, but this depends on many factors.",
     "uploadChunkSizeMb": "Upload chunk size in MB",
-    "uploadChunkSizeMbHelp": "Typically 5 to 50 MB, smaller is better for unstable or restricted connections. Setting to 0 will disable upload chunking.",
+    "uploadChunkSizeMbHelp": "Typically 5 to 50 MB, smaller is better for unstable or restricted connections. Setting to 0 will disable upload chunking. On iOS 26+ devices, if multi-chunk uploads stall after the first chunk, set this to 0 or larger than your largest file.",
     "downloadChunkSizeMb": "Download chunk size in MB",
     "downloadChunkSizeMbHelp": "Chunk size for chunked downloads. Files larger than this size will be downloaded in chunks to prevent timeout issues (e.g., Cloudflare 524 errors). Setting to 0 disables chunked downloads.",
     "clearAll": "Clear completed should remove error, pause, and conflict",

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -334,15 +334,12 @@ class UploadManager {
     this.hadActiveUploads = true; // Mark that we've had active uploads
     upload.status = "uploading";
 
-    // Get chunk size in MB, default to 5 if not set or if 0
-    let chunkSizeMb = state.user.fileLoading?.uploadChunkSizeMb ?? 5;
-    if (chunkSizeMb === 0) {
-      chunkSizeMb = 5;
-    }
+    // Default to 5 MB when unset; explicit 0 disables chunking (single-shot upload).
+    const chunkSizeMb = state.user.fileLoading?.uploadChunkSizeMb ?? 5;
     const chunkSize = chunkSizeMb * 1024 * 1024;
 
-    // Use non-chunked upload if file size is less than chunk size
-    if (upload.size < chunkSize) {
+    // Single-shot upload when chunking is disabled or file is smaller than chunk size.
+    if (chunkSize === 0 || upload.size < chunkSize) {
       const progress = (percent) => {
         this.updateProgress(upload, percent);
       };
@@ -465,10 +462,7 @@ class UploadManager {
   }
 
   chunkSizeBytes() {
-    let chunkSizeMb = state.user.fileLoading?.uploadChunkSizeMb ?? 5;
-    if (chunkSizeMb === 0) {
-      chunkSizeMb = 5;
-    }
+    const chunkSizeMb = state.user.fileLoading?.uploadChunkSizeMb ?? 5;
     return chunkSizeMb * 1024 * 1024;
   }
 
@@ -494,7 +488,8 @@ class UploadManager {
     if (upload?.status !== "uploading" || !upload.xhr) {
       return;
     }
-    if (upload.type !== "directory" && upload.size >= this.chunkSizeBytes()) {
+    const chunkBytes = this.chunkSizeBytes();
+    if (upload.type !== "directory" && chunkBytes > 0 && upload.size >= chunkBytes) {
       try {
         if (getters.isShare()) {
           await resourcesApi.signalUploadPause(null, upload.path, state.shareInfo.hash);


### PR DESCRIPTION
Explicit uploadChunkSizeMb=0 again uses single-shot uploads instead of being coerced to 5 MB. Restores documented behavior (#2202) and provides a workaround for iOS 26 multi-chunk upload stalls.

**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored support for setting upload chunk size to `0`, allowing files to upload in a single request.
  * Prevented unnecessary pause requests when chunking is disabled.
  * Resolved multi-chunk upload stalls affecting iOS 26 by providing a single-upload workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->