### PR TITLE
Fix GHSA-p5cc-4p84-c4m2 and disappearing links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. For commit 
 
  **Security**:
  - [High] Stored XSS via HTML preview: strip `<script>` from sanitized srcdoc, remove `allow-same-origin` from the preview iframe sandbox, set HttpOnly on the session cookie, and add a nonce-based `script-src` CSP on the SPA shell (GHSA-vvm6-jwrf-hgmg) -- thanks @qrn12580
+ - [Moderate] Non-admin users could PATCH privileged fields on their own account (scopes, permissions, etc.), allowing privilege escalation; restores v1 non-admin field guard on PATCH /api/users (GHSA-p5cc-4p84-c4m2) -- thanks @Chri6s
 
  **New Features**:
  - Added option to globally disable the "Install App" message via `frontend.disablePWAInstall`
@@ -18,6 +19,8 @@ All notable changes to this project will be documented in this file. For commit 
  - "Install app" message reappears after being cleared on device.
  - Restored upload chunk size `0` to disable chunking as documented ([#2202](https://github.com/gtsteffaniak/filebrowser/issues/2202)).
  - Fixed iOS 26 / WebKit multi-chunk upload stall by isolating chunk connections and returning partial chunk JSON responses ([#2734](https://github.com/gtsteffaniak/filebrowser/issues/2734)).
+ - Sidebar folder links with custom names, icons, or styles no longer disappear after restart; multiple shortcuts to different folders on the same source are preserved ([#2809](https://github.com/gtsteffaniak/filebrowser/issues/2809)).
+ - Adding a source to a user via scopes now auto-adds a matching sidebar link; removing a source keeps the link (shown disabled) so users can delete it manually.
 
 ## v2.0.2
 

--- a/backend/cmd/user.go
+++ b/backend/cmd/user.go
@@ -233,35 +233,27 @@ func updatePreviewSettings(user *users.User) bool {
 
 // updateSidebarLinks normalizes sidebar links and ensures scoped sources have sidebar entries.
 func updateSidebarLinks(user *users.User) bool {
-	updated := false
+	needsEnsure := usersidebar.NeedsSidebarLinksFromScopes(user.SidebarLinks, user.BackendScopes)
+	validBefore := usersidebar.ValidSourceSidebarLinkCount(user.SidebarLinks)
 
-	if normalized, changed := usersidebar.NormalizeSidebarLinks(user.SidebarLinks); changed {
-		user.SidebarLinks = normalized
-		updated = true
-	}
-
-	if !usersidebar.NeedsSidebarLinksFromScopes(user.SidebarLinks, user.BackendScopes) {
-		return updated
+	links, changed := usersidebar.PrepareSidebarLinksForPersist(user.SidebarLinks, user.BackendScopes)
+	if !changed {
+		return false
 	}
 
-	if usersidebar.ValidSourceSidebarLinkCount(user.SidebarLinks) == 0 && len(user.SidebarLinks) > 0 {
-		logger.Infof("User %s has stale source sidebar links, merging missing links from scopes", user.Username)
-	} else if usersidebar.ValidSourceSidebarLinkCount(user.SidebarLinks) == 0 {
-		logger.Infof("User %s has no source sidebar links, building from scopes", user.Username)
-	} else {
-		logger.Infof("User %s is missing sidebar links for some scoped sources, merging from scopes", user.Username)
+	user.SidebarLinks = links
+
+	if needsEnsure {
+		if validBefore == 0 && len(user.SidebarLinks) > 0 {
+			logger.Infof("User %s has stale source sidebar links, merging missing links from scopes", user.Username)
+		} else if validBefore == 0 {
+			logger.Infof("User %s has no source sidebar links, building from scopes", user.Username)
+		} else {
+			logger.Infof("User %s is missing sidebar links for some scoped sources, merging from scopes", user.Username)
+		}
 	}
 
-	merged, changed := usersidebar.EnsureSidebarLinksFromScopes(user.SidebarLinks, user.BackendScopes)
-	if changed {
-		user.SidebarLinks = merged
-		updated = true
-	}
-	if normalized, changed := usersidebar.NormalizeSidebarLinks(user.SidebarLinks); changed {
-		user.SidebarLinks = normalized
-		updated = true
-	}
-	return updated
+	return true
 }
 
 func updateTokens(user *users.User) bool {

--- a/backend/internal/state/users.go
+++ b/backend/internal/state/users.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/share"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/usersidebar"
 )
 
 // User operations
@@ -221,6 +222,10 @@ func CreateUser(user *users.User, plaintextPassword string) error {
 
 	users.SyncBackendSourcePermissionsMap(user)
 
+	if links, changed := usersidebar.PrepareSidebarLinksForPersist(user.SidebarLinks, user.BackendScopes); changed {
+		user.SidebarLinks = links
+	}
+
 	usersMux.Lock()
 	defer usersMux.Unlock()
 
@@ -328,6 +333,19 @@ func UpdateUser(user *users.User, plaintextPassword string, fields ...string) er
 		}
 	}
 
+	if sidebarFieldsPatched(fields) {
+		var links []users.SidebarLink
+		var changed bool
+		if fieldListRequiresScopeConversion(fields) {
+			links, changed = usersidebar.PrepareSidebarLinksForPersist(existingUser.SidebarLinks, existingUser.BackendScopes)
+		} else {
+			links, changed = usersidebar.NormalizeSidebarLinks(existingUser.SidebarLinks)
+		}
+		if changed {
+			existingUser.SidebarLinks = links
+		}
+	}
+
 	return commitUserUpdate(existingUser, storedSnapshot, sourceDefaults, sourceEnforced)
 }
 
@@ -388,6 +406,10 @@ func fieldListPatchesAPISourcePermissions(fields []string) bool {
 
 func fieldListRequiresScopeConversion(fields []string) bool {
 	return fieldListPatchesBackendScopes(fields) || fieldListPatchesAPISourcePermissions(fields)
+}
+
+func sidebarFieldsPatched(fields []string) bool {
+	return FieldListIncludes(fields, "sidebarLinks") || fieldListRequiresScopeConversion(fields)
 }
 
 // applyScopesFromAPI converts API scopes (with nested permissions) into BackendScopes.

--- a/backend/internal/state/users_sidebar_test.go
+++ b/backend/internal/state/users_sidebar_test.go
@@ -1,0 +1,181 @@
+package state
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
+)
+
+func initSidebarLinkTestDB(t *testing.T) {
+	t.Setenv("FILEBROWSER_ONLYOFFICE_SECRET", "")
+	settings.Initialize("../../../_docker/src/noauth/backend/config.yaml")
+	settings.Env.IsPlaywright = true
+
+	dbPath := filepath.Join(t.TempDir(), "filebrowser.sqlite")
+	if _, err := Initialize(dbPath); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = Close() })
+}
+
+func countSourceSidebarLinks(links []users.SidebarLink) int {
+	n := 0
+	for _, link := range links {
+		if strings.HasPrefix(link.Category, "source") {
+			n++
+		}
+	}
+	return n
+}
+
+func TestCreateUserAddsSidebarLinksForAllScopes(t *testing.T) {
+	initSidebarLinkTestDB(t)
+
+	u := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username: "scope-user",
+			FrontendScopes: []users.FrontendScope{
+				{Name: "exclude", Scope: "/"},
+				{Name: "include", Scope: "/"},
+			},
+		},
+	}
+	if err := CreateUser(u, "password"); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := GetUserByUsername("scope-user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := countSourceSidebarLinks(loaded.SidebarLinks); count != 2 {
+		t.Fatalf("source sidebar links = %d, want 2: %#v", count, loaded.SidebarLinks)
+	}
+}
+
+func TestUpdateUserScopesAddsMissingSidebarLink(t *testing.T) {
+	initSidebarLinkTestDB(t)
+
+	u := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username: "patch-user",
+			FrontendScopes: []users.FrontendScope{
+				{Name: "exclude", Scope: "/"},
+			},
+		},
+	}
+	if err := CreateUser(u, "password"); err != nil {
+		t.Fatal(err)
+	}
+
+	patch := &users.User{
+		ID: u.ID,
+		FrontendUser: users.FrontendUser{
+			Username: "patch-user",
+			FrontendScopes: []users.FrontendScope{
+				{Name: "exclude", Scope: "/"},
+				{Name: "include", Scope: "/"},
+			},
+		},
+	}
+	if err := UpdateUser(patch, "", "scopes"); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := GetUserByUsername("patch-user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := countSourceSidebarLinks(loaded.SidebarLinks); count != 2 {
+		t.Fatalf("source sidebar links = %d, want 2: %#v", count, loaded.SidebarLinks)
+	}
+}
+
+func TestUpdateUserScopesKeepsStaleSidebarLinks(t *testing.T) {
+	initSidebarLinkTestDB(t)
+
+	u := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username: "stale-user",
+			FrontendScopes: []users.FrontendScope{
+				{Name: "exclude", Scope: "/"},
+				{Name: "include", Scope: "/"},
+			},
+		},
+	}
+	if err := CreateUser(u, "password"); err != nil {
+		t.Fatal(err)
+	}
+
+	patch := &users.User{
+		ID: u.ID,
+		FrontendUser: users.FrontendUser{
+			Username: "stale-user",
+			FrontendScopes: []users.FrontendScope{
+				{Name: "exclude", Scope: "/"},
+			},
+		},
+	}
+	if err := UpdateUser(patch, "", "scopes"); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := GetUserByUsername("stale-user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := countSourceSidebarLinks(loaded.SidebarLinks); count != 2 {
+		t.Fatalf("expected stale include link kept, got %d links: %#v", count, loaded.SidebarLinks)
+	}
+}
+
+func TestUpdateUserSidebarLinksPreservesFolderShortcuts(t *testing.T) {
+	initSidebarLinkTestDB(t)
+
+	u := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username: "folder-user",
+			FrontendScopes: []users.FrontendScope{
+				{Name: "exclude", Scope: "/"},
+			},
+		},
+	}
+	if err := CreateUser(u, "password"); err != nil {
+		t.Fatal(err)
+	}
+
+	links := []users.SidebarLink{
+		{Name: "exclude", Category: "source", SourceName: "exclude", Target: "/"},
+		{Name: "Photos", Category: string(users.SidebarLinkSourceMinimal), Icon: "photo", SourceName: "exclude", Target: "/photos"},
+		{Name: "divider", Category: "divider", Target: "#"},
+	}
+	patch := &users.User{
+		ID: u.ID,
+		FrontendUser: users.FrontendUser{
+			Username: "folder-user",
+			NonAdminEditable: users.NonAdminEditable{
+				SidebarLinks: links,
+			},
+		},
+	}
+	if err := UpdateUser(patch, "", "sidebarLinks"); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := GetUserByUsername("folder-user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.SidebarLinks) != 3 {
+		t.Fatalf("len(sidebarLinks) = %d, want 3: %#v", len(loaded.SidebarLinks), loaded.SidebarLinks)
+	}
+	if loaded.SidebarLinks[1].Name != "Photos" || loaded.SidebarLinks[1].Icon != "photo" || loaded.SidebarLinks[1].Target != "/photos" {
+		t.Fatalf("folder shortcut not preserved: %#v", loaded.SidebarLinks[1])
+	}
+	if !strings.Contains(loaded.SidebarLinks[0].SourceName, "playwright-files") {
+		t.Fatalf("expected canonical path persisted, got SourceName=%q", loaded.SidebarLinks[0].SourceName)
+	}
+}

