### PR TITLE
Support non-ASCII share passwords

### DIFF
--- a/backend/internal/web/auth.go
+++ b/backend/internal/web/auth.go
@@ -8,6 +8,7 @@ import (
 	libError "errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -414,6 +415,10 @@ func AuthenticateShareRequest(r *http.Request, l share.Share) (int, error) {
 	password := r.Header.Get("X-SHARE-PASSWORD")
 	if password == "" {
 		logger.Debugf("share auth failed: hash=%s reason=missing_password", l.Hash)
+		return http.StatusUnauthorized, nil
+	}
+	password, err := url.QueryUnescape(password)
+	if err != nil {
 		return http.StatusUnauthorized, nil
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(l.PasswordHash), []byte(password)); err != nil {

--- a/backend/internal/web/middleware_test.go
+++ b/backend/internal/web/middleware_test.go
@@ -353,6 +353,7 @@ func TestPublicShareHandlerAuthentication(t *testing.T) {
 	setupTestEnv(t)
 
 	const passwordBcrypt = "$2y$10$TFAmdCbyd/mEZDe5fUeZJu.MaJQXRTwdqb/IQV.eTn6dWrF58gCSe" // bcrypt hashed password
+	const accentedPasswordBcrypt = "$2b$04$JaVUkztbmWKgV8GsSvRorettpNHrc0BvYV3/oARpepfoanKbqt5zi"
 
 	// Create and save a dummy user (shares reference owner by UserID)
 	dummyUser := &users.User{
@@ -455,6 +456,22 @@ func TestPublicShareHandlerAuthentication(t *testing.T) {
 				"X-SHARE-PASSWORD": "wrong-password",
 			},
 			expectedStatusCode: http.StatusUnauthorized,
+		},
+		{
+			name: "Private share, valid encoded non-ASCII password",
+			share: &share.Share{
+				ShareSettings: share.ShareSettings{
+					ShareLimits: share.ShareLimits{SourceName: "srv"},
+				},
+				ShareColumns: share.ShareColumns{Hash: "accented_password_hash", Path: "/"},
+				SourcePath:   "/srv",
+				UserID:       1,
+				PasswordHash: accentedPasswordBcrypt,
+			},
+			extraHeaders: map[string]string{
+				"X-SHARE-PASSWORD": "pass%C3%A9",
+			},
+			expectedStatusCode: http.StatusOK,
 		},
 	}
 

--- a/frontend/src/api/media.js
+++ b/frontend/src/api/media.js
@@ -23,7 +23,7 @@ export async function getSubtitleContent(source, path, subtitleName, embedded = 
       })
       const sharePassword = localStorage.getItem(`sharepass:${hash}`) || ''
       res = await fetchURL(apiPath, {
-        headers: { 'X-SHARE-PASSWORD': sharePassword },
+        headers: { 'X-SHARE-PASSWORD': encodeURIComponent(sharePassword) },
       })
     } else {
       const apiPath = getApiPath('media/subtitles', {
@@ -61,7 +61,7 @@ export async function getLyricsPublic(path, hash, password = "") {
     };
     const apiPath = getPublicApiPath("media/lyrics", params);
     const response = await fetch(apiPath, {
-        headers: { "X-SHARE-PASSWORD": password || "" },
+        headers: { "X-SHARE-PASSWORD": encodeURIComponent(password || "") },
     });
     if (!response.ok) {
         const error = new Error(response.statusText);
@@ -102,7 +102,7 @@ export async function fetchDirectoryMediaMetadataPublic(path, hash, password = "
   };
   const apiPath = getPublicApiPath("media/metadata", params);
   const response = await fetch(apiPath, {
-    headers: { "X-SHARE-PASSWORD": password || "" },
+    headers: { "X-SHARE-PASSWORD": encodeURIComponent(password || "") },
   });
   if (!response.ok) {
     const error = new Error(response.statusText);

--- a/frontend/src/api/office.js
+++ b/frontend/src/api/office.js
@@ -17,7 +17,7 @@ export async function getConfig(req) {
     if (req.hash) {
       const sharePassword = localStorage.getItem(`sharepass:${req.hash}`)
       if (sharePassword) {
-        headers['X-SHARE-PASSWORD'] = sharePassword
+        headers['X-SHARE-PASSWORD'] = encodeURIComponent(sharePassword)
       }
     }
     

--- a/frontend/src/api/resources.js
+++ b/frontend/src/api/resources.js
@@ -1148,7 +1148,7 @@ function sharePublicAuthHeaders(hash) {
   if (!password) {
     return {};
   }
-  return { "X-SHARE-PASSWORD": password };
+  return { "X-SHARE-PASSWORD": encodeURIComponent(password) };
 }
 
 // Fetch public share data
@@ -1172,7 +1172,7 @@ export async function fetchFilesPublic(path, hash, password = "", content = fals
   const apiPath = getPublicApiPath("resources", params);
   const response = await fetch(apiPath, {
     headers: {
-      "X-SHARE-PASSWORD": password || "",
+      "X-SHARE-PASSWORD": encodeURIComponent(password || ""),
     },
   });
 


### PR DESCRIPTION
**Description**

## Context

Share passwords are hashed from UTF-8 input when they are created, but the web client sent raw Unicode in `X-SHARE-PASSWORD` and share authentication compared that wire value without decoding it. An accented password such as `passé` therefore failed even when entered correctly.

## Changes

Percent-encode the share-password header across resource, media, and OnlyOffice requests, then decode it once in `AuthenticateShareRequest` before the bcrypt comparison.

## User impact

Password-protected shares now accept accented and other Unicode passwords across public file and media paths.

## Verification

- Confirmed the regression on the unmodified base: `pass%C3%A9` returned 401; the focused authentication table passes after the change.
- Exercised a locally built server: login returned 200, a share created with `passé` accepted the encoded password with 200, and rejected a wrong password with 401.
- Frontend: 162/162 Vitest tests, ESLint, `vue-tsc`, i18n/icon checks, and the production Vite build passed.
- Backend: focused tests, `gofmt`, `go mod tidy`, build, and golangci-lint passed with zero issues.
- The complete non-race Go suite was run; existing Windows path, symlink, and settings failures were reproduced on the clean base. The race suite requires a cgo C compiler that is unavailable in this environment.

- [x] A clear description of the changes made in this pull request.
- [x] A short title that summarizes the changes made.
- [ ] Must pass unit and integration tests before merging.
- [x] Any additional details that might be helpful for reviewers.

**Additional Details**

This updates all six production `X-SHARE-PASSWORD` writers. The Docker Playwright suite is left to CI because Docker is unavailable locally.

Fixes #2889


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved public-share authentication for passwords containing accented or other special characters.
  * Public-share requests now reliably handle encoded passwords across media, document, and resource access.
  * Invalid password encoding is rejected with an unauthorized response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->