### PR TITLE
Fix disk-usage overstatement on virtiofs bind mounts (#2894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. For commit 
  - tilde paths for sources were not properly expanded. (eg "~" for home)
  - fixed tooltip not showing up for some circumstances on mobile, improved consistency.
  - a few styling fixes for inconsistencies (#2908)
+ - Disk-usage widget no longer reports PB/TB-scale garbage on Docker Desktop for Mac (virtiofs) bind mounts; space is computed from the filesystem fragment size (`f_frsize`) instead of the optimal-transfer block size (`f_bsize`) on Linux ([#2894](https://github.com/gtsteffaniak/filebrowser/issues/2894)).
 
 ## v2.0.4
 

--- a/backend/internal/adapters/fs/fileutils/partition_linux.go
+++ b/backend/internal/adapters/fs/fileutils/partition_linux.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package fileutils
+
+import (
+	"syscall"
+)
+
+func blockSize(stat *syscall.Statfs_t) uint64 {
+	if stat.Frsize > 0 {
+		return uint64(stat.Frsize)
+	}
+	return uint64(stat.Bsize)
+}
+
+// GetPartitionSize returns the filesystem size for Linux systems
+func GetPartitionSize(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	err := syscall.Statfs(path, &stat)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(stat.Blocks) * blockSize(&stat), nil
+}
+
+// GetFreeSpace returns the available free space for Linux systems
+func GetFreeSpace(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	err := syscall.Statfs(path, &stat)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(stat.Bavail) * blockSize(&stat), nil
+}
+
+// GetPartitionUsed returns the used space for Linux systems (total - free)
+func GetPartitionUsed(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	err := syscall.Statfs(path, &stat)
+	if err != nil {
+		return 0, err
+	}
+	bsize := blockSize(&stat)
+	total := uint64(stat.Blocks) * bsize
+	free := uint64(stat.Bavail) * bsize
+	return total - free, nil
+}

--- a/backend/internal/adapters/fs/fileutils/partition_linux_test.go
+++ b/backend/internal/adapters/fs/fileutils/partition_linux_test.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package fileutils
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestBlockSizePrefersFrsize(t *testing.T) {
+	// virtiofs (Docker Desktop for Mac) reports Bsize as the 1 MiB optimal
+	// transfer size while Blocks are still counted in the 4 KiB fragment unit.
+	stat := &syscall.Statfs_t{
+		Bsize:  1048576,
+		Frsize: 4096,
+		Blocks: 1465121792,
+		Bavail: 1054717543,
+	}
+
+	got := blockSize(stat)
+	if got != 4096 {
+		t.Fatalf("blockSize = %d, want 4096 (Frsize)", got)
+	}
+
+	total := uint64(stat.Blocks) * blockSize(stat)
+	const wantTotal = 1465121792 * 4096 // ~5.5 TiB, matches df
+	if total != wantTotal {
+		t.Fatalf("total = %d bytes, want %d (~5.5 TiB)", total, uint64(wantTotal))
+	}
+	// Sanity: the old Bsize-based math overstates by exactly 256x.
+	if inflated := uint64(stat.Blocks) * uint64(stat.Bsize); inflated != total*256 {
+		t.Fatalf("expected 256x inflation from Bsize, got %d vs %d", inflated, total)
+	}
+}
+
+func TestBlockSizeFallsBackToBsize(t *testing.T) {
+	// Normal filesystems report Frsize == Bsize (or leave Frsize unset on
+	// exotic drivers); either way the accounting unit is recovered.
+	stat := &syscall.Statfs_t{Bsize: 4096, Frsize: 4096}
+	if got := blockSize(stat); got != 4096 {
+		t.Fatalf("blockSize = %d, want 4096", got)
+	}
+
+	zero := &syscall.Statfs_t{Bsize: 4096, Frsize: 0}
+	if got := blockSize(zero); got != 4096 {
+		t.Fatalf("blockSize with Frsize=0 = %d, want 4096 (Bsize fallback)", got)
+	}
+}

--- a/backend/internal/adapters/fs/fileutils/partition_unix.go
+++ b/backend/internal/adapters/fs/fileutils/partition_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package fileutils
 


### PR DESCRIPTION
### What

Closes #2894. The sidebar disk-usage bars show PB/TB-scale garbage for sources that are Docker Desktop for Mac bind mounts (backed by `virtiofs`) — a real 5.5 TB drive renders as "1.5 TB / 1.4 PB".

### Fix

`GetPartitionSize` / `GetFreeSpace` / `GetPartitionUsed` computed space as `Blocks * Bsize` from `syscall.Statfs`. `statfs(2)` defines `f_bsize` as the *optimal transfer block size*, not the unit `f_blocks` is counted in. On `virtiofs`, `f_bsize` is reported as 1 MiB while `f_blocks` is still counted in the real 4 KiB fragment unit, overstating space by exactly 256x (1048576 / 4096).

This splits out a Linux implementation (`partition_linux.go`) that uses `f_frsize` (the fragment size = actual block-accounting unit, same field `df`/`statvfs` use) with a fallback to `f_bsize` when `f_frsize` is 0. The generic Unix file is re-scoped to `!windows && !linux` (darwin/BSD, whose `Statfs_t` has no `Frsize` and where `f_bsize` is correct).

### Tests

`backend/internal/adapters/fs/fileutils/partition_linux_test.go`:
- `TestBlockSizePrefersFrsize` — reproduces the issue's exact virtiofs numbers (`Bsize=1048576, Frsize=4096, Blocks=1465121792`), asserts total ≈ 5.5 TiB (matching `df`) and that the old `Bsize` math is exactly 256x larger.
- `TestBlockSizeFallsBackToBsize` — `Frsize == Bsize` and `Frsize == 0` both recover the correct unit.

### Validation (real output)

```
$ go test ./internal/adapters/fs/fileutils/ -run TestBlockSize -v
=== RUN   TestBlockSizePrefersFrsize
--- PASS: TestBlockSizePrefersFrsize (0.00s)
=== RUN   TestBlockSizeFallsBackToBsize
--- PASS: TestBlockSizeFallsBackToBsize (0.00s)
PASS
ok  github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/fileutils  0.005s
```

RED→GREEN verified: forcing `blockSize` back to returning `Bsize` makes `TestBlockSizePrefersFrsize` fail with `blockSize = 1048576, want 4096`; restoring the `f_frsize` preference passes again. `go build`, `go vet`, and `gofmt -l` are all clean on the package (Go 1.27.0).

Happy to adjust the approach if you'd prefer a different structure.

### AI disclosure

This change was prepared with AI assistance and reviewed/verified by me before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed disk-usage reporting for Docker Desktop on Mac bind mounts, preventing incorrect PB/TB-scale values.
  - Disk space calculations now accurately reflect filesystem fragment sizes on Linux systems.

- **Documentation**
  - Updated the v2.0.5 changelog with details of the disk-usage correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->