### PR TITLE
Preserve deleted sidebar links across restarts

### DIFF
--- a/backend/cmd/user.go
+++ b/backend/cmd/user.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/gtsteffaniak/filebrowser/backend/internal/adapters/fs/fileutils"
-	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/state"
 	"github.com/gtsteffaniak/filebrowser/backend/internal/usersidebar"
+	"github.com/gtsteffaniak/filebrowser/backend/pkg/settings"
 	"github.com/gtsteffaniak/go-logger/logger"
 )
 
@@ -27,7 +27,8 @@ func validateUserInfo(newDB bool) {
 		changedFields := make([]string, 0, 8)
 		changePass := false
 
-		if updateUserScopes(user) {
+		scopesChanged := updateUserScopes(user)
+		if scopesChanged {
 			changedFields = append(changedFields, "backendScopes")
 		}
 		if updatePermissions(user) {
@@ -45,7 +46,7 @@ func validateUserInfo(newDB bool) {
 		if updateShowFirstLogin(user) {
 			changedFields = append(changedFields, "showFirstLogin")
 		}
-		if updateSidebarLinks(user) {
+		if updateSidebarLinks(user, scopesChanged) {
 			changedFields = append(changedFields, "sidebarLinks")
 		}
 		if updateTokens(user) {
@@ -232,28 +233,17 @@ func updatePreviewSettings(user *users.User) bool {
 	return false
 }
 
-// updateSidebarLinks normalizes sidebar links and ensures scoped sources have sidebar entries.
-func updateSidebarLinks(user *users.User) bool {
-	needsEnsure := usersidebar.NeedsSidebarLinksFromScopes(user.SidebarLinks, user.BackendScopes)
-	validBefore := usersidebar.ValidSourceSidebarLinkCount(user.SidebarLinks)
-
-	links, changed := usersidebar.PrepareSidebarLinksForPersist(user.SidebarLinks, user.BackendScopes)
+// updateSidebarLinks normalizes saved links and adds defaults for new or changed scopes.
+func updateSidebarLinks(user *users.User, scopesChanged bool) bool {
+	links, changed := usersidebar.NormalizeSidebarLinks(user.SidebarLinks)
+	if scopesChanged || user.SidebarLinks == nil {
+		links, changed = usersidebar.PrepareSidebarLinksForPersist(user.SidebarLinks, user.BackendScopes)
+	}
 	if !changed {
 		return false
 	}
 
 	user.SidebarLinks = links
-
-	if needsEnsure {
-		if validBefore == 0 && len(user.SidebarLinks) > 0 {
-			logger.Infof("User %s has stale source sidebar links, merging missing links from scopes", user.Username)
-		} else if validBefore == 0 {
-			logger.Infof("User %s has no source sidebar links, building from scopes", user.Username)
-		} else {
-			logger.Infof("User %s is missing sidebar links for some scoped sources, merging from scopes", user.Username)
-		}
-	}
-
 	return true
 }
 

--- a/backend/cmd/user_scopes_test.go
+++ b/backend/cmd/user_scopes_test.go
@@ -79,7 +79,7 @@ func TestMigrationGraham_gainsAccessAfterScopeMerge(t *testing.T) {
 
 	updateUserScopes(graham)
 	updateSourcePermissions(graham)
-	updateSidebarLinks(graham)
+	updateSidebarLinks(graham, true)
 
 	foundScope := false
 	for _, scope := range graham.BackendScopes {

--- a/backend/cmd/user_sidebar_test.go
+++ b/backend/cmd/user_sidebar_test.go
@@ -33,7 +33,7 @@ func TestUpdateSidebarLinks_dedupesDuplicateMigratedLinks(t *testing.T) {
 		},
 	}
 
-	if !updateSidebarLinks(user) {
+	if !updateSidebarLinks(user, false) {
 		t.Fatal("expected updateSidebarLinks to return true")
 	}
 
@@ -63,7 +63,7 @@ func TestUpdateSidebarLinks_buildsFromScopesWhenNoSourceLinks(t *testing.T) {
 		},
 	}
 
-	if !updateSidebarLinks(user) {
+	if !updateSidebarLinks(user, false) {
 		t.Fatal("expected updateSidebarLinks to return true")
 	}
 
@@ -75,5 +75,34 @@ func TestUpdateSidebarLinks_buildsFromScopesWhenNoSourceLinks(t *testing.T) {
 	}
 	if count != 3 {
 		t.Fatalf("got %d source links, want 3: %v", count, user.SidebarLinks)
+	}
+}
+
+func TestUpdateSidebarLinks_keepsDeletedSourceLinkAbsent(t *testing.T) {
+	settings.Initialize(settingsMigrationConfigPath(t))
+	alignSettingsSourcesForMigrationFixture(t)
+
+	user := &users.User{
+		FrontendUser: users.FrontendUser{
+			Username: "admin",
+			NonAdminEditable: users.NonAdminEditable{
+				SidebarLinks: []users.SidebarLink{
+					{Name: "playwright + files", Category: "source", SourceName: fixturePlaywrightSource, Target: "/"},
+					{Name: "docker", Category: "source", SourceName: fixtureDockerSource, Target: "/"},
+				},
+			},
+		},
+		BackendScopes: []users.BackendScope{
+			{Path: fixturePlaywrightSource, Scope: "/"},
+			{Path: fixtureDockerSource, Scope: "/"},
+			{Path: fixtureAccessSource, Scope: "/"},
+		},
+	}
+
+	if updateSidebarLinks(user, false) {
+		t.Fatal("expected saved sidebar links to remain unchanged")
+	}
+	if len(user.SidebarLinks) != 2 {
+		t.Fatalf("got %d sidebar links, want 2: %v", len(user.SidebarLinks), user.SidebarLinks)
 	}
 }


### PR DESCRIPTION
## Context

Startup reconciliation treated every scoped source missing from `sidebarLinks` as a new default. That also included source links a user had deliberately removed, so the link was restored on every restart.

Fixes #2906.

## Changes

- Normalize an explicitly saved sidebar configuration without adding missing source links.
- Continue seeding links for legacy users with no saved configuration and when startup adds a newly enabled source.
- Cover the deleted-link case while retaining the existing migration coverage.

## User impact

Source links removed from the sidebar stay removed after File Browser restarts. Newly enabled sources still receive their initial sidebar link.

## Verification

- `go test ./cmd -run '^(TestUpdateSidebarLinks_.*|TestMigrationGraham_gainsAccessAfterScopeMerge)$' -count=1` — passed.
- `go test ./internal/usersidebar -count=1` — passed.
- `go tool golangci-lint run --path-prefix=backend` — passed with 0 issues.
- Windows backend build — passed.
- Live restart check with three local sources — removed `drive`, restarted the built server, and confirmed the API still returned two source links while retaining all three source scopes.
- `go test -timeout=30s ./... -count=1` — the touched regression and migration coverage passed; the full run remains red on this Windows host in platform-dependent path, symlink, executable-bit, image-fixture, and SQLite cleanup tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar-link migration when user access scopes change.
  - Existing sidebar links are now preserved when their associated access scope is no longer present.
  - Sidebar links are rebuilt only when necessary, reducing unexpected navigation changes during account updates.
  - Account updates now maintain saved navigation more consistently, preventing deleted or outdated source links from unexpectedly reappearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->