### PR TITLE
updated with token change for backwards compatiblity

### DIFF
--- a/backend/internal/database/sqldb/migrations.go
+++ b/backend/internal/database/sqldb/migrations.go
@@ -6,7 +6,7 @@ import (
 )
 
 // currentSchemaVersion is the SQLite schema marker for this codebase.
-const currentSchemaVersion = 1
+const currentSchemaVersion = 2
 
 // Schema creates all tables for the SQLite database
 func createSchema(db *sql.DB) error {
@@ -181,6 +181,10 @@ func runMigrations(db *sql.DB, fromVersion int) error {
 		switch v {
 		case 1:
 			// Canonical schema is createSchema + Bolt import; no step migrations.
+		case 2:
+			if err := normalizeLegacyShareTokens(db); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("unknown schema version: %d", v)
 		}

--- a/backend/internal/database/sqldb/shares.go
+++ b/backend/internal/database/sqldb/shares.go
@@ -40,9 +40,7 @@ func scanShareUserID(s string, dest *uint64) error {
 
 // GetShareByHash retrieves a share by hash
 func (s *SQLStore) GetShareByHash(hash string) (*share.Share, error) {
-	query := `SELECT hash, user_id, source, path, expire, downloads, 
-			  password_hash, user_downloads, share_settings, version 
-			  FROM shares WHERE hash = ?`
+	query := `SELECT ` + shareSelectColumns + ` FROM shares WHERE hash = ?`
 
 	var link share.Share
 	var userIDStr string
@@ -86,9 +84,7 @@ func (s *SQLStore) GetShareByHash(hash string) (*share.Share, error) {
 // GetSharesByUserID retrieves all non-expired shares for an owner user id.
 func (s *SQLStore) GetSharesByUserID(userID uint64) ([]*share.Share, error) {
 	now := time.Now().Unix()
-	query := `SELECT hash, user_id, source, path, expire, downloads, 
-			  password_hash, user_downloads, share_settings, version 
-			  FROM shares WHERE user_id = ? AND (expire = 0 OR expire > ?) 
+	query := `SELECT ` + shareSelectColumns + ` FROM shares WHERE user_id = ? AND (expire = 0 OR expire > ?) 
 			  ORDER BY path`
 
 	rows, err := s.db.Query(query, shareUserIDDB(userID), now)
@@ -102,9 +98,7 @@ func (s *SQLStore) GetSharesByUserID(userID uint64) ([]*share.Share, error) {
 
 // GetSharesBySourcePath retrieves shares for a specific source and path
 func (s *SQLStore) GetSharesBySourcePath(source, path string) ([]*share.Share, error) {
-	query := `SELECT hash, user_id, source, path, expire, downloads, 
-			  password_hash, user_downloads, share_settings, version 
-			  FROM shares WHERE source = ? AND path = ? ORDER BY hash`
+	query := `SELECT ` + shareSelectColumns + ` FROM shares WHERE source = ? AND path = ? ORDER BY hash`
 
 	rows, err := s.db.Query(query, source, path)
 	if err != nil {
@@ -118,9 +112,7 @@ func (s *SQLStore) GetSharesBySourcePath(source, path string) ([]*share.Share, e
 // GetSharesBySourcePathUser retrieves shares for a specific source, path, and owner user id.
 func (s *SQLStore) GetSharesBySourcePathUser(source, path string, userID uint64) ([]*share.Share, error) {
 	now := time.Now().Unix()
-	query := `SELECT hash, user_id, source, path, expire, downloads, 
-			  password_hash, user_downloads, share_settings, version 
-			  FROM shares WHERE source = ? AND path = ? AND user_id = ? 
+	query := `SELECT ` + shareSelectColumns + ` FROM shares WHERE source = ? AND path = ? AND user_id = ? 
 			  AND (expire = 0 OR expire > ?) ORDER BY hash`
 
 	rows, err := s.db.Query(query, source, path, shareUserIDDB(userID), now)
@@ -134,9 +126,7 @@ func (s *SQLStore) GetSharesBySourcePathUser(source, path string, userID uint64)
 
 // GetPermanentShare retrieves a permanent share (expire = 0) for source, path, and owner.
 func (s *SQLStore) GetPermanentShare(source, path string, userID uint64) (*share.Share, error) {
-	query := `SELECT hash, user_id, source, path, expire, downloads,
-			  password_hash, user_downloads, share_settings, version
-			  FROM shares WHERE source = ? AND path = ? AND user_id = ? AND expire = 0
+	query := `SELECT ` + shareSelectColumns + ` FROM shares WHERE source = ? AND path = ? AND user_id = ? AND expire = 0
 			  LIMIT 1`
 
 	var link share.Share
@@ -181,9 +171,7 @@ func (s *SQLStore) GetPermanentShare(source, path string, userID uint64) (*share
 // ListAllShares retrieves all non-expired shares
 func (s *SQLStore) ListAllShares() ([]*share.Share, error) {
 	now := time.Now().Unix()
-	query := `SELECT hash, user_id, source, path, expire, downloads, 
-			  password_hash, user_downloads, share_settings, version 
-			  FROM shares WHERE expire = 0 OR expire > ? ORDER BY path`
+	query := `SELECT ` + shareSelectColumns + ` FROM shares WHERE expire = 0 OR expire > ? ORDER BY path`
 
 	rows, err := s.db.Query(query, now)
 	if err != nil {
@@ -205,23 +193,59 @@ func (s *SQLStore) SaveShare(link *share.Share) error {
 		return fmt.Errorf("failed to marshal share settings: %w", err)
 	}
 
-	query := `INSERT OR REPLACE INTO shares 
+	hasLegacyToken, err := s.sharesHasLegacyTokenColumn()
+	if err != nil {
+		return fmt.Errorf("failed to inspect shares schema: %w", err)
+	}
+
+	legacyToken := ""
+	if hasLegacyToken {
+		legacyToken, err = s.legacyShareToken(link.Hash)
+		if err != nil {
+			return err
+		}
+	}
+
+	var query string
+	var args []any
+	if hasLegacyToken {
+		query = `INSERT OR REPLACE INTO shares 
+			  (hash, user_id, source, path, expire, downloads, password_hash, 
+			   token, user_downloads, share_settings, version) 
+			  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		args = []any{
+			link.Hash,
+			shareUserIDDB(link.UserID),
+			link.SourcePath,
+			link.Path,
+			link.Expire,
+			link.Downloads,
+			link.PasswordHash,
+			legacyToken,
+			userDownloadsJSON,
+			shareSettingsJSON,
+			link.Version,
+		}
+	} else {
+		query = `INSERT OR REPLACE INTO shares 
 			  (hash, user_id, source, path, expire, downloads, password_hash, 
 			   user_downloads, share_settings, version) 
 			  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		args = []any{
+			link.Hash,
+			shareUserIDDB(link.UserID),
+			link.SourcePath,
+			link.Path,
+			link.Expire,
+			link.Downloads,
+			link.PasswordHash,
+			userDownloadsJSON,
+			shareSettingsJSON,
+			link.Version,
+		}
+	}
 
-	_, err = s.db.Exec(query,
-		link.Hash,
-		shareUserIDDB(link.UserID),
-		link.SourcePath,
-		link.Path,
-		link.Expire,
-		link.Downloads,
-		link.PasswordHash,
-		userDownloadsJSON,
-		shareSettingsJSON,
-		link.Version,
-	)
+	_, err = s.db.Exec(query, args...)
 	if err != nil {
 		return fmt.Errorf("failed to save share: %w", err)
 	}

--- a/backend/internal/database/sqldb/shares_legacy.go
+++ b/backend/internal/database/sqldb/shares_legacy.go
@@ -1,0 +1,81 @@
+package sqldb
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+const shareSelectColumns = `hash, user_id, source, path, expire, downloads,
+			  password_hash, user_downloads, share_settings, version`
+
+func sharesTableHasColumn(db *sql.DB, column string) (bool, error) {
+	rows, err := db.Query(`PRAGMA table_info(shares)`)
+	if err != nil {
+		return false, fmt.Errorf("read shares schema: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			colType   string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &colType, &notnull, &dfltValue, &pk); err != nil {
+			return false, fmt.Errorf("scan shares schema: %w", err)
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterate shares schema: %w", err)
+	}
+	return false, nil
+}
+
+// normalizeLegacyShareTokens keeps rollback compatibility with releases that still
+// scan shares.token into a Go string (NULL is unsupported there).
+func normalizeLegacyShareTokens(db *sql.DB) error {
+	hasToken, err := sharesTableHasColumn(db, "token")
+	if err != nil {
+		return err
+	}
+	if !hasToken {
+		return nil
+	}
+	if _, err := db.Exec(`UPDATE shares SET token = '' WHERE token IS NULL`); err != nil {
+		return fmt.Errorf("normalize legacy share tokens: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) sharesHasLegacyTokenColumn() (bool, error) {
+	return sharesTableHasColumn(s.db, "token")
+}
+
+func (s *SQLStore) legacyShareToken(hash string) (string, error) {
+	hasToken, err := s.sharesHasLegacyTokenColumn()
+	if err != nil {
+		return "", err
+	}
+	if !hasToken {
+		return "", nil
+	}
+
+	var token sql.NullString
+	err = s.db.QueryRow(`SELECT token FROM shares WHERE hash = ?`, hash).Scan(&token)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read legacy share token: %w", err)
+	}
+	if !token.Valid {
+		return "", nil
+	}
+	return token.String, nil
+}

--- a/backend/internal/database/sqldb/shares_legacy_test.go
+++ b/backend/internal/database/sqldb/shares_legacy_test.go
@@ -1,0 +1,171 @@
+package sqldb
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/share"
+)
+
+func createLegacySharesDB(t *testing.T) *SQLStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "legacy-shares.db")
+	store, _, err := NewSQLStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLStore: %v", err)
+	}
+
+	_, err = store.db.Exec(`DROP TABLE shares`)
+	if err != nil {
+		t.Fatalf("drop shares: %v", err)
+	}
+	_, err = store.db.Exec(`
+		CREATE TABLE shares (
+			hash TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			source TEXT NOT NULL,
+			path TEXT NOT NULL,
+			expire INTEGER NOT NULL DEFAULT 0,
+			downloads INTEGER NOT NULL DEFAULT 0,
+			password_hash TEXT,
+			token TEXT,
+			user_downloads TEXT,
+			share_settings TEXT NOT NULL,
+			version INTEGER NOT NULL DEFAULT 0
+		)`)
+	if err != nil {
+		t.Fatalf("create legacy shares table: %v", err)
+	}
+	_, err = store.db.Exec(`
+		INSERT INTO shares (
+			hash, user_id, source, path, expire, downloads, password_hash, token,
+			user_downloads, share_settings, version
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"legacy-null-token",
+		"1",
+		"/data",
+		"/docs/file.txt",
+		0,
+		0,
+		"",
+		nil,
+		"{}",
+		`{"shareType":"normal"}`,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("insert legacy share: %v", err)
+	}
+
+	return store
+}
+
+func scanLegacyShareToken(t *testing.T, store *SQLStore, hash string) string {
+	t.Helper()
+	var token string
+	err := store.db.QueryRow(`
+		SELECT hash, user_id, source, path, expire, downloads,
+		       password_hash, token, user_downloads, share_settings, version
+		FROM shares WHERE hash = ?`, hash).Scan(
+		new(string),
+		new(string),
+		new(string),
+		new(string),
+		new(int64),
+		new(int),
+		new(string),
+		&token,
+		new([]byte),
+		new([]byte),
+		new(int),
+	)
+	if err != nil {
+		t.Fatalf("scan legacy share row: %v", err)
+	}
+	return token
+}
+
+func TestMigrationNormalizesNullLegacyShareToken(t *testing.T) {
+	store := createLegacySharesDB(t)
+
+	if err := runMigrations(store.db, 1); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	token := scanLegacyShareToken(t, store, "legacy-null-token")
+	if token != "" {
+		t.Fatalf("token = %q, want empty string after migration", token)
+	}
+
+	links, err := store.ListAllShares()
+	if err != nil {
+		t.Fatalf("ListAllShares: %v", err)
+	}
+	if len(links) != 1 || links[0].Hash != "legacy-null-token" {
+		t.Fatalf("unexpected shares loaded: %#v", links)
+	}
+}
+
+func TestSaveSharePreservesLegacyTokenColumn(t *testing.T) {
+	store := createLegacySharesDB(t)
+	if err := normalizeLegacyShareTokens(store.db); err != nil {
+		t.Fatalf("normalizeLegacyShareTokens: %v", err)
+	}
+
+	_, err := store.db.Exec(`UPDATE shares SET token = ? WHERE hash = ?`, "keep-me", "legacy-null-token")
+	if err != nil {
+		t.Fatalf("seed legacy token: %v", err)
+	}
+
+	link, err := store.GetShareByHash("legacy-null-token")
+	if err != nil {
+		t.Fatalf("GetShareByHash: %v", err)
+	}
+	link.Downloads = 2
+
+	if err := store.SaveShare(link); err != nil {
+		t.Fatalf("SaveShare: %v", err)
+	}
+
+	token := scanLegacyShareToken(t, store, "legacy-null-token")
+	if token != "keep-me" {
+		t.Fatalf("token = %q, want keep-me", token)
+	}
+
+	var tokenSQL sql.NullString
+	if err := store.db.QueryRow(`SELECT token FROM shares WHERE hash = ?`, "legacy-null-token").Scan(&tokenSQL); err != nil {
+		t.Fatalf("select token: %v", err)
+	}
+	if !tokenSQL.Valid {
+		t.Fatal("expected legacy token column to remain non-null after save")
+	}
+}
+
+func TestSaveShareSetsEmptyLegacyTokenForNewShare(t *testing.T) {
+	store := createLegacySharesDB(t)
+	if err := normalizeLegacyShareTokens(store.db); err != nil {
+		t.Fatalf("normalizeLegacyShareTokens: %v", err)
+	}
+
+	newShare := &share.Share{
+		ShareSettings: share.ShareSettings{
+			FrontendShareInfo: share.FrontendShareInfo{ShareType: "normal"},
+		},
+		ShareColumns: share.ShareColumns{
+			Hash: "brand-new-share",
+			Path: "/new/file.txt",
+		},
+		SourcePath: "/data",
+		UserID:     1,
+		Version:    1,
+	}
+	if err := store.SaveShare(newShare); err != nil {
+		t.Fatalf("SaveShare: %v", err)
+	}
+
+	token := scanLegacyShareToken(t, store, "brand-new-share")
+	if token != "" {
+		t.Fatalf("token = %q, want empty string for new share", token)
+	}
+}


### PR DESCRIPTION
**Description**

According to the [contributing guide](https://github.com/gtsteffaniak/filebrowser/wiki/Contributing#contributing-as-an-unofficial-contributor), A PR should contain:

- [ ] A clear description of why it was opened.
- [ ] A short title that best describes the change.
- [ ] Must pass unit and integration tests, which can be run checked locally prior to opening a PR.
- [ ] Any additional details for functionality not covered by tests.

**Additional Details**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older SQLite databases containing legacy share-token fields.
  * Preserved existing share tokens when updating records.
  * Ensured newly created and migrated shares use empty values instead of unsupported NULL tokens.

* **Tests**
  * Added coverage for database migration, token preservation, and new-share behavior with legacy schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->