### PR TITLE
fix: serve subtitle content on public video shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. For commit 
 
  **BugFixes**:
  - "install app" message reappears after being cleared on device.
+ - External subtitles fail to load on public video shares due to authenticated subtitle endpoint (#2822) (#2827)
 
 ## v1.5.3-stable
 

--- a/backend/http/httpRouter.go
+++ b/backend/http/httpRouter.go
@@ -191,6 +191,7 @@ func StartHttp(ctx context.Context, storage *bolt.BoltStore, shutdownComplete ch
 	api.HandleFunc("GET /media/metadata", withUser(metadataHandler))
 	api.HandleFunc("GET /media/lyrics", withUser(lyricsHandler))
 	publicApi.HandleFunc("GET /media/metadata", withHashFile(publicMetadataHandler))
+	publicApi.HandleFunc("GET /media/subtitles", withHashFile(publicSubtitlesHandler))
 	publicApi.HandleFunc("GET /media/lyrics", withHashFile(publicLyricsHandler))
 
 	// ========================================

--- a/backend/http/media.go
+++ b/backend/http/media.go
@@ -262,3 +262,79 @@ func publicLyricsHandler(w http.ResponseWriter, r *http.Request, d *requestConte
 	}
 	return renderJSON(w, r, map[string]any{"lyrics": lyrics})
 }
+
+// publicSubtitlesHandler is the share-link variant of subtitlesHandler.
+// @Summary Get subtitle content (public share)
+// @Tags Shares
+// @Produce text/plain
+// @Param hash query string true "Share hash"
+// @Param path query string false "Path within the share"
+// @Param name query string true "Subtitle track name"
+// @Param embedded query bool false "Whether this is an embedded stream"
+// @Success 200 {string} string "Raw subtitle content"
+// @Failure 403 {object} map[string]string "Forbidden"
+// @Failure 404 {object} map[string]string "Not found"
+// @Router /public/api/media/subtitles [get]
+func publicSubtitlesHandler(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
+	if d.share.ShareType == "upload" {
+		return http.StatusNotImplemented, fmt.Errorf("browsing is disabled for upload shares")
+	}
+
+	name := r.URL.Query().Get("name")
+	embedded := r.URL.Query().Get("embedded") == "true"
+	if name == "" {
+		return http.StatusBadRequest, fmt.Errorf("name parameter is required")
+	}
+
+	sourceCfg, ok := config.Server.SourceMap[d.share.Source]
+	if !ok {
+		return http.StatusNotFound, fmt.Errorf("source not found")
+	}
+
+	fileInfo, err := files.FileInfoFaster(utils.FileOptions{
+		Path:                     d.IndexPath,
+		Source:                   sourceCfg.Name,
+		Expand:                   true,
+		Content:                  false,
+		Metadata:                 true,
+		ExtractEmbeddedSubtitles: config.Integrations.Media.ExtractEmbeddedSubtitles && d.share.ExtractEmbeddedSubtitles,
+		ShowHidden:               d.share.ShowHidden,
+		HideFileExt:              d.user.HideFileExt,
+		FollowSymlinks:           false,
+		SkipExtendedAttrs:        false,
+	}, store.Access, d.shareUser, store.Share)
+	if err != nil {
+		return errToStatus(err), err
+	}
+	if !strings.HasPrefix(fileInfo.Type, "video") {
+		return http.StatusNotFound, fmt.Errorf("file is not a video")
+	}
+
+	track := findSubtitleTrack(fileInfo.Subtitles, name, embedded)
+	if track == nil {
+		return http.StatusNotFound, fmt.Errorf("subtitle track '%s' not found", name)
+	}
+
+	var content string
+	if !embedded {
+		subtitlePath := filepath.Join(filepath.Dir(fileInfo.RealPath), filepath.Base(track.Name))
+		content, err = utils.GetSubtitleSidecarContent(subtitlePath)
+		if err != nil {
+			return http.StatusInternalServerError, fmt.Errorf("failed to get subtitle sidecar content: %v", err)
+		}
+	} else {
+		if track.Index == nil {
+			return http.StatusNotFound, fmt.Errorf("embedded subtitle track '%s' not found", name)
+		}
+		content, err = ffmpeg.ExtractSubtitleContent(fileInfo.RealPath, *track.Index)
+		if err != nil {
+			return http.StatusInternalServerError, fmt.Errorf("failed to extract embedded subtitle: %v", err)
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", "inline")
+	w.Header().Set("Cache-Control", "private")
+	http.ServeContent(w, r, name, time.Now(), bytes.NewReader([]byte(content)))
+	return http.StatusOK, nil
+}

--- a/backend/http/media.go
+++ b/backend/http/media.go
@@ -334,7 +334,7 @@ func publicSubtitlesHandler(w http.ResponseWriter, r *http.Request, d *requestCo
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Content-Disposition", "inline")
-	w.Header().Set("Cache-Control", "private")
+	w.Header().Set("Cache-Control", "no-store")
 	http.ServeContent(w, r, name, time.Now(), bytes.NewReader([]byte(content)))
 	return http.StatusOK, nil
 }

--- a/backend/http/middleware.go
+++ b/backend/http/middleware.go
@@ -121,7 +121,8 @@ func withHashFileHelper(fn handleFunc) handleFunc {
 		// skip file fetch for certain apis
 		if (r.Method == "POST" && strings.Contains(r.URL.Path, "/resources")) ||
 			(r.Method == "GET" && strings.Contains(r.URL.Path, "/resources/items")) ||
-			(r.Method == "GET" && strings.Contains(r.URL.Path, "/media/metadata")) {
+			(r.Method == "GET" && strings.Contains(r.URL.Path, "/media/metadata")) ||
+			(r.Method == "GET" && strings.Contains(r.URL.Path, "/media/subtitles")) {
 			return fn(w, r, data)
 		}
 		file, err := FileInfoFasterFunc(utils.FileOptions{

--- a/backend/http/middleware_test.go
+++ b/backend/http/middleware_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -423,6 +424,65 @@ func TestPublicShareHandlerAuthentication(t *testing.T) {
 				t.Errorf("expected status code %d, got %d", tc.expectedStatusCode, status)
 			}
 		})
+	}
+}
+
+func TestWithHashFileHelper_SkipsPrefetchForMediaSubtitles(t *testing.T) {
+	setupTestEnv(t)
+
+	dummyUser := &users.User{
+		ID:       1,
+		Username: "testuser",
+		Scopes: []users.SourceScope{
+			{Name: "srv", Scope: "/"},
+		},
+	}
+	if err := store.Users.Save(dummyUser, false, false); err != nil {
+		t.Fatal("failed to save dummy user:", err)
+	}
+
+	shareLink := &share.Link{
+		Hash:   "subtitle_share_hash",
+		UserID: 1,
+		CommonShare: share.CommonShare{
+			Source: "/srv",
+			Path:   "/",
+		},
+	}
+	if err := store.Share.Save(shareLink); err != nil {
+		t.Fatal("failed to save share:", err)
+	}
+
+	fileInfoCalled := false
+	originalFileInfoFaster := FileInfoFasterFunc
+	t.Cleanup(func() { FileInfoFasterFunc = originalFileInfoFaster })
+	FileInfoFasterFunc = func(opts utils.FileOptions, access *access.Storage, user *users.User, share *share.Storage) (*iteminfo.ExtendedFileInfo, error) {
+		fileInfoCalled = true
+		return nil, fmt.Errorf("FileInfoFasterFunc should not be called for /media/subtitles")
+	}
+
+	handlerCalled := false
+	handler := withHashFileHelper(func(w http.ResponseWriter, r *http.Request, d *requestContext) (int, error) {
+		handlerCalled = true
+		return http.StatusOK, nil
+	})
+
+	if err := store.Settings.Save(&settings.Settings{Auth: settings.Auth{Key: "key"}}); err != nil {
+		t.Fatal("failed to save settings:", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/public/api/media/subtitles?hash=subtitle_share_hash&path=/video.mkv&name=sub.srt", http.NoBody)
+
+	status, err := handler(recorder, req, &requestContext{})
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d (err=%v)", http.StatusOK, status, err)
+	}
+	if !handlerCalled {
+		t.Fatal("expected wrapped handler to run")
+	}
+	if fileInfoCalled {
+		t.Fatal("FileInfoFasterFunc should not be called for GET /media/subtitles")
 	}
 }
 

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -3777,6 +3777,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/public/api/media/subtitles": {
+            "get": {
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "Shares"
+                ],
+                "summary": "Get subtitle content (public share)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share hash",
+                        "name": "hash",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Path within the share",
+                        "name": "path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Subtitle track name",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Whether this is an embedded stream",
+                        "name": "embedded",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw subtitle content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
         "/public/api/resources": {
             "get": {
                 "description": "Returns metadata for files or directories accessible via a public share link. Browsing is disabled for upload-only shares.",

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -3824,19 +3824,19 @@ const docTemplate = `{
                     "403": {
                         "description": "Forbidden",
                         "schema": {
+                            "type": "object",
                             "additionalProperties": {
                                 "type": "string"
-                            },
-                            "type": "object"
+                            }
                         }
                     },
                     "404": {
                         "description": "Not found",
                         "schema": {
+                            "type": "object",
                             "additionalProperties": {
                                 "type": "string"
-                            },
-                            "type": "object"
+                            }
                         }
                     }
                 }

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -3766,6 +3766,71 @@
                 }
             }
         },
+        "/public/api/media/subtitles": {
+            "get": {
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "Shares"
+                ],
+                "summary": "Get subtitle content (public share)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share hash",
+                        "name": "hash",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Path within the share",
+                        "name": "path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Subtitle track name",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Whether this is an embedded stream",
+                        "name": "embedded",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw subtitle content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
         "/public/api/resources": {
             "get": {
                 "description": "Returns metadata for files or directories accessible via a public share link. Browsing is disabled for upload-only shares.",

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -3813,19 +3813,19 @@
                     "403": {
                         "description": "Forbidden",
                         "schema": {
+                            "type": "object",
                             "additionalProperties": {
                                 "type": "string"
-                            },
-                            "type": "object"
+                            }
                         }
                     },
                     "404": {
                         "description": "Not found",
                         "schema": {
+                            "type": "object",
                             "additionalProperties": {
                                 "type": "string"
-                            },
-                            "type": "object"
+                            }
                         }
                     }
                 }

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -5019,6 +5019,49 @@ paths:
       summary: Directory with media metadata (public share)
       tags:
       - Shares
+  /public/api/media/subtitles:
+    get:
+      parameters:
+      - description: Share hash
+        in: query
+        name: hash
+        required: true
+        type: string
+      - description: Path within the share
+        in: query
+        name: path
+        type: string
+      - description: Subtitle track name
+        in: query
+        name: name
+        required: true
+        type: string
+      - description: Whether this is an embedded stream
+        in: query
+        name: embedded
+        type: boolean
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: Raw subtitle content
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get subtitle content (public share)
+      tags:
+      - Shares
   /public/api/resources:
     get:
       consumes:

--- a/frontend/src/api/media.js
+++ b/frontend/src/api/media.js
@@ -3,16 +3,35 @@ import { state } from "@/store";
 import { getApiPath, getPublicApiPath } from "@/utils/url.js";
 import { adjustedData, fetchURL } from "./utils";
 
-// GET /api/media/subtitles
+// GET /api/media/subtitles or /public/api/media/subtitles
 export async function getSubtitleContent(source, path, subtitleName, embedded = false) {
   try {
-    const apiPath = getApiPath('media/subtitles', {
-      source: source,
-      path: path,
+    const hash = state.shareInfo?.hash || null
+    const baseParams = {
+      path,
       name: subtitleName,
-      embedded: embedded.toString()
-    })
-    const res = await fetchURL(apiPath)
+      ...(embedded && { embedded: 'true' }),
+    }
+
+    let res
+    if (hash) {
+      const apiPath = getPublicApiPath('media/subtitles', {
+        hash,
+        ...baseParams,
+        ...(state.shareInfo.token && { token: state.shareInfo.token }),
+      })
+      const sharePassword = localStorage.getItem(`sharepass:${hash}`) || ''
+      res = await fetchURL(apiPath, {
+        headers: { 'X-SHARE-PASSWORD': sharePassword },
+      })
+    } else {
+      const apiPath = getApiPath('media/subtitles', {
+        source,
+        ...baseParams,
+      })
+      res = await fetchURL(apiPath)
+    }
+
     const content = await res.text()
     return content
   } catch (err) {


### PR DESCRIPTION
Public share visitors could see external subtitle tracks in metadata but received 401 when loading content because the frontend always requested /api/media/subtitles. Add /public/api/media/subtitles with share hash and password validation, route share views through the public endpoint, and skip the share middleware file prefetch for subtitle requests.

**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external subtitles failing to load when viewing publicly shared videos.
  * Public video shares can now retrieve sidecar and embedded subtitle tracks, including password-protected shares.
  * Restored upload chunk size `0` behavior to disable chunking and help prevent multi-chunk upload stalls on iOS 26.
* **Documentation**
  * Added these fixes to the v1.5.4 stable changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->