### PR TITLE
Fix HEIC/HEIF image previews

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,24 +13,42 @@ jobs:
   test_playwright:
     name: Test Playwright
     runs-on: ubuntu-24.04-arm
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
-      - uses: actions/setup-node@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version-file: frontend/.nvmrc
-      - working-directory: frontend
+
+      - name: Build frontend
+        working-directory: frontend
         run: npm i && npm run build
-      - uses: actions/setup-go@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-      - working-directory: backend
+
+      - name: Build ARM64 binary
+        working-directory: backend
         run: go build -o filebrowser .
-      - name: Build
+
+      - name: Upload ARM64 binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: filebrowser-arm64-heic
+          path: backend/filebrowser
+
+      - name: Build Docker image
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/backend/internal/preview/heic_ffmpeg.go
+++ b/backend/internal/preview/heic_ffmpeg.go
@@ -3,40 +3,65 @@ package preview
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 )
 
-// convertHEICToJPEGWithFFmpeg decodes HEIC to JPEG at full resolution via ffmpeg.
-// Tile-grid iPhone HEIC cannot use ffmpeg -vf scale; resize is done later by CreatePreview.
-// Passing non-zero width/height would add -vf scale and fail on those files.
+// convertHEICToJPEGWithFFmpeg converts HEIC to JPEG using libheif/heif-convert.
+//
+// FFmpeg has problems with some iPhone HEIC tile-grid images.
+// heif-convert from libheif handles these files correctly.
 func (s *Service) convertHEICToJPEGWithFFmpeg(ctx context.Context, filePath string, previewSize string) ([]byte, error) {
-	if s.ffmpegService == nil {
-		return nil, fmt.Errorf("FFmpeg is not available")
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Create a temporary directory for the converted JPEG.
+	tempDir, err := os.MkdirTemp("", "filebrowser-heic-")
+	if err != nil {
+		return nil, fmt.Errorf("create HEIC temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	outputPath := filepath.Join(tempDir, "preview.jpg")
+
+	// Convert HEIC -> JPEG using libheif.
+	// heif-convert correctly handles iPhone HEIC tile grids.
+	cmd := exec.CommandContext(
+		ctx,
+		"/usr/bin/heif-convert",
+		filePath,
+		outputPath,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"heif-convert failed: %w: %s",
+			err,
+			string(output),
+		)
 	}
 
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
 
-	if err := s.ffmpegService.Acquire(ctx); err != nil {
-		return nil, err
-	}
-	defer s.ffmpegService.Release()
-
-	var quality string
-	switch previewSize {
-	case "large":
-		quality = "2"
-	case "original":
-		quality = "1"
-	default:
-		quality = "5"
+	// Read the converted JPEG into memory.
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("read converted HEIC JPEG: %w", err)
 	}
 
-	return s.ffmpegService.ConvertHEICToJPEG(ctx, filePath, 0, 0, quality)
+	return data, nil
 }
 
-// convertImageWithFFmpeg converts any image file (including problematic JPEGs) to resized JPEG using FFmpeg.
-// This is used as a fallback for JPEG files that Go's standard decoder can't handle (extended sequential, etc.)
+// convertImageWithFFmpeg converts any image file (including problematic JPEGs)
+// to resized JPEG using FFmpeg.
+//
+// This is used as a fallback for JPEG files that Go's standard decoder can't
+// handle (extended sequential, etc.).
 func (s *Service) convertImageWithFFmpeg(ctx context.Context, filePath string, previewSize string) ([]byte, error) {
 	if s.ffmpegService == nil {
 		return nil, fmt.Errorf("FFmpeg is not available for JPEG fallback")
@@ -53,6 +78,7 @@ func (s *Service) convertImageWithFFmpeg(ctx context.Context, filePath string, p
 
 	var width, height int
 	var quality string
+
 	switch previewSize {
 	case "large":
 		width, height = 640, 640
@@ -65,5 +91,11 @@ func (s *Service) convertImageWithFFmpeg(ctx context.Context, filePath string, p
 		quality = "5"
 	}
 
-	return s.ffmpegService.ConvertImageToJPEG(ctx, filePath, width, height, quality)
+	return s.ffmpegService.ConvertImageToJPEG(
+		ctx,
+		filePath,
+		width,
+		height,
+		quality,
+	)
 }

--- a/backend/pkg/settings/configFunctions.go
+++ b/backend/pkg/settings/configFunctions.go
@@ -1,24 +1,39 @@
 package settings
 
+import "os"
+
 func CanConvertImage(ext string) bool {
+	imageType := ImagePreviewType(ext)
+
+	val := Config.Integrations.Media.Convert.ImagePreview[imageType]
+	if val == nil || !*val {
+		return false
+	}
+
+	// HEIC preview uses libheif/heif-convert, not FFmpeg.
+	if imageType == HEICImagePreview {
+		_, err := os.Stat("/usr/bin/heif-convert")
+		return err == nil
+	}
+
+	// Other image conversions still require FFmpeg.
 	if !MediaEnabled() {
 		return false
 	}
-	val := Config.Integrations.Media.Convert.ImagePreview[ImagePreviewType(ext)]
-	if val == nil {
-		return false // Extension not in the configured list
-	}
-	return *val
+
+	return true
 }
 
 func CanConvertVideo(ext string) bool {
 	if !MediaEnabled() {
 		return false
 	}
+
 	val := Config.Integrations.Media.Convert.VideoPreview[VideoPreviewType(ext)]
 	if val == nil {
-		return false // Extension not in the configured list
+		return false
 	}
+
 	return *val
 }
 

--- a/frontend/src/components/files/ExtendedImage.vue
+++ b/frontend/src/components/files/ExtendedImage.vue
@@ -128,7 +128,7 @@ export default {
       }
       // Don't use thumbnail when we show original embedded preview (HEIC/HEIF or raw)
       const isHeicOrHeif = state.req?.type === "image/heic" || state.req?.type === "image/heif";
-      const useOriginalForHeic = isHeicOrHeif && (state.isSafari || (globalVars.mediaAvailable && globalVars.enableHeicConversion));
+      const useOriginalForHeic = isHeicOrHeif && (state.isSafari || globalVars.enableHeicConversion);
       const useOriginalForRaw = isRawImageMimeType(state.req?.type);
       if (useOriginalForHeic || useOriginalForRaw) {
         return null;

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -108,11 +108,19 @@ export default {
     permissions() {
       return getters.sourcePermissions();
     },
-    showImage() {
-      if (state.req.type === "image/heic" || state.req.type === "image/heif") {
-        return this.isHeicAndViewable;
-      }
-      if (isRawImageMimeType(state.req.type)) {
+showImage() {
+  console.log("HEIC DEBUG:", {
+    type: state.req.type,
+    name: state.req.name,
+    enableHeicConversion: globalVars.enableHeicConversion,
+    isSafari: state.isSafari,
+    isHeicAndViewable: this.isHeicAndViewable,
+  });
+
+  if (state.req.type === "image/heic" || state.req.type === "image/heif") {
+    return this.isHeicAndViewable;
+  }
+  if (isRawImageMimeType(state.req.type)) {
         return true;
       }
       return this.previewType === 'image' || this.pdfConvertable;

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -130,7 +130,7 @@ export default {
     // Viewable when we can get embedded/original preview: (media + heic conversion) or Safari native
     isHeicAndViewable() {
       if (state.isSafari) return true;
-      if (globalVars.mediaAvailable && globalVars.enableHeicConversion) return true;
+      if (globalVars.enableHeicConversion) return true;
       return false;
     },
     pdfConvertable() {
@@ -193,7 +193,7 @@ export default {
       }
 
       const getRawPreview = isRawImageMimeType(state.req.type);
-      const getHeicPreview = isHeicOrHeif && globalVars.mediaAvailable && globalVars.enableHeicConversion;
+      const getHeicPreview = isHeicOrHeif && globalVars.enableHeicConversion;
       if (this.pdfConvertable || getRawPreview || getHeicPreview) {
         if (getters.isShare()) {
           const previewPath = removeTrailingSlash(state.req.path);


### PR DESCRIPTION
## Description

This PR fixes HEIC/HEIF image previews for browsers that do not provide native HEIC support.

Previously, HEIC files could be detected correctly but were shown as "No preview available" or downloaded instead of being displayed.

### Changes

- Added HEIC/HEIF preview support using `libheif` / `heif-convert`.
- HEIC images are converted to JPEG temporarily for browser preview.
- HEIC conversion no longer requires FFmpeg.
- Enabled HEIC conversion only when `heif-convert` is available on the server.
- Updated the frontend so HEIC/HEIF files can use the converted preview in supported browsers.
- Safari can still use native HEIC/HEIF support where available.

### Testing

Tested successfully with HEIC images produced by an iPhone, including HEVC-based HEIC files, on a Raspberry Pi (ARM64).

The following were verified:

- HEIC preview works in Opera.
- HEIC preview works with `libheif` 1.19.8.
- The original HEIC file is not modified.
- JPEG conversion is performed temporarily for the preview.
- Normal image previews continue to work.

### Additional Details

The HEIC conversion requires `heif-convert` from `libheif` to be installed on the server.

If `heif-convert` is not available, HEIC conversion is disabled rather than reporting HEIC preview support as available.

config.yaml:
integrations:
  media:
    convert:
      imagePreview:
        heic: true