--- a/backend/internal/usersidebar/normalize.go
+++ b/backend/internal/usersidebar/normalize.go
@@ -8,9 +8,10 @@ import (
 
 // NormalizeSidebarLinks canonicalizes persisted sidebar links for storage.
 // Source links are resolved via ResolveSourceKey on SourceName, with Name as fallback.
-// SourceName is set to the canonical backend path; Name to the configured display name.
-// Unresolvable source links are dropped. Source links are deduped by canonical path
-// (first occurrence wins). Non-source links pass through; duplicate Tools links are deduped.
+// SourceName is set to the canonical backend path; custom Name, Icon, and Category are preserved.
+// Unresolvable source links are dropped. Source links are deduped by canonical path plus target
+// (first occurrence wins), so multiple folder shortcuts on one source are kept. Non-source links
+// pass through; duplicate Tools links are deduped.
 func NormalizeSidebarLinks(links []users.SidebarLink) ([]users.SidebarLink, bool) {
 	if !users.SourceConfigLoaded() {
 		return links, false
@@ -19,7 +20,7 @@ func NormalizeSidebarLinks(links []users.SidebarLink) ([]users.SidebarLink, bool
 		return links, false
 	}
 
-	seenSourcePaths := make(map[string]struct{})
+	seenSourceKeys := make(map[string]struct{})
 	hasTools := false
 	out := make([]users.SidebarLink, 0, len(links))
 	changed := false
@@ -31,11 +32,6 @@ func NormalizeSidebarLinks(links []users.SidebarLink) ([]users.SidebarLink, bool
 				changed = true
 				continue
 			}
-			if _, dup := seenSourcePaths[source.Path]; dup {
-				changed = true
-				continue
-			}
-			seenSourcePaths[source.Path] = struct{}{}
 
 			normalized := link
 			normalized.Category = users.NormalizeSidebarLinkCategory(normalized.Category)
@@ -43,9 +39,15 @@ func NormalizeSidebarLinks(links []users.SidebarLink) ([]users.SidebarLink, bool
 			if strings.TrimSpace(normalized.Name) == "" {
 				normalized.Name = source.Name
 			}
-			if normalized.Target == "" {
-				normalized.Target = "/"
+			normalized.Target = normalizeSidebarTarget(normalized.Target)
+
+			dedupeKey := sourceLinkDedupeKey(source.Path, normalized.Target)
+			if _, dup := seenSourceKeys[dedupeKey]; dup {
+				changed = true
+				continue
 			}
+			seenSourceKeys[dedupeKey] = struct{}{}
+
 			if normalized != link {
 				changed = true
 			}
@@ -76,4 +78,22 @@ func resolveSourceLink(link users.SidebarLink) (users.SourceInfo, bool) {
 		return users.ResolveSourceKey(link.Name)
 	}
 	return users.SourceInfo{}, false
+}
+
+func normalizeSidebarTarget(target string) string {
+	t := strings.TrimSpace(target)
+	if t == "" || t == "#" {
+		return "/"
+	}
+	if !strings.HasPrefix(t, "/") {
+		t = "/" + t
+	}
+	if t != "/" && strings.HasSuffix(t, "/") {
+		t = strings.TrimSuffix(t, "/")
+	}
+	return t
+}
+
+func sourceLinkDedupeKey(sourcePath, target string) string {
+	return sourcePath + "|" + normalizeSidebarTarget(target)
 }

--- a/backend/internal/usersidebar/normalize.go
+++ b/backend/internal/usersidebar/normalize.go
@@ -20,7 +20,7 @@ func NormalizeSidebarLinks(links []users.SidebarLink) ([]users.SidebarLink, bool
 		return links, false
 	}
 
-	seenSourceKeys := make(map[string]struct{})
+	seenSourceKeys := make(map[sourceLinkDedupeKey]struct{})
 	hasTools := false
 	out := make([]users.SidebarLink, 0, len(links))
 	changed := false
@@ -41,12 +41,12 @@ func NormalizeSidebarLinks(links []users.SidebarLink) ([]users.SidebarLink, bool
 			}
 			normalized.Target = normalizeSidebarTarget(normalized.Target)
 
-			dedupeKey := sourceLinkDedupeKey(source.Path, normalized.Target)
-			if _, dup := seenSourceKeys[dedupeKey]; dup {
+			key := sourceLinkDedupeKey{sourcePath: source.Path, target: normalized.Target}
+			if _, dup := seenSourceKeys[key]; dup {
 				changed = true
 				continue
 			}
-			seenSourceKeys[dedupeKey] = struct{}{}
+			seenSourceKeys[key] = struct{}{}
 
 			if normalized != link {
 				changed = true
@@ -94,6 +94,7 @@ func normalizeSidebarTarget(target string) string {
 	return t
 }
 
-func sourceLinkDedupeKey(sourcePath, target string) string {
-	return sourcePath + "|" + normalizeSidebarTarget(target)
+type sourceLinkDedupeKey struct {
+	sourcePath string
+	target     string
 }

--- a/backend/internal/usersidebar/normalize_test.go
+++ b/backend/internal/usersidebar/normalize_test.go
@@ -209,6 +209,43 @@ func TestNormalizeSidebarLinks_dedupesSameSourceAndTarget(t *testing.T) {
 	}
 }
 
+func TestNormalizeSidebarLinks_noCollisionOnPipeInPathOrTarget(t *testing.T) {
+	had := users.SourceConfigLoaded()
+	t.Cleanup(func() {
+		if !had {
+			users.SetSourceConfig(nil)
+		}
+	})
+	users.SetSourceConfig(&users.SourceConfigProvider{
+		GetSourceByPath: func(path string) (users.SourceInfo, bool) {
+			switch path {
+			case "a":
+				return users.SourceInfo{Path: "a", Name: "src-a"}, true
+			case "a|/b":
+				return users.SourceInfo{Path: "a|/b", Name: "src-pipe"}, true
+			default:
+				return users.SourceInfo{}, false
+			}
+		},
+		GetSourceByName: func(name string) (users.SourceInfo, bool) {
+			return users.SourceInfo{}, false
+		},
+	})
+
+	in := []users.SidebarLink{
+		{Name: "one", Category: "source", SourceName: "a", Target: "/b|/c"},
+		{Name: "two", Category: "source", SourceName: "a|/b", Target: "/c"},
+	}
+
+	out, changed := NormalizeSidebarLinks(in)
+	if changed {
+		t.Fatal("expected changed=false for distinct path/target pairs")
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2 (no false dedupe)", len(out))
+	}
+}
+
 func TestNormalizeSidebarLinks_noConfigLoaded(t *testing.T) {
 	had := users.SourceConfigLoaded()
 	t.Cleanup(func() {

--- a/backend/internal/usersidebar/normalize_test.go
+++ b/backend/internal/usersidebar/normalize_test.go
@@ -164,6 +164,51 @@ func TestNormalizeSidebarLinks_dedupesToolsLink(t *testing.T) {
 	}
 }
 
+func TestNormalizeSidebarLinks_preservesMultipleFolderShortcutsOnSameSource(t *testing.T) {
+	testSourceConfig(t)
+
+	in := []users.SidebarLink{
+		{Name: "docker", Category: "source", SourceName: ".", Target: "/"},
+		{Name: "Photos", Category: string(users.SidebarLinkSourceMinimal), Icon: "photo", SourceName: ".", Target: "/photos"},
+		{Name: "Docs", Category: string(users.SidebarLinkSourceAlt), Icon: "folder", SourceName: ".", Target: "/docs"},
+		{Name: "divider", Category: "divider", Target: "#"},
+	}
+
+	out, changed := NormalizeSidebarLinks(in)
+	if changed {
+		t.Fatal("expected canonical folder shortcuts unchanged")
+	}
+	if len(out) != 4 {
+		t.Fatalf("len(out) = %d, want 4", len(out))
+	}
+	if out[1].Name != "Photos" || out[1].Icon != "photo" || out[1].Target != "/photos" {
+		t.Fatalf("photos link = %#v", out[1])
+	}
+	if out[2].Category != string(users.SidebarLinkSourceAlt) {
+		t.Fatalf("docs category = %q", out[2].Category)
+	}
+}
+
+func TestNormalizeSidebarLinks_dedupesSameSourceAndTarget(t *testing.T) {
+	testSourceConfig(t)
+
+	in := []users.SidebarLink{
+		{Name: "docker", Category: "source", SourceName: ".", Target: "/"},
+		{Name: "docker root", Category: "source-minimal", Icon: "home", SourceName: "docker", Target: "/"},
+	}
+
+	out, changed := NormalizeSidebarLinks(in)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if len(out) != 1 {
+		t.Fatalf("len(out) = %d, want 1", len(out))
+	}
+	if out[0].Name != "docker" {
+		t.Fatalf("first link wins: %#v", out[0])
+	}
+}
+
 func TestNormalizeSidebarLinks_noConfigLoaded(t *testing.T) {
 	had := users.SourceConfigLoaded()
 	t.Cleanup(func() {

--- a/backend/internal/usersidebar/persist.go
+++ b/backend/internal/usersidebar/persist.go
@@ -1,0 +1,28 @@
+package usersidebar
+
+import (
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+)
+
+// PrepareSidebarLinksForPersist normalizes sidebar links and adds missing scoped source entries.
+// Inaccessible sources are not pruned; callers rely on the UI to gray out stale links.
+func PrepareSidebarLinksForPersist(links []users.SidebarLink, scopes []users.BackendScope) ([]users.SidebarLink, bool) {
+	updated := false
+
+	if normalized, changed := NormalizeSidebarLinks(links); changed {
+		links = normalized
+		updated = true
+	}
+
+	merged, changed := EnsureSidebarLinksFromScopes(links, scopes)
+	if changed {
+		links = merged
+		updated = true
+		if normalized, changed := NormalizeSidebarLinks(links); changed {
+			links = normalized
+			updated = true
+		}
+	}
+
+	return links, updated
+}

--- a/backend/internal/usersidebar/persist_test.go
+++ b/backend/internal/usersidebar/persist_test.go
@@ -1,0 +1,55 @@
+package usersidebar
+
+import (
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+)
+
+func TestPrepareSidebarLinksForPersist_addsScopedSourcesAndPreservesFolders(t *testing.T) {
+	testSourceConfig(t)
+
+	links := []users.SidebarLink{
+		{Name: "docker", Category: "source", SourceName: ".", Target: "/"},
+		{Name: "Photos", Category: string(users.SidebarLinkSourceMinimal), Icon: "photo", SourceName: ".", Target: "/photos"},
+	}
+	scopes := []users.BackendScope{
+		{Path: "."},
+		{Path: "../frontend/tests/playwright-files"},
+	}
+
+	out, changed := PrepareSidebarLinksForPersist(links, scopes)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3", len(out))
+	}
+	if out[1].Name != "Photos" || out[1].Icon != "photo" {
+		t.Fatalf("folder shortcut lost: %#v", out[1])
+	}
+	if out[2].Name != "playwright + files" {
+		t.Fatalf("added scope link = %#v", out[2])
+	}
+}
+
+func TestPrepareSidebarLinksForPersist_keepsLinksWhenScopeRemoved(t *testing.T) {
+	testSourceConfig(t)
+
+	links := []users.SidebarLink{
+		{Name: "docker", Category: "source", SourceName: ".", Target: "/"},
+		{Name: "Photos", Category: string(users.SidebarLinkSourceMinimal), Icon: "photo", SourceName: ".", Target: "/photos"},
+		{Name: "playwright + files", Category: "source", SourceName: "../frontend/tests/playwright-files", Target: "/"},
+	}
+	scopes := []users.BackendScope{
+		{Path: "."},
+	}
+
+	out, changed := PrepareSidebarLinksForPersist(links, scopes)
+	if changed {
+		t.Fatal("expected changed=false when only pruning is not performed")
+	}
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3 (stale scope link kept)", len(out))
+	}
+}

--- a/backend/internal/web/users.go
+++ b/backend/internal/web/users.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
-	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
-	"github.com/gtsteffaniak/filebrowser/backend/internal/activity"
 	"io"
 	"net/http"
 	"net/url"
@@ -13,15 +11,17 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gtsteffaniak/filebrowser/backend/internal/activity"
+	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/files"
+
 	activitydb "github.com/gtsteffaniak/filebrowser/backend/internal/database/activity"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/errors"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/state"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/usersidebar"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/utils"
-	"github.com/gtsteffaniak/go-logger/logger"
 	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
-
+	"github.com/gtsteffaniak/go-logger/logger"
 )
 
 type UserRequest struct {
@@ -393,7 +393,7 @@ func userPatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, 
 		return http.StatusForbidden, nil
 	}
 	if !d.User.Permissions.Admin && targetUsername == d.User.Username {
-		if err := validateNonAdminSelfPatchWhich(req.Which); err != nil {
+		if err = validateNonAdminSelfPatchWhich(req.Which); err != nil {
 			return http.StatusForbidden, err
 		}
 	}

--- a/backend/internal/web/users.go
+++ b/backend/internal/web/users.go
@@ -273,6 +273,25 @@ func validatePatchWhich(which []string) error {
 	return nil
 }
 
+// validateNonAdminSelfPatchWhich rejects self-service PATCH attempts that touch privileged fields.
+// Non-admins may only update NonAdminEditable profile fields, plus password (with X-Password) and otpEnabled.
+func validateNonAdminSelfPatchWhich(which []string) error {
+	allowed := nonAdminEditableFieldNameSet()
+	for _, w := range which {
+		f := utils.CapitalizeFirst(strings.TrimSpace(w))
+		if f == "" {
+			return fmt.Errorf("which must not contain empty field names")
+		}
+		if strings.EqualFold(f, "Password") || strings.EqualFold(f, "OtpEnabled") {
+			continue
+		}
+		if _, ok := allowed[f]; !ok {
+			return fmt.Errorf("cannot update privileged user fields without admin permissions")
+		}
+	}
+	return nil
+}
+
 // userPutOnlyNonAdminEditableFields reports whether req.Which lists exclusively NonAdminEditable fields,
 // excluding Password.
 func userPutOnlyNonAdminEditableFields(which []string) bool {
@@ -372,6 +391,11 @@ func userPatchHandler(w http.ResponseWriter, r *http.Request, d *Context) (int, 
 
 	if !d.User.Permissions.Admin && targetUsername != d.User.Username {
 		return http.StatusForbidden, nil
+	}
+	if !d.User.Permissions.Admin && targetUsername == d.User.Username {
+		if err := validateNonAdminSelfPatchWhich(req.Which); err != nil {
+			return http.StatusForbidden, err
+		}
 	}
 
 	uValue, err2 := state.GetUserByUsername(targetUsername)

--- a/backend/internal/web/users_patch_test.go
+++ b/backend/internal/web/users_patch_test.go
@@ -53,3 +53,51 @@ func TestValidatePatchWhich(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateNonAdminSelfPatchWhich(t *testing.T) {
+	t.Run("allows profile fields", func(t *testing.T) {
+		for _, which := range [][]string{
+			{"locale"},
+			{"darkMode", "viewMode"},
+			{"preview"},
+			{"sorting"},
+		} {
+			if err := validateNonAdminSelfPatchWhich(which); err != nil {
+				t.Fatalf("unexpected error for which=%v: %v", which, err)
+			}
+		}
+	})
+
+	t.Run("allows password and otpEnabled", func(t *testing.T) {
+		for _, which := range [][]string{
+			{"password"},
+			{"otpEnabled"},
+			{"locale", "password"},
+		} {
+			if err := validateNonAdminSelfPatchWhich(which); err != nil {
+				t.Fatalf("unexpected error for which=%v: %v", which, err)
+			}
+		}
+	})
+
+	t.Run("rejects privileged fields", func(t *testing.T) {
+		for _, which := range [][]string{
+			{"scopes"},
+			{"permissions"},
+			{"sourcePermissions"},
+			{"loginMethod"},
+			{"lockPassword"},
+			{"disableSettings"},
+		} {
+			if err := validateNonAdminSelfPatchWhich(which); err == nil {
+				t.Fatalf("expected error for which=%v", which)
+			}
+		}
+	})
+
+	t.Run("rejects mixed privileged and profile fields", func(t *testing.T) {
+		if err := validateNonAdminSelfPatchWhich([]string{"locale", "scopes"}); err == nil {
+			t.Fatal("expected error when which mixes profile and privileged fields")
+		}
+	})
+}


### PR DESCRIPTION
helps prevent this issue: https://github.com/gtsteffaniak/filebrowser/issues/2809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Hardened HTML previews against stored cross-site scripting.
  - Restored restrictions preventing non-administrators from changing privileged account settings.

- **Bug Fixes**
  - Improved support for Fuji `.raf` thumbnails, unsupported preview formats, OIDC and LDAP sign-ins, PWA prompts, chunk restoration and uploads, and sidebar shortcut persistence.

- **Improvements**
  - Added `frontend.disablePWAInstall` configuration to disable PWA installation prompts.
  - Sidebar links now preserve folder shortcuts, normalize paths consistently, and automatically include links from assigned sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->