### PR TITLE
fix GHSA-55mw-cwg7-m8f5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. For commit 
 
 ## v1.5.6
 
+ **Security**:
+ - [Moderate] public metadata api returns file content to anonymous share visitors, ignoring the share's download limit and file-viewer setting (GHSA-55mw-cwg7-m8f5) -- thanks @kta1kri
+
  **BugFixes**:
  - Saving an existing share clears its password, even with no changes made (#2898)
  - Fixed infinite loading spinner on `/` and `/login` after CSP security hardening (#2886, #2890)

--- a/backend/adapters/fs/files/files.go
+++ b/backend/adapters/fs/files/files.go
@@ -382,7 +382,7 @@ func processContent(info *iteminfo.ExtendedFileInfo, idx *indexing.Index, opts u
 	}
 
 	// Process text content for non-video, non-audio files
-	if info.Size < 20*1024*1024 { // 20 megabytes in bytes
+	if opts.Content && info.Size < 20*1024*1024 { // 20 megabytes in bytes
 		content, err := getContent(info.RealPath)
 		if err != nil {
 			logger.Debugf("could not get content for file: "+info.RealPath, info.Name, err)


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Anonymous visitors to shared files can no longer retrieve file content through the metadata API when downloads are limited or file viewing is disabled.
  - File content is now returned only when content retrieval is explicitly requested.
- **Bug Fixes**
  - The existing 20 MB file-size limit remains in effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->