### PR TITLE
docs: mention OnlyOffice in download tooltip

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -366,7 +366,7 @@
     "selectBannerImage": "Select banner image",
     "selectFaviconImage": "Select favicon image",
     "disableDownload": "Disable downloading files",
-    "disableDownloadDescription": "Anyone won't be able to download files or view a file's content.",
+    "disableDownloadDescription": "Users won't be able to download files, view file contents, or access OnlyOffice.",
     "allowModify": "Allow editing files",
     "allowModifyDescription": "Anyone can edit files in this share.",
     "allowDelete": "Allow deleting files",


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), a PR should contain:

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [x] Any additional details for functionality not covered by tests.

Fixes #2813.

The share dialog's "Disable downloading files" tooltip listed download and file-viewing restrictions but omitted that OnlyOffice also becomes unavailable. This updates the existing English master-locale message without changing share permissions or OnlyOffice behavior.

**Additional Details**

Tests:

- `npm run i18n:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (22 files, 136 tests)
- `npm run build:docker`
