### PR TITLE
Add PWA maskable icons and safe-area foundation for notched devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. For commit 
 
  **New Features**:
  - Added option to globally disable the "Install App" message via `frontend.disablePWAInstall`
- - PWA improvements for installed mobile apps: dedicated maskable icons (192/512), manifest and splash colors that follow the instance default theme, runtime `theme-color` sync on dark-mode toggle, and edge-to-edge safe-area layout for notched devices (#2625) (#2625) -- thanks @APatenaude
+ - PWA improvements for installed mobile apps: dedicated maskable icons (192/512), manifest and splash colors that follow the instance default theme, runtime `theme-color` sync on dark-mode toggle, and edge-to-edge safe-area layout for notched devices (#2625) (#2869) -- thanks @APatenaude
 
  **Bugfixes**:
  - Fixed Fuji `.raf` thumbnail preview by extracting the camera-embedded JPEG from the RAF header (regression for files where TIFF-based raw extraction does not apply).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. For commit 
 
  **New Features**:
  - Added option to globally disable the "Install App" message via `frontend.disablePWAInstall`
- - PWA improvements for installed mobile apps: dedicated maskable icons (192/512), manifest and splash colors that follow the instance default theme, runtime `theme-color` sync on dark-mode toggle, and edge-to-edge safe-area layout for notched devices ([#2625](https://github.com/gtsteffaniak/filebrowser/pull/2625)) -- thanks @APatenaude
+ - PWA improvements for installed mobile apps: dedicated maskable icons (192/512), manifest and splash colors that follow the instance default theme, runtime `theme-color` sync on dark-mode toggle, and edge-to-edge safe-area layout for notched devices (#2625) (#2625) -- thanks @APatenaude
 
  **Bugfixes**:
  - Fixed Fuji `.raf` thumbnail preview by extracting the camera-embedded JPEG from the RAF header (regression for files where TIFF-based raw extraction does not apply).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. For commit 
 
  **New Features**:
  - Added option to globally disable the "Install App" message via `frontend.disablePWAInstall`
+ - PWA improvements for installed mobile apps: dedicated maskable icons (192/512), manifest and splash colors that follow the instance default theme, runtime `theme-color` sync on dark-mode toggle, and edge-to-edge safe-area layout for notched devices ([#2625](https://github.com/gtsteffaniak/filebrowser/pull/2625)) -- thanks @APatenaude
 
  **Bugfixes**:
  - Fixed Fuji `.raf` thumbnail preview by extracting the camera-embedded JPEG from the RAF header (regression for files where TIFF-based raw extraction does not apply).

--- a/backend/internal/icons/generator.go
+++ b/backend/internal/icons/generator.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"image"
+	"image/color"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -28,8 +30,9 @@ const (
 
 // iconSize defines an icon size to generate
 type iconSize struct {
-	size int
-	name string
+	size     int
+	name     string
+	maskable bool
 }
 
 // determineSourceType determines which type of favicon source we have
@@ -153,13 +156,16 @@ func handleRasterFavicon(faviconPath string) ([]byte, error) {
 func getIconSizesToGenerate() []iconSize {
 	return []iconSize{
 		// Browser favicon (32x32 PNG for Safari/older browsers)
-		{32, "favicon-32x32.png"},
+		{32, "favicon-32x32.png", false},
 		// PWA icons (PNG required for Apple PWA compatibility)
-		{192, "pwa-icon-192.png"},
-		{256, "pwa-icon-256.png"}, // Also serves as Windows tile
-		{512, "pwa-icon-512.png"},
+		{192, "pwa-icon-192.png", false},
+		{256, "pwa-icon-256.png", false}, // Also serves as Windows tile
+		{512, "pwa-icon-512.png", false},
+		// Maskable PWA icons: art inset into the Android adaptive-icon safe zone
+		{192, "pwa-icon-maskable-192.png", true},
+		{512, "pwa-icon-maskable-512.png", true},
 		// Platform-specific icons
-		{180, "apple-touch-icon.png"}, // iOS home screen (required for Apple)
+		{180, "apple-touch-icon.png", false}, // iOS home screen (required for Apple)
 	}
 }
 
@@ -193,8 +199,55 @@ func generateIconSizes(sourceData []byte) error {
 	return nil
 }
 
+// generateMaskableIcon insets the art into the safe zone on an opaque background, since launchers zoom maskable icons to fill the mask edge-to-edge
+func generateMaskableIcon(sourceData []byte, icon iconSize) error {
+	img, err := imaging.Decode(bytes.NewReader(sourceData))
+	if err != nil {
+		return fmt.Errorf("failed to decode source: %w", err)
+	}
+
+	// Android adaptive-icon content ratio (72/108 ≈ 2/3) keeps square art inside every mask shape
+	inner := icon.size * 2 / 3
+	art := imaging.Fit(img, inner, inner, imaging.Lanczos)
+	canvas := imaging.PasteCenter(imaging.New(icon.size, icon.size, maskableBackground(img)), art)
+
+	outputPath := filepath.Join(settings.PWAIconsCacheDir(), icon.name)
+	outFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer outFile.Close()
+
+	if err := imaging.Encode(outFile, canvas, imaging.PNG); err != nil {
+		os.Remove(outputPath)
+		return fmt.Errorf("encode failed: %w", err)
+	}
+	return nil
+}
+
+// maskableBackground samples the art's corners then edge midpoints for an opaque pad color, else white
+func maskableBackground(img image.Image) color.Color {
+	b := img.Bounds()
+	cx, cy := (b.Min.X+b.Max.X)/2, (b.Min.Y+b.Max.Y)/2
+	points := []image.Point{
+		{b.Min.X, b.Min.Y}, {b.Max.X - 1, b.Min.Y}, {b.Min.X, b.Max.Y - 1}, {b.Max.X - 1, b.Max.Y - 1},
+		{cx, b.Min.Y}, {cx, b.Max.Y - 1}, {b.Min.X, cy}, {b.Max.X - 1, cy},
+	}
+	for _, p := range points {
+		r, g, bl, a := img.At(p.X, p.Y).RGBA()
+		if a == 0xffff {
+			return color.NRGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(bl >> 8), A: 255}
+		}
+	}
+	return color.White
+}
+
 // generateSingleIcon generates a single icon file at the specified size
 func generateSingleIcon(previewService *preview.Service, sourceData []byte, icon iconSize) error {
+	if icon.maskable {
+		return generateMaskableIcon(sourceData, icon)
+	}
+
 	outputPath := filepath.Join(settings.PWAIconsCacheDir(), icon.name)
 
 	// Create output file

--- a/backend/internal/icons/generator_test.go
+++ b/backend/internal/icons/generator_test.go
@@ -1,0 +1,64 @@
+package icons
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
+)
+
+func TestMaskableBackgroundOpaqueCorner(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 12, 12))
+	img.Set(0, 0, color.RGBA{R: 10, G: 20, B: 30, A: 255})
+
+	got := maskableBackground(img)
+	want := color.NRGBA{R: 10, G: 20, B: 30, A: 255}
+	if got != want {
+		t.Fatalf("opaque corner: got %#v, want %#v", got, want)
+	}
+}
+
+func TestMaskableBackgroundOpaqueEdge(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 12, 12))
+	img.Set(6, 0, color.RGBA{R: 200, G: 100, B: 50, A: 255})
+
+	got := maskableBackground(img)
+	want := color.NRGBA{R: 200, G: 100, B: 50, A: 255}
+	if got != want {
+		t.Fatalf("opaque edge: got %#v, want %#v", got, want)
+	}
+}
+
+func TestMaskableBackgroundAllTransparent(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 12, 12))
+	if got := maskableBackground(img); got != color.White {
+		t.Fatalf("all transparent: got %#v, want white", got)
+	}
+}
+
+func TestDefaultBackgroundColor(t *testing.T) {
+	saved := settings.Config
+	defer func() { settings.Config = saved }()
+
+	dark := true
+	light := false
+
+	settings.Config.Frontend.Styling.DarkBackground = "#111111"
+	settings.Config.Frontend.Styling.LightBackground = "#ffffff"
+
+	settings.Config.UserDefaults.UI.DarkMode = &dark
+	if got := settings.DefaultBackgroundColor(); got != "#111111" {
+		t.Fatalf("dark branch: got %q, want %q", got, "#111111")
+	}
+
+	settings.Config.UserDefaults.UI.DarkMode = &light
+	if got := settings.DefaultBackgroundColor(); got != "#ffffff" {
+		t.Fatalf("light branch (dark disabled): got %q, want %q", got, "#ffffff")
+	}
+
+	settings.Config.UserDefaults.UI.DarkMode = nil
+	if got := settings.DefaultBackgroundColor(); got != "#ffffff" {
+		t.Fatalf("light branch (unset): got %q, want %q", got, "#ffffff")
+	}
+}

--- a/backend/internal/icons/manifest.go
+++ b/backend/internal/icons/manifest.go
@@ -44,14 +44,14 @@ func pwaManifestName(name string) string {
 }
 
 // generatePWAManifest creates the PWA manifest structure
-func generatePWAManifest(name, description, baseURL, themeColor, pwaIcon192, pwaIcon256, pwaIcon512 string) PWAManifest {
+func generatePWAManifest(name, description, baseURL, themeColor, backgroundColor, pwaIcon192, pwaIcon256, pwaIcon512, pwaIconMaskable192, pwaIconMaskable512 string) PWAManifest {
 	return PWAManifest{
 		Name:            pwaManifestName(name),
 		ID:              baseURL,
 		Scope:           baseURL,
 		StartURL:        baseURL,
 		Display:         "standalone",
-		BackgroundColor: "#ffffff",
+		BackgroundColor: backgroundColor,
 		ThemeColor:      themeColor,
 		Description:     description,
 		Icons: []PWAIcon{
@@ -65,13 +65,25 @@ func generatePWAManifest(name, description, baseURL, themeColor, pwaIcon192, pwa
 				Src:     pwaIcon256,
 				Sizes:   "256x256",
 				Type:    "image/png",
-				Purpose: "any maskable",
+				Purpose: "any",
 			},
 			{
 				Src:     pwaIcon512,
 				Sizes:   "512x512",
 				Type:    "image/png",
 				Purpose: "any",
+			},
+			{
+				Src:     pwaIconMaskable192,
+				Sizes:   "192x192",
+				Type:    "image/png",
+				Purpose: "maskable",
+			},
+			{
+				Src:     pwaIconMaskable512,
+				Sizes:   "512x512",
+				Type:    "image/png",
+				Purpose: "maskable",
 			},
 		},
 	}
@@ -85,11 +97,13 @@ func InitializePWAManifest() {
 	staticURL := config.Http.BaseURL + "public/static"
 	title := config.Frontend.Name
 	description := config.Frontend.Description
-	defaultThemeColor := "#455a64"
-
 	pwaIcon192 := staticURL + "/icons/pwa-icon-192.png"
 	pwaIcon256 := staticURL + "/icons/pwa-icon-256.png"
 	pwaIcon512 := staticURL + "/icons/pwa-icon-512.png"
+	pwaIconMaskable192 := staticURL + "/icons/pwa-icon-maskable-192.png"
+	pwaIconMaskable512 := staticURL + "/icons/pwa-icon-maskable-512.png"
 
-	CachedManifest = generatePWAManifest(title, description, config.Http.BaseURL, defaultThemeColor, pwaIcon192, pwaIcon256, pwaIcon512)
+	backgroundColor := settings.DefaultBackgroundColor()
+
+	CachedManifest = generatePWAManifest(title, description, config.Http.BaseURL, backgroundColor, backgroundColor, pwaIcon192, pwaIcon256, pwaIcon512, pwaIconMaskable192, pwaIconMaskable512)
 }

--- a/backend/internal/web/static.go
+++ b/backend/internal/web/static.go
@@ -96,7 +96,7 @@ func handleWithStaticData(w http.ResponseWriter, r *http.Request, d *requestCont
 		externalLinks = newExternalLinks
 	}
 
-	defaultThemeColor := "#455a64"
+	defaultThemeColor := settings.DefaultBackgroundColor()
 	staticURL := settings.Config.Http.BaseURL + "public/static"
 	description := settings.Config.Frontend.Description
 	title := settings.Config.Frontend.Name
@@ -211,6 +211,8 @@ func handleWithStaticData(w http.ResponseWriter, r *http.Request, d *requestCont
 		"minSearchLength":        settings.Config.Server.MinSearchLength,
 		"disableExternal":        settings.Config.Frontend.DisableDefaultLinks,
 		"darkMode":               settings.Config.UserDefaults.UI.DarkMode,
+		"lightBackground":        settings.Config.Frontend.Styling.LightBackground,
+		"darkBackground":         settings.Config.Frontend.Styling.DarkBackground,
 		"baseURL":                settings.Config.Http.BaseURL,
 		"version":                versionString,
 		"commitSHA":              commitSHAString,
@@ -352,6 +354,7 @@ func staticAssetHandler(w http.ResponseWriter, r *http.Request) {
 		assetPath = "img/icons/favicon.png"
 	case "icons/favicon-32x32.png",
 		"icons/pwa-icon-192.png", "icons/pwa-icon-256.png", "icons/pwa-icon-512.png",
+		"icons/pwa-icon-maskable-192.png", "icons/pwa-icon-maskable-512.png",
 		"icons/apple-touch-icon.png", "icons/mstile-256x256.png":
 		// Files are generated as PWAIconsCacheDir()/basename (URL uses icons/ prefix only for routing)
 		rel := strings.TrimPrefix(path, "icons/")

--- a/backend/pkg/settings/styling.go
+++ b/backend/pkg/settings/styling.go
@@ -118,3 +118,11 @@ func readCustomCSS(path string) (string, error) {
 	logger.Debugf("Loaded custom CSS from: %s (%d bytes)", path, len(content))
 	return string(content), nil
 }
+
+// DefaultBackgroundColor returns the background color of the instance's default theme.
+func DefaultBackgroundColor() string {
+	if Config.UserDefaults.UI.DarkMode != nil && *Config.UserDefaults.UI.DarkMode {
+		return Config.Frontend.Styling.DarkBackground
+	}
+	return Config.Frontend.Styling.LightBackground
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">
   <title>"{{ .htmlVars.title }}"</title>
 
   <link rel="icon" type="image/png" sizes="256x256" href="{{ .htmlVars.favicon }}">
@@ -21,7 +21,7 @@
 
   <!-- Add to home screen for Safari on iOS/iPadOS -->
   <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="assets">
   <link rel="apple-touch-icon" sizes="180x180" href="{{ .htmlVars.appIcon }}">
 
@@ -71,6 +71,14 @@
       --textSecondary: gray;
       --iconBackground: #dddddd;
       --activeWhiteIcon: gray;
+    }
+    /* paint safe areas + iOS overscroll with app background (notched PWAs) */
+    html {
+      background-color: {{ .htmlVars.lightBackground }};
+      min-height: calc(100% + env(safe-area-inset-top, 0px));
+    }
+    html:has(.dark-mode) {
+      background-color: {{ .htmlVars.darkBackground }};
     }
     .dark-mode {
       --background: {{ .htmlVars.darkBackground }};

--- a/frontend/src/css/_variables.css
+++ b/frontend/src/css/_variables.css
@@ -18,6 +18,13 @@
   --layer-middle: 3;
   --layer-below-top: 4;
   --layer-top: 10;
+  /* device insets (notch, rounded corners, home indicator) */
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  /* app top bar height, including the top safe-area inset */
+  --header-height: calc(4em + var(--safe-area-top));
   --borderRadius: 1em;
   --borderWidth: 1.5px;
   --surfaceElevationShadow:

--- a/frontend/src/css/base.css
+++ b/frontend/src/css/base.css
@@ -1,6 +1,6 @@
 body {
   font-family: "Roboto", sans-serif;
-  padding-top: 4em;
+  padding-top: var(--header-height);
   color: #333333;
   overflow:initial;
   scrollbar-width: none; /* Firefox */
@@ -70,9 +70,12 @@ i.spin {
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE and Edge */
   position: fixed;
-  padding-top: 4em;
+  padding-top: var(--header-height);
+  padding-left: var(--safe-area-left);
+  padding-right: var(--safe-area-right);
   overflow: unset;
   top: 0;
+  /* fill the visible viewport only; the html background paints the black-translucent safe areas */
   height: 100%;
   width: 100%;
   display: flex;

--- a/frontend/src/css/header.css
+++ b/frontend/src/css/header.css
@@ -12,6 +12,14 @@ header {
   padding: 0.5em;
 }
 
+/* only the app top bar absorbs the safe-area insets (top bar, landscape notch) */
+header.flexbar {
+  height: var(--header-height);
+  padding-top: calc(0.5em + var(--safe-area-top));
+  padding-left: calc(0.5em + var(--safe-area-left));
+  padding-right: calc(0.5em + var(--safe-area-right));
+}
+
 header title {
   display: block;
   flex: 1 1 auto;

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -167,6 +167,15 @@ export default {
     $route() {
       this.reEval()
     },
+    isDarkMode: {
+      immediate: true,
+      handler(dark) {
+        const color = dark ? globalVars.darkBackground : globalVars.lightBackground;
+        if (!color) return;
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.setAttribute("content", color);
+      },
+    },
   },
   methods: {
     reEval() {


### PR DESCRIPTION
Ports the high-value parts of #2625: theme-aware manifest colors, dedicated maskable icons, runtime theme-color sync, and edge-to-edge safe-area layout for installed PWAs on notched phones.

**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added maskable PWA icons in 192px and 512px sizes for adaptive display.
  * PWA manifest and theme colors now follow the configured light or dark theme.
  * Theme colors update automatically when dark mode changes.
  * Added edge-to-edge support for mobile devices with display cutouts and safe areas.

* **Bug Fixes**
  * Improved icon backgrounds and spacing across supported devices.
  * Corrected viewport, header, and content layout around screen cutouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->