### PR TITLE
Fall back to buffered copies when FUSE rejects fast paths

### DIFF
--- a/backend/internal/adapters/fs/fileutils/file.go
+++ b/backend/internal/adapters/fs/fileutils/file.go
@@ -1,10 +1,12 @@
 package fileutils
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
+	"syscall"
 
 	"github.com/gtsteffaniak/go-logger/logger"
 )
@@ -126,8 +128,7 @@ func copySingleFile(source, dest string) error {
 	defer dst.Close()
 
 	// Copy the contents of the file.
-	_, err = io.Copy(dst, src)
-	if err != nil {
+	if err = copyFileContents(dst, src); err != nil {
 		return err
 	}
 
@@ -144,6 +145,18 @@ func copySingleFile(source, dest string) error {
 		logger.Debugf("Could not preserve modification time for %s: %v", dest, err)
 	}
 	return nil
+}
+
+func copyFileContents(dst io.Writer, src io.Reader) error {
+	_, err := io.Copy(dst, src)
+	if !errors.Is(err, syscall.EBADF) {
+		return err
+	}
+
+	// Some FUSE filesystems reject copy_file_range. Hide the optional fast-path
+	// methods so io.Copy retries from the current offsets with buffered I/O.
+	_, err = io.Copy(struct{ io.Writer }{dst}, struct{ io.Reader }{src})
+	return err
 }
 
 // copyDirectory handles copying directories recursively.

--- a/backend/internal/adapters/fs/fileutils/file_test.go
+++ b/backend/internal/adapters/fs/fileutils/file_test.go
@@ -1,11 +1,32 @@
 package fileutils
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 )
+
+type copyFileRangeRejectingWriter struct {
+	bytes.Buffer
+	readFromCalls int
+}
+
+func (w *copyFileRangeRejectingWriter) ReadFrom(r io.Reader) (int64, error) {
+	w.readFromCalls++
+	buf := make([]byte, 4)
+	n, err := r.Read(buf)
+	if n > 0 {
+		_, _ = w.Write(buf[:n])
+	}
+	if err != nil {
+		return int64(n), err
+	}
+	return int64(n), syscall.EBADF
+}
 
 func TestUnixModeToFileMode_setgid(t *testing.T) {
 	m := unixModeToFileMode(0o2770)
@@ -115,5 +136,21 @@ func TestCopyFilePreservesModTime(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCopyFileContentsFallsBackAfterCopyFileRangeBadFileDescriptor(t *testing.T) {
+	const content = "complete file contents"
+	src := struct{ io.Reader }{bytes.NewBufferString(content)}
+	dst := &copyFileRangeRejectingWriter{}
+
+	if err := copyFileContents(dst, src); err != nil {
+		t.Fatal(err)
+	}
+	if got := dst.String(); got != content {
+		t.Fatalf("copied contents = %q, want %q", got, content)
+	}
+	if dst.readFromCalls != 1 {
+		t.Fatalf("ReadFrom calls = %d, want 1", dst.readFromCalls)
 	}
 }


### PR DESCRIPTION
## Context

File Browser delegates physical file copies to `io.Copy`. For file-to-file copies on Linux, Go can select the `copy_file_range` fast path. rclone FUSE mounts may reject that operation with `EBADF`, which Go does not treat as a portable fallback error, so copying between two such mounts fails with HTTP 207.

## Changes

- Retry an `EBADF` copy with the optional `WriterTo`/`ReaderFrom` fast paths hidden, which makes `io.Copy` continue with buffered I/O from the current file offsets.
- Add a regression test that exercises a partial fast-path write followed by `EBADF` and verifies the completed file contents.

## User impact

Files and recursively copied directories can move between rclone FUSE mounts even when the filesystem rejects `copy_file_range`. Other copy errors are still returned unchanged.

## Verification

- `go test ./internal/adapters/fs/fileutils -run 'TestCopyFileContentsFallsBackAfterCopyFileRangeBadFileDescriptor|TestCopyFilePreservesModTime' -count=10` — passed.
- `go build ./...` — passed.
- `go vet ./...` — passed.
- `go tool golangci-lint run` — passed with 0 issues.
- Mounted two separate rclone v1.75.1 `:local:` remotes through WinFsp, recursively copied a nested 1.5 MiB file through `fileutils.CopyFile`, and verified the destination bytes — passed.
- `go test ./... -count=1` — the changed regression passes; the suite retains existing Windows failures for Unix permission/symlink behavior, path separators, and a config-generator panic, all reproduced on clean `dev/v2.1.0`.

Fixes #2924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-copy reliability on filesystems that reject optimized copy operations.
  * Ensured complete file contents are copied by automatically falling back to buffered I/O when needed.
  * Preserved already-copied data and continued from the current position during fallback, reducing the risk of incomplete or corrupted file transfers.

* **Tests**
  * Added coverage for partial-copy failures, complete content preservation, and successful fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->