### PR TITLE
fix security, PWA, and upload changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,20 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v2.0.3
 
+ **Security**:
+ - [High] Stored XSS via HTML preview: strip `<script>` from sanitized srcdoc, remove `allow-same-origin` from the preview iframe sandbox, set HttpOnly on the session cookie, and add a nonce-based `script-src` CSP on the SPA shell (GHSA-vvm6-jwrf-hgmg) -- thanks @qrn12580
+
+ **New Features**:
+ - Added option to globally disable the "Install App" message via `frontend.disablePWAInstall`
+
  **Bugfixes**:
  - Fixed Fuji `.raf` thumbnail preview by extracting the camera-embedded JPEG from the RAF header (regression for files where TIFF-based raw extraction does not apply).
  - Image previews for unsupported decodable formats now return HTTP 415 immediately instead of attempting JPEG decode and returning HTTP 500.
  - OIDC: preserve the verified ID-token user identifier when falling back to the UserInfo endpoint for missing groups, so login no longer fails with HTTP 500 when UserInfo returns groups but omits the configured identifier.
  - LDAP: restore `memberOf` as the default `groupsClaim` when unset, fixing group-based admin and login authorization for existing LDAP configs after the v2.0.2 default changed to `groups`.
+ - "Install app" message reappears after being cleared on device.
+ - Restored upload chunk size `0` to disable chunking as documented ([#2202](https://github.com/gtsteffaniak/filebrowser/issues/2202)).
+ - Fixed iOS 26 / WebKit multi-chunk upload stall by isolating chunk connections and returning partial chunk JSON responses ([#2734](https://github.com/gtsteffaniak/filebrowser/issues/2734)).
 
 ## v2.0.2
 

--- a/backend/internal/utils/crypto.go
+++ b/backend/internal/utils/crypto.go
@@ -89,3 +89,22 @@ func CSPNonce() (string, error) {
 	}
 	return base64.StdEncoding.EncodeToString(b), nil
 }
+
+// CSPNonceFromData returns an existing cspNonce from map template data, or generates
+// and stores one when data is a map[string]interface{}. For other data types it
+// generates a fresh nonce without modifying data.
+func CSPNonceFromData(data interface{}) (string, error) {
+	m, ok := data.(map[string]interface{})
+	if !ok {
+		return CSPNonce()
+	}
+	if nonce, ok := m["cspNonce"].(string); ok && nonce != "" {
+		return nonce, nil
+	}
+	nonce, err := CSPNonce()
+	if err != nil {
+		return "", fmt.Errorf("csp nonce: %w", err)
+	}
+	m["cspNonce"] = nonce
+	return nonce, nil
+}

--- a/backend/internal/web/auth.go
+++ b/backend/internal/web/auth.go
@@ -233,17 +233,7 @@ func logoutHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, err
 	}
 
 	// Clear the authentication cookie by setting it to expire in the past
-	host := sessionCookieDomain(r)
-	cookie := &http.Cookie{
-		Name:     "filebrowser_quantum_jwt",
-		Value:    "",
-		Domain:   host,
-		Path:     "/",
-		SameSite: http.SameSiteStrictMode,
-		Expires:  time.Unix(0, 0), // Expire immediately
-		MaxAge:   -1,              // Delete cookie
-	}
-	http.SetCookie(w, cookie)
+	http.SetCookie(w, sessionCookie(r, "", time.Unix(0, 0), -1, http.SameSiteStrictMode))
 
 	logoutUrl := fmt.Sprintf("%vlogin", settings.Config.Http.BaseURL) // Default fallback
 	if d.User != nil && d.User.LoginMethod == users.LoginMethodProxy {
@@ -427,17 +417,27 @@ func AuthenticateShareRequest(r *http.Request, l share.Share) (int, error) {
 	return 200, nil
 }
 
-// SetSessionCookie sets the authentication token as an HTTP cookie.
-func SetSessionCookie(w http.ResponseWriter, r *http.Request, token string, expiresTime time.Time) {
-	cookie := &http.Cookie{
-		Name:     "filebrowser_quantum_jwt",
+const sessionCookieName = "filebrowser_quantum_jwt"
+
+// sessionCookie builds the JWT cookie. HttpOnly prevents srcdoc XSS from reading
+// document.cookie; Secure is set when the request is HTTPS (including via proxy).
+func sessionCookie(r *http.Request, token string, expiresTime time.Time, maxAge int, sameSite http.SameSite) *http.Cookie {
+	return &http.Cookie{
+		Name:     sessionCookieName,
 		Value:    token,
 		Domain:   sessionCookieDomain(r),
 		Path:     "/",
-		SameSite: http.SameSiteStrictMode, // strict mode prevents cookie from being sent to other domains
+		SameSite: sameSite,
+		HttpOnly: true,
+		Secure:   requestScheme(r) == "https",
 		Expires:  expiresTime,
+		MaxAge:   maxAge,
 	}
-	http.SetCookie(w, cookie)
+}
+
+// SetSessionCookie sets the authentication token as an HTTP cookie.
+func SetSessionCookie(w http.ResponseWriter, r *http.Request, token string, expiresTime time.Time) {
+	http.SetCookie(w, sessionCookie(r, token, expiresTime, 0, http.SameSiteStrictMode))
 }
 
 // applyNamedApiTokenGlobalCaps intersects owner globals with JWT global caps for named custom API tokens.

--- a/backend/internal/web/oidc.go
+++ b/backend/internal/web/oidc.go
@@ -394,19 +394,8 @@ func loginWithOidcUser(w http.ResponseWriter, r *http.Request, username string, 
 	// This allows backend to identify expired sessions and provide better user feedback
 	expiresTime := time.Now().Add(expires).Add(time.Minute * 30)
 
-	// Set the authentication token as an HTTP cookie
-	host := requestHost(r)
-	cookie := &http.Cookie{
-		Name:     "filebrowser_quantum_jwt",
-		Value:    tokenString,
-		Domain:   strings.Split(host, ":")[0], // Set domain to the host without port
-		Path:     "/",
-		SameSite: http.SameSiteLaxMode, // Lax mode allows cookie on navigation from OIDC provider
-		Expires:  expiresTime,
-		// HttpOnly: true, // Cannot use HttpOnly since frontend needs to read cookie for renew operations
-		// Secure: true, // Enable this in production with HTTPS
-	}
-	http.SetCookie(w, cookie)
+	// Set the authentication token as an HTTP cookie (Lax for OIDC redirect return).
+	http.SetCookie(w, sessionCookie(r, tokenString, expiresTime, 0, http.SameSiteLaxMode))
 
 	// Set the authenticated user in the request context or response writer
 	// This allows subsequent handlers to access the current user.

--- a/backend/internal/web/resource.go
+++ b/backend/internal/web/resource.go
@@ -803,6 +803,7 @@ func ResourcePostHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 		if acquireErr := activeUploadSessions.acquire(realPath, sessionID); acquireErr != nil {
 			if isUploadSessionConflict(acquireErr) {
 				logger.Debugf("%v", acquireErr)
+				drainRequestBody(r)
 				return http.StatusConflict, acquireErr
 			}
 			logger.Debugf("%v", acquireErr)
@@ -819,6 +820,7 @@ func ResourcePostHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 				// If type mismatch (existing dir vs requesting file) and not overriding
 				if existingIsDir != requestingDir && r.URL.Query().Get("override") != "true" {
 					logger.Debugf("Type conflict detected in chunked: existing is dir=%v, requesting dir=%v at path=%v", existingIsDir, requestingDir, realPath)
+					drainRequestBody(r)
 					return http.StatusConflict, nil
 				}
 			}
@@ -828,6 +830,7 @@ func ResourcePostHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 			if err == nil { // File exists
 				if r.URL.Query().Get("override") != "true" {
 					logger.Debugf("resource already exists: %v", fileInfo.RealPath)
+					drainRequestBody(r)
 					return http.StatusConflict, nil
 				}
 				// If overriding, delete existing thumbnails
@@ -934,6 +937,9 @@ func ResourcePostHandler(w http.ResponseWriter, r *http.Request, d *Context) (in
 			reconcileSharesAfterMove(false, source, source, tempFilePath, realPath)
 			activity.RecordUpload(r, toActor(d), source, path, false)
 			activeUploadSessions.release(realPath, sessionID)
+		}
+		if err = writeChunkUploadResponse(w, assembled, totalSize, assembled == totalSize); err != nil {
+			logger.Debugf("could not write chunk upload response: %v", err)
 		}
 		return http.StatusOK, nil
 	}

--- a/backend/internal/web/resource_upload_test.go
+++ b/backend/internal/web/resource_upload_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -558,5 +559,53 @@ func TestResourcePostHandler_ExpiredSessionAllowsNewUpload(t *testing.T) {
 	}
 	if !bytes.Equal(got, body) {
 		t.Fatalf("got %q want %q", got, body)
+	}
+}
+
+func TestResourcePostHandler_PartialChunkResponse(t *testing.T) {
+	_, user := setupUploadHTTPTest(t)
+	part1 := []byte("aaaa")
+	total := 8
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/resources?source=uploads&path=/partial.bin", bytes.NewReader(part1))
+	req.ContentLength = int64(len(part1))
+	req.Header.Set("X-File-Upload-Session", "session-partial")
+	req.Header.Set("X-File-Chunk-Offset", "0")
+	req.Header.Set("X-File-Total-Size", strconv.Itoa(total))
+
+	status, err := ResourcePostHandler(rec, req, &requestContext{User: user})
+	if status != http.StatusOK || err != nil {
+		t.Fatalf("chunk1 status=%d err=%v", status, err)
+	}
+	if rec.Header().Get("Connection") != "close" {
+		t.Fatalf("expected Connection: close, got %q", rec.Header().Get("Connection"))
+	}
+	var payload chunkUploadResponse
+	if decodeErr := json.NewDecoder(rec.Body).Decode(&payload); decodeErr != nil {
+		t.Fatalf("decode response: %v", decodeErr)
+	}
+	if payload.Complete || payload.Offset != int64(len(part1)) || payload.Total != int64(total) {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+
+	part2 := []byte("bbbb")
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/resources?source=uploads&path=/partial.bin", bytes.NewReader(part2))
+	req2.ContentLength = int64(len(part2))
+	req2.Header.Set("X-File-Upload-Session", "session-partial")
+	req2.Header.Set("X-File-Chunk-Offset", strconv.Itoa(len(part1)))
+	req2.Header.Set("X-File-Total-Size", strconv.Itoa(total))
+
+	status, err = ResourcePostHandler(rec2, req2, &requestContext{User: user})
+	if status != http.StatusOK || err != nil {
+		t.Fatalf("chunk2 status=%d err=%v", status, err)
+	}
+	var finalPayload chunkUploadResponse
+	if decodeErr := json.NewDecoder(rec2.Body).Decode(&finalPayload); decodeErr != nil {
+		t.Fatalf("decode final response: %v", decodeErr)
+	}
+	if !finalPayload.Complete || finalPayload.Offset != int64(total) {
+		t.Fatalf("unexpected final payload: %+v", finalPayload)
 	}
 }

--- a/backend/internal/web/session_cookie_test.go
+++ b/backend/internal/web/session_cookie_test.go
@@ -1,0 +1,63 @@
+package web
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
+)
+
+func TestSessionCookie_HttpOnlyAndSecureOnHTTPS(t *testing.T) {
+	prev := settings.Config.Http.TrustProxyHeaders
+	settings.Config.Http.TrustProxyHeaders = true
+	t.Cleanup(func() { settings.Config.Http.TrustProxyHeaders = prev })
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Host = "example.com"
+
+	c := sessionCookie(req, "token", time.Now().Add(time.Hour), 0, http.SameSiteStrictMode)
+	if !c.HttpOnly {
+		t.Fatal("expected HttpOnly session cookie")
+	}
+	if !c.Secure {
+		t.Fatal("expected Secure session cookie over HTTPS")
+	}
+	if c.Name != sessionCookieName {
+		t.Fatalf("cookie name: got %q", c.Name)
+	}
+}
+
+func TestSessionCookie_NotSecureOnHTTP(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "localhost"
+
+	c := sessionCookie(req, "token", time.Now().Add(time.Hour), 0, http.SameSiteStrictMode)
+	if !c.HttpOnly {
+		t.Fatal("expected HttpOnly session cookie")
+	}
+	if c.Secure {
+		t.Fatal("did not expect Secure cookie on plain HTTP")
+	}
+}
+
+func TestSpaContentSecurityPolicy_BlocksUntrustedScripts(t *testing.T) {
+	csp := spaContentSecurityPolicy("testnonce")
+	if csp != "script-src 'self' 'nonce-testnonce' https://cdn.jsdelivr.net https://www.google.com https://www.gstatic.com" {
+		t.Fatalf("unexpected CSP: %s", csp)
+	}
+	if strings.Contains(csp, "'unsafe-inline'") {
+		t.Fatal("script-src must not allow unsafe-inline (srcdoc XSS)")
+	}
+	if strings.Contains(csp, "default-src") {
+		t.Fatal("CSP should only restrict script-src to avoid breaking frames, blobs, and external assets")
+	}
+}

--- a/backend/internal/web/static.go
+++ b/backend/internal/web/static.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -42,13 +43,28 @@ func (t *TemplateRenderer) Render(w http.ResponseWriter, name string, data inter
 			return fmt.Errorf("error reloading template: %w", err)
 		}
 	}
-	// Set headers
+	nonce, err := utils.CSPNonceFromData(data)
+	if err != nil {
+		return err
+	}
+
+	// Inherited by srcdoc preview frames: nonce'd SPA scripts run; untrusted preview scripts do not.
+	w.Header().Set("Content-Security-Policy", spaContentSecurityPolicy(nonce))
 	w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("X-Accel-Expires", "0")
 	w.Header().Set("Transfer-Encoding", "identity")
 	// Execute the template with the provided data
 	return templates.ExecuteTemplate(w, name, data)
+}
+
+// spaContentSecurityPolicy restricts only scripts. srcdoc preview frames inherit
+// this header, blocking inline scripts without limiting frames, images, or API calls.
+func spaContentSecurityPolicy(nonce string) string {
+	return fmt.Sprintf(
+		"script-src 'self' 'nonce-%s' https://cdn.jsdelivr.net https://www.google.com https://www.gstatic.com",
+		nonce,
+	)
 }
 
 func handleWithStaticData(w http.ResponseWriter, r *http.Request, d *requestContext, file, contentType string) (int, error) {
@@ -223,7 +239,19 @@ func handleWithStaticData(w http.ResponseWriter, r *http.Request, d *requestCont
 		"loginButtonText":        settings.Config.Frontend.LoginButtonText,
 		"passkeyAvailable":       settings.Config.Auth.Methods.PasskeyAuth.Enabled,
 		"passkeyLoginButtonText": settings.Config.Auth.Methods.PasskeyAuth.LoginButtonText,
+		"disablePWAInstall":      settings.Config.Frontend.DisablePWAInstall,
 	}
+
+	cspNonce, err := utils.CSPNonce()
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("csp nonce: %w", err)
+	}
+	globalVars, ok := data["globalVars"].(map[string]interface{})
+	if !ok {
+		return http.StatusInternalServerError, errors.New("unable to load global variables")
+	}
+	globalVars["cspNonce"] = cspNonce
+	data["cspNonce"] = cspNonce
 
 	// Marshal each variable to JSON strings for direct template usage
 	globalVarsJSON, err := json.Marshal(data["globalVars"])

--- a/backend/internal/web/upload_validate.go
+++ b/backend/internal/web/upload_validate.go
@@ -3,7 +3,9 @@ package web
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"strconv"
@@ -95,4 +97,28 @@ func isContentUpload(r *http.Request) bool {
 	}
 	_, ok, err := parseUploadTotalSize(r)
 	return err == nil && ok
+}
+
+func drainRequestBody(r *http.Request) {
+	if r.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, r.Body)
+	_ = r.Body.Close()
+}
+
+type chunkUploadResponse struct {
+	Offset   int64 `json:"offset"`
+	Total    int64 `json:"total"`
+	Complete bool  `json:"complete"`
+}
+
+func writeChunkUploadResponse(w http.ResponseWriter, offset, total int64, complete bool) error {
+	w.Header().Set("Connection", "close")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	return json.NewEncoder(w).Encode(chunkUploadResponse{
+		Offset:   offset,
+		Total:    total,
+		Complete: complete,
+	})
 }

--- a/backend/pkg/settings/structs.go
+++ b/backend/pkg/settings/structs.go
@@ -300,6 +300,7 @@ type Frontend struct {
 	LoginIcon             string         `json:"loginIcon"`           // path to an image file for the login page icon
 	LoginButtonText       string         `json:"loginButtonText"`     // text to display on the login button
 	OIDCLoginButtonText   string         `json:"oidcLoginButtonText"` // text to display on the OIDC login button
+	DisablePWAInstall     bool           `json:"disablePWAInstall"`   // disable the PWA install button in the sidebar
 }
 
 type StylingConfig struct {

--- a/backend/swagger/docs/docs.go
+++ b/backend/swagger/docs/docs.go
@@ -5675,6 +5675,10 @@ const docTemplate = `{
                     "description": "disable the nav buttons in the sidebar",
                     "type": "boolean"
                 },
+                "disablePWAInstall": {
+                    "description": "disable the PWA install button in the sidebar",
+                    "type": "boolean"
+                },
                 "disableUsedPercentage": {
                     "description": "disable used percentage for the sources in the sidebar",
                     "type": "boolean"

--- a/backend/swagger/docs/swagger.json
+++ b/backend/swagger/docs/swagger.json
@@ -5664,6 +5664,10 @@
                     "description": "disable the nav buttons in the sidebar",
                     "type": "boolean"
                 },
+                "disablePWAInstall": {
+                    "description": "disable the PWA install button in the sidebar",
+                    "type": "boolean"
+                },
                 "disableUsedPercentage": {
                     "description": "disable used percentage for the sources in the sidebar",
                     "type": "boolean"

--- a/backend/swagger/docs/swagger.yaml
+++ b/backend/swagger/docs/swagger.yaml
@@ -413,6 +413,9 @@ definitions:
       disableNavButtons:
         description: disable the nav buttons in the sidebar
         type: boolean
+      disablePWAInstall:
+        description: disable the PWA install button in the sidebar
+        type: boolean
       disableUsedPercentage:
         description: disable used percentage for the sources in the sidebar
         type: boolean

--- a/frontend/public/config.generated.yaml
+++ b/frontend/public/config.generated.yaml
@@ -164,6 +164,7 @@ frontend:
   loginIcon: ""                           # path to an image file for the login page icon
   loginButtonText: ""                     # text to display on the login button
   oidcLoginButtonText: ""                 # text to display on the OIDC login button
+  disablePWAInstall: false                # disable the PWA install button in the sidebar
 userDefaults:                             # optional signup/CLI defaults; per-user values are managed in the UI
   sidebar:
     disableQuickToggles: false            # disable the quick toggles in the sidebar

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -50,7 +50,7 @@
   <link rel="canonical" href="https://filebrowserquantum.com">
 
   <!-- Injected variables come from backend server -->
-  <script>
+  <script nonce="{{ .cspNonce }}">
     window.globalVars = {{ .globalVars }};
     window.__pwaDeferredPrompt = null;
     window.addEventListener("beforeinstallprompt", function (event) {

--- a/frontend/src/api/resources.js
+++ b/frontend/src/api/resources.js
@@ -19,6 +19,14 @@ export { fetchPreviewImage } from '@/utils/previewRequests'
 
 const VIEW_TOKEN_TTL_SECONDS = 15 * 60;
 
+function chunkUploadApiPath(apiPath, headers) {
+  if (headers["X-File-Chunk-Offset"] === undefined) {
+    return apiPath;
+  }
+  const sep = apiPath.includes("?") ? "&" : "?";
+  return `${apiPath}${sep}_chunkSeq=${headers["X-File-Chunk-Offset"]}`;
+}
+
 function cacheViewTokenFromListing(data) {
   const scope = getters.isShare()
     ? state.shareInfo?.hash || data?.source
@@ -718,11 +726,15 @@ export function post(
         }
         const request = new XMLHttpRequest();
         opState.xhr = request;
-        request.open("POST", apiPath, true);
+        const resolvedPath = chunkUploadApiPath(apiPath, headers);
+        request.open("POST", resolvedPath, true);
 
         Object.entries(headers).forEach(([header, value]) => {
           request.setRequestHeader(header, value);
         });
+        if (headers["X-File-Chunk-Offset"] !== undefined) {
+          request.setRequestHeader("Connection", "close");
+        }
 
         if (typeof onupload === "function") {
           request.upload.onprogress = (event) => {
@@ -1258,11 +1270,14 @@ export function postPublic(
     });
 
     const request = new XMLHttpRequest();
-    request.open("POST", apiPath, true);
+    request.open("POST", chunkUploadApiPath(apiPath, headers), true);
 
     Object.entries(headers).forEach(([header, value]) => {
       request.setRequestHeader(header, value);
     });
+    if (headers["X-File-Chunk-Offset"] !== undefined) {
+      request.setRequestHeader("Connection", "close");
+    }
 
     if (typeof onupload === "function") {
       request.upload.onprogress = (event) => {

--- a/frontend/src/components/sidebar/Sidebar.vue
+++ b/frontend/src/components/sidebar/Sidebar.vue
@@ -57,7 +57,7 @@ export default {
       resizeStartX: 0,
       resizeStartWidth: 0,
       previousSidebarSize: null, // Remember the previous width when switching from desktop to mobile.
-      pwaInstallDismissed: sessionStorage.getItem("pwaInstallDismissed") === "true",
+      pwaInstallDismissed: localStorage.getItem("pwaInstallDismissed") === "true",
     };
   },
   mounted() {
@@ -121,7 +121,7 @@ export default {
       );
     },
     showPwaInstall() {
-      return installAvailable.value && !this.pwaInstallDismissed && !this.isSettings;
+      return installAvailable.value && !this.pwaInstallDismissed && !this.isSettings && !globalVars.disablePWAInstall;
     },
   },
   methods: {
@@ -178,11 +178,14 @@ export default {
       mutations.setSeenUpdate(globalVars.updateAvailable);
     },
     async installPwa() {
-      await promptInstall();
+      const accepted = await promptInstall();
+      if (accepted) {
+        this.dismissPwaInstall();
+      }
     },
     dismissPwaInstall() {
       this.pwaInstallDismissed = true;
-      sessionStorage.setItem("pwaInstallDismissed", "true");
+      localStorage.setItem("pwaInstallDismissed", "true");
     },
   },
 };

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -1,6 +1,5 @@
 import { getters, mutations, state } from "@/store";
 import { globalVars } from "@/utils/constants";
-import { getCookie } from "@/utils/cookie.js";
 import { getApiPath } from "@/utils/url.js";
 
 /** Session JWT: renew when within 30 minutes of expiry (former X-Renew-Token threshold). */
@@ -14,6 +13,29 @@ const KEEP_ALIVE_INTERVAL_MS = 60 * 1000;
 
 let keepAliveTimer = null;
 let renewInFlight = null;
+let sessionExpiresAt = null;
+
+function decodeJwtExp(token) {
+  if (!token) {
+    return null;
+  }
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+  try {
+    const padded = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padLength = (4 - (padded.length % 4)) % 4;
+    const payload = JSON.parse(atob(padded + "=".repeat(padLength)));
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+function setSessionExpiresAtFromToken(token) {
+  sessionExpiresAt = decodeJwtExp(token);
+}
 
 /**
  * @param {number|null|undefined} expiresAtSeconds Unix expiry in seconds
@@ -36,36 +58,9 @@ export function shouldRefreshBeforeExpiry(expiresAtSeconds, refreshBeforeMs) {
   return msUntilRefresh(expiresAtSeconds, refreshBeforeMs) === 0;
 }
 
-function decodeBase64UrlJson(segment) {
-  const padded = segment.replace(/-/g, "+").replace(/_/g, "/");
-  const padLength = (4 - (padded.length % 4)) % 4;
-  const base64 = padded + "=".repeat(padLength);
-  return JSON.parse(atob(base64));
-}
-
-/** Unix `exp` from the session JWT cookie, or null if missing/unreadable. */
+/** Unix `exp` tracked from the last successful renew response, or null if unknown. */
 export function getSessionJwtExpiresAt() {
-  const raw = getCookie(SESSION_COOKIE_NAME);
-  if (!raw) {
-    return null;
-  }
-  // Cookie value may be URI-encoded depending on how it was set.
-  let token = raw;
-  try {
-    token = decodeURIComponent(raw);
-  } catch {
-    // use raw
-  }
-  const parts = token.split(".");
-  if (parts.length < 2) {
-    return null;
-  }
-  try {
-    const payload = decodeBase64UrlJson(parts[1]);
-    return typeof payload.exp === "number" ? payload.exp : null;
-  } catch {
-    return null;
-  }
+  return sessionExpiresAt;
 }
 
 export async function validateLogin(isPublicRoute = false) {
@@ -80,19 +75,11 @@ export async function validateLogin(isPublicRoute = false) {
   });
 
   if (res.status !== 200) {
-    // A 401 from the non-public self check means our session cookie (JWT) is no
-    // longer valid — typically it expired. Clear it and redirect to login so the
-    // user can re-authenticate, instead of leaving the stale cookie in place
-    // (which otherwise leaves the app stuck on reload). Only do this for a real,
-    // non-public session: public routes legitimately 401 for anonymous share
-    // visitors, and we skip it when there is no session cookie to clear.
-    if (
-      res.status === 401 &&
-      !isPublicRoute &&
-      document.cookie
-        .split(";")
-        .some((c) => c.trim().startsWith(`${SESSION_COOKIE_NAME}=`))
-    ) {
+    // A 401 from the non-public self check means our session is no longer valid —
+    // typically the HttpOnly JWT cookie expired. Redirect to login when the app
+    // still considers the user logged in (public routes legitimately 401 for
+    // anonymous share visitors).
+    if (res.status === 401 && !isPublicRoute && getters.isLoggedIn()) {
       sessionExpired();
     }
     throw new Error(`{"status":${res.status},"message":"${await res.text()}"}`);
@@ -136,6 +123,7 @@ export async function renew() {
     });
     const body = await res.text();
     if (res.status === 200) {
+      setSessionExpiresAtFromToken(body);
       mutations.setSession(generateRandomCode(8));
       return;
     }
@@ -208,8 +196,8 @@ export async function logout(redirectUrl) {
       if (redirectUrl) {
         destination = redirectUrl;
       }
-      // Backend clears the cookie, but frontend does it as fail-safe cleanup
-      document.cookie = `${SESSION_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/`;
+      // Backend clears the HttpOnly session cookie.
+      sessionExpiresAt = null;
       void mutations.setCurrentUser(null);
       // No need to clear state.jwt - cookie is the source of truth
       // Add a small delay to ensure cookie deletion completes before redirect
@@ -226,16 +214,12 @@ export async function logout(redirectUrl) {
   }
 }
 
-// Handle an authenticated request that came back 401 because the session cookie
-// (JWT) is no longer valid — typically it expired while the tab was idle. Unlike
-// logout(), this does NOT call the server (which would itself 401 on an expired
-// token and leave the stale cookie in place); it clears the cookie locally and
-// redirects to the login page so the user can re-authenticate, instead of being
-// stuck on a raw "token is expired" error.
+// Handle an authenticated request that came back 401 because the session is no
+// longer valid — typically it expired while the tab was idle. Unlike logout(),
+// this does NOT call the server; it clears client state and redirects to login.
 export function sessionExpired() {
   stopSessionKeepAlive();
-  document.cookie =
-    `${SESSION_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/`;
+  sessionExpiresAt = null;
   void mutations.setCurrentUser(null);
   // Avoid a redirect loop if we're already on the login page.
   if (window.location.pathname.endsWith("/login")) {

--- a/frontend/src/utils/auth.test.js
+++ b/frontend/src/utils/auth.test.js
@@ -24,7 +24,6 @@ import {
   getSessionJwtExpiresAt,
   msUntilRefresh,
   renew,
-  SESSION_COOKIE_NAME,
   SESSION_REFRESH_BEFORE_MS,
   shouldRefreshBeforeExpiry,
   startSessionKeepAlive,
@@ -32,8 +31,6 @@ import {
   validateLogin,
   VIEW_REFRESH_BEFORE_MS,
 } from './auth.js';
-
-const COOKIE = SESSION_COOKIE_NAME;
 
 function respond(status, body = '') {
   global.fetch = vi.fn().mockResolvedValue({
@@ -58,10 +55,8 @@ function makeJwt(expSeconds) {
 describe('validateLogin session-expiry handling', () => {
   beforeEach(() => {
     storeMock.mutations.setCurrentUser.mockClear();
+    storeMock.getters.isLoggedIn.mockReturnValue(true);
     stopSessionKeepAlive();
-    document.cookie = `${COOKIE}=stale; path=/`;
-    // Stub navigation via Vitest's global-stub API (jsdom doesn't implement
-    // real navigation). pathname+search feed the redirect; href captures it.
     vi.stubGlobal('location', { pathname: '/files/', search: '?a=1', href: '' });
   });
 
@@ -70,12 +65,10 @@ describe('validateLogin session-expiry handling', () => {
     vi.unstubAllGlobals();
   });
 
-  it('clears the cookie + user and redirects (with encoded return path) on a non-public 401 with a session cookie', async () => {
+  it('clears the user and redirects (with encoded return path) on a non-public 401 while logged in', async () => {
     respond(401, 'token is expired');
     await expect(validateLogin(false)).rejects.toThrow();
     expect(storeMock.mutations.setCurrentUser).toHaveBeenCalledWith(null);
-    expect(document.cookie.includes(`${COOKIE}=stale`)).toBe(false);
-    // Full redirect contract: login route + correctly encoded current path+query.
     expect(window.location.href).toBe(
       `/login?redirect=${encodeURIComponent('/files/?a=1')}`
     );
@@ -85,12 +78,11 @@ describe('validateLogin session-expiry handling', () => {
     respond(401, 'unauthorized');
     await expect(validateLogin(true)).rejects.toThrow();
     expect(storeMock.mutations.setCurrentUser).not.toHaveBeenCalledWith(null);
-    expect(document.cookie.includes(`${COOKIE}=stale`)).toBe(true);
     expect(window.location.href).toBe('');
   });
 
-  it('does NOT log out or redirect on a non-public 401 when there is NO session cookie', async () => {
-    document.cookie = `${COOKIE}=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/`;
+  it('does NOT log out or redirect on a non-public 401 when the app is not logged in', async () => {
+    storeMock.getters.isLoggedIn.mockReturnValue(false);
     respond(401, 'unauthorized');
     await expect(validateLogin(false)).rejects.toThrow();
     expect(storeMock.mutations.setCurrentUser).not.toHaveBeenCalledWith(null);
@@ -101,7 +93,6 @@ describe('validateLogin session-expiry handling', () => {
     respond(500, 'server error');
     await expect(validateLogin(false)).rejects.toThrow();
     expect(storeMock.mutations.setCurrentUser).not.toHaveBeenCalledWith(null);
-    expect(document.cookie.includes(`${COOKIE}=stale`)).toBe(true);
     expect(window.location.href).toBe('');
   });
 });
@@ -133,22 +124,24 @@ describe('session JWT keep-alive', () => {
   afterEach(() => {
     stopSessionKeepAlive();
     vi.useRealTimers();
-    document.cookie = `${COOKIE}=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/`;
   });
 
-  it('parses exp from the session cookie JWT', () => {
+  it('tracks exp from the renew response JWT', async () => {
     const exp = Math.floor(Date.now() / 1000) + 3600;
-    document.cookie = `${COOKIE}=${makeJwt(exp)}; path=/`;
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      text: async () => makeJwt(exp),
+    });
+    await renew();
     expect(getSessionJwtExpiresAt()).toBe(exp);
   });
 
   it('ensureSessionFresh renews when JWT is within the refresh window', async () => {
     const exp = Math.floor(Date.now() / 1000) + 60; // 1 minute left
-    document.cookie = `${COOKIE}=${makeJwt(exp)}; path=/`;
-    global.fetch = vi.fn().mockResolvedValue({
-      status: 200,
-      text: async () => 'new-token',
-    });
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ status: 200, text: async () => makeJwt(exp) })
+      .mockResolvedValueOnce({ status: 200, text: async () => makeJwt(exp + 3600) });
+    await renew();
     const renewed = await ensureSessionFresh(SESSION_REFRESH_BEFORE_MS);
     expect(renewed).toBe(true);
     expect(global.fetch).toHaveBeenCalledWith(
@@ -160,7 +153,11 @@ describe('session JWT keep-alive', () => {
 
   it('ensureSessionFresh skips renew when JWT is still fresh', async () => {
     const exp = Math.floor(Date.now() / 1000) + 2 * 60 * 60; // 2 hours left
-    document.cookie = `${COOKIE}=${makeJwt(exp)}; path=/`;
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      text: async () => makeJwt(exp),
+    });
+    await renew();
     global.fetch = vi.fn();
     const renewed = await ensureSessionFresh(SESSION_REFRESH_BEFORE_MS);
     expect(renewed).toBe(false);
@@ -169,7 +166,11 @@ describe('session JWT keep-alive', () => {
 
   it('ensureSessionFresh returns false for joined callers when renew fails', async () => {
     const exp = Math.floor(Date.now() / 1000) + 60;
-    document.cookie = `${COOKIE}=${makeJwt(exp)}; path=/`;
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      text: async () => makeJwt(exp),
+    });
+    await renew();
     let release;
     const barrier = new Promise((resolve) => {
       release = resolve;
@@ -206,10 +207,9 @@ describe('session JWT keep-alive', () => {
 
   it('startSessionKeepAlive ticks ensureSessionFresh on an interval', async () => {
     const exp = Math.floor(Date.now() / 1000) + 60;
-    document.cookie = `${COOKIE}=${makeJwt(exp)}; path=/`;
     global.fetch = vi.fn().mockResolvedValue({
       status: 200,
-      text: async () => 'new-token',
+      text: async () => makeJwt(exp),
     });
     startSessionKeepAlive();
     expect(global.fetch).toHaveBeenCalledTimes(1);

--- a/frontend/src/utils/htmlPreview.test.js
+++ b/frontend/src/utils/htmlPreview.test.js
@@ -141,7 +141,7 @@ describe("rewriteCssContent", () => {
 });
 
 describe("buildHtmlPreview", () => {
-  it("rewrites linked assets and preserves scripts in sandboxed srcdoc", () => {
+  it("rewrites linked assets and strips scripts from sandboxed srcdoc", () => {
     const html = `<!DOCTYPE html>
 <html>
 <head>
@@ -156,10 +156,9 @@ describe("buildHtmlPreview", () => {
 
     const { srcdoc } = buildHtmlPreview(html, "/pages/index.html", "src");
     expect(srcdoc).toContain(encodeURIComponent("/pages/theme.css"));
-    expect(srcdoc).toContain(encodeURIComponent("/pages/app.js"));
     expect(srcdoc).toContain(encodeURIComponent("/pages/photo.jpg"));
     expect(srcdoc).toContain(encodeURIComponent("/pages/other.html"));
-    expect(srcdoc).toContain("<script");
+    expect(srcdoc).not.toContain("<script");
     expect(srcdoc).not.toContain("javascript:");
   });
 

--- a/frontend/src/utils/htmlPreview.ts
+++ b/frontend/src/utils/htmlPreview.ts
@@ -7,8 +7,8 @@ import { getParentDir, resolveRelativePath } from "@/utils/url";
 export const HTML_SANITIZE_CONFIG = {
   USE_PROFILES: { html: true, svg: true, svgFilters: true },
   WHOLE_DOCUMENT: true,
-  ADD_TAGS: ["link", "script"],
-  FORBID_TAGS: ["iframe", "object", "embed", "form", "base", "meta"],
+  ADD_TAGS: ["link"],
+  FORBID_TAGS: ["iframe", "object", "embed", "form", "base", "meta", "script"],
   FORBID_ATTR: ["target", "formaction"],
 };
 
@@ -30,7 +30,6 @@ const REWRITABLE_LINK_RELS = new Set([
 ]);
 
 const RESOURCE_ATTRIBUTES: Array<[string, string]> = [
-  ["script", "src"],
   ["link", "href"],
   ["img", "src"],
   ["video", "src"],

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -357,15 +357,12 @@ class UploadManager {
     this.hadActiveUploads = true; // Mark that we've had active uploads
     upload.status = "uploading";
 
-    // Get chunk size in MB, default to 5 if not set or if 0
-    let chunkSizeMb = state.user.fileLoading?.uploadChunkSizeMb ?? 5;
-    if (chunkSizeMb === 0) {
-      chunkSizeMb = 5;
-    }
+    // Default to 5 MB when unset; explicit 0 disables chunking (single-shot upload).
+    const chunkSizeMb = state.user.fileLoading?.uploadChunkSizeMb ?? 5;
     const chunkSize = chunkSizeMb * 1024 * 1024;
 
-    // Use non-chunked upload if file size is less than chunk size
-    if (upload.size < chunkSize) {
+    // Single-shot upload when chunking is disabled or file is smaller than chunk size.
+    if (chunkSize === 0 || upload.size < chunkSize) {
       const progress = (percent) => {
         this.updateProgress(upload, percent);
       };
@@ -496,10 +493,7 @@ class UploadManager {
   }
 
   chunkSizeBytes() {
-    let chunkSizeMb = state.user.fileLoading?.uploadChunkSizeMb ?? 5;
-    if (chunkSizeMb === 0) {
-      chunkSizeMb = 5;
-    }
+    const chunkSizeMb = state.user.fileLoading?.uploadChunkSizeMb ?? 5;
     return chunkSizeMb * 1024 * 1024;
   }
 
@@ -541,7 +535,7 @@ class UploadManager {
     if (upload?.status !== "uploading") {
       return;
     }
-    if (upload.type !== "directory" && upload.size >= this.chunkSizeBytes()) {
+    if (upload.type !== "directory" && this.chunkSizeBytes() > 0 && upload.size >= this.chunkSizeBytes()) {
       try {
         if (getters.isShare()) {
           await resourcesApi.signalUploadPause(null, upload.path, state.shareInfo.hash);

--- a/frontend/src/views/files/MarkdownViewer.vue
+++ b/frontend/src/views/files/MarkdownViewer.vue
@@ -10,7 +10,7 @@
       :key="req.path"
       class="html-content"
       :srcdoc="htmlPreview.srcdoc"
-      sandbox="allow-scripts allow-popups allow-same-origin"
+      sandbox="allow-scripts allow-popups"
       referrerpolicy="no-referrer"
       title="HTML preview"
     ></iframe>


### PR DESCRIPTION
- Patch GHSA-vvm6-jwrf-hgmg stored XSS via HTML preview (strip script tags, opaque-origin iframe sandbox, HttpOnly session cookie, SPA CSP nonce)
- Add frontend.disablePWAInstall and persist PWA dismiss in localStorage
- Restore uploadChunkSizeMb=0 single-shot uploads (#2202)
- Fix iOS 26 WebKit multi-chunk upload stall with Connection: close, per-chunk cache-bust, and partial JSON chunk responses (#2734)

**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened HTML previews and session protection.
  * Added Content Security Policy safeguards for the application shell.
* **New Features**
  * Added an option to disable the “Install App” prompt.
* **Bug Fixes**
  * Improved persistence and restoration of the install prompt.
  * Restored upload chunk size `0` as the setting to disable chunking.
  * Fixed multi-part uploads stalling on newer iOS/WebKit versions.
  * Improved upload responses and handling of interrupted or conflicting chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->