### PR TITLE
Sidebar link name fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file. For commit 
  **Security**:
  - Share download links no longer create links with token, instead they link to the UI prompting for password before download. If a direct download is required, the `/api/share/direct` api exists and documented by swagger. (#2888)
 
+ **Notes**:
+ - renaming sources updates sidebar links (#2878)
+ - disabling/deleting a user source removes that source from sidebar links (#2942)
+
  **Bugfixes**:
  - Fix disk-usage overstatement on virtiofs bind mounts (#2894) (#2894)
  - Support non-ASCII share passwords (#2933)

--- a/backend/cmd/user_sidebar_test.go
+++ b/backend/cmd/user_sidebar_test.go
@@ -99,10 +99,15 @@ func TestUpdateSidebarLinks_keepsDeletedSourceLinkAbsent(t *testing.T) {
 		},
 	}
 
-	if updateSidebarLinks(user, false) {
-		t.Fatal("expected saved sidebar links to remain unchanged")
+	if !updateSidebarLinks(user, false) {
+		t.Fatal("expected default source names to be blanked on normalize")
 	}
 	if len(user.SidebarLinks) != 2 {
 		t.Fatalf("got %d sidebar links, want 2: %v", len(user.SidebarLinks), user.SidebarLinks)
+	}
+	for _, link := range user.SidebarLinks {
+		if link.Name != "" {
+			t.Fatalf("expected blank default name, got %#v", link)
+		}
 	}
 }

--- a/backend/internal/state/users_sidebar_test.go
+++ b/backend/internal/state/users_sidebar_test.go
@@ -94,7 +94,7 @@ func TestUpdateUserScopesAddsMissingSidebarLink(t *testing.T) {
 	}
 }
 
-func TestUpdateUserScopesKeepsStaleSidebarLinks(t *testing.T) {
+func TestUpdateUserScopesPrunesSidebarLinks(t *testing.T) {
 	initSidebarLinkTestDB(t)
 
 	u := &users.User{
@@ -127,8 +127,8 @@ func TestUpdateUserScopesKeepsStaleSidebarLinks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count := countSourceSidebarLinks(loaded.SidebarLinks); count != 2 {
-		t.Fatalf("expected stale include link kept, got %d links: %#v", count, loaded.SidebarLinks)
+	if count := countSourceSidebarLinks(loaded.SidebarLinks); count != 1 {
+		t.Fatalf("expected revoked include link pruned, got %d links: %#v", count, loaded.SidebarLinks)
 	}
 }
 

--- a/backend/internal/usersidebar/links.go
+++ b/backend/internal/usersidebar/links.go
@@ -28,6 +28,9 @@ func FrontendLinks(links []users.SidebarLink, showToolsInSidebar bool) []users.S
 				}
 			}
 			link.SourceName = source.Name
+			if link.Name == "" {
+				link.Name = source.Name
+			}
 		} else if link.Category == "tool" && link.Target == "/tools" {
 			hasTools = true
 		}

--- a/backend/internal/usersidebar/links_test.go
+++ b/backend/internal/usersidebar/links_test.go
@@ -1,0 +1,27 @@
+package usersidebar
+
+import (
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+)
+
+func TestFrontendLinks_populatesEmptySourceName(t *testing.T) {
+	testSourceConfig(t)
+
+	in := []users.SidebarLink{
+		{Category: "source", SourceName: ".", Target: "/"},
+		{Name: "My Vault", Category: string(users.SidebarLinkSourceMinimal), Icon: "folder", SourceName: "../frontend/tests/playwright-files", Target: "/docs"},
+	}
+
+	out := FrontendLinks(in, false)
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2", len(out))
+	}
+	if out[0].Name != "docker" || out[0].SourceName != "docker" {
+		t.Fatalf("default source link = %#v", out[0])
+	}
+	if out[1].Name != "My Vault" || out[1].SourceName != "playwright + files" {
+		t.Fatalf("custom source link = %#v", out[1])
+	}
+}

--- a/backend/internal/usersidebar/normalize.go
+++ b/backend/internal/usersidebar/normalize.go
@@ -9,6 +9,8 @@ import (
 // NormalizeSidebarLinks canonicalizes persisted sidebar links for storage.
 // Source links are resolved via ResolveSourceKey on SourceName, with Name as fallback.
 // SourceName is set to the canonical backend path; custom Name, Icon, and Category are preserved.
+// Empty Name means "use live source display name"; names matching the current source display name
+// are blanked so renames propagate without overwriting custom labels.
 // Unresolvable source links are dropped. Source links are deduped by canonical path plus target
 // (first occurrence wins), so multiple folder shortcuts on one source are kept. Non-source links
 // pass through; duplicate Tools links are deduped.
@@ -36,8 +38,8 @@ func NormalizeSidebarLinks(links []users.SidebarLink) ([]users.SidebarLink, bool
 			normalized := link
 			normalized.Category = users.NormalizeSidebarLinkCategory(normalized.Category)
 			normalized.SourceName = source.Path
-			if strings.TrimSpace(normalized.Name) == "" {
-				normalized.Name = source.Name
+			if strings.TrimSpace(normalized.Name) == source.Name {
+				normalized.Name = ""
 			}
 			normalized.Target = normalizeSidebarTarget(normalized.Target)
 

--- a/backend/internal/usersidebar/normalize_test.go
+++ b/backend/internal/usersidebar/normalize_test.go
@@ -69,9 +69,9 @@ func TestNormalizeSidebarLinks_dedupesLinuxAndDockerPaths(t *testing.T) {
 		t.Fatalf("len(out) = %d, want 3", len(out))
 	}
 	want := []users.SidebarLink{
-		{Name: "playwright + files", Category: "source", SourceName: "../frontend/tests/playwright-files", Target: "/"},
-		{Name: "docker", Category: "source", SourceName: ".", Target: "/"},
-		{Name: "access", Category: "source", SourceName: "/tests/playwright-files", Target: "/"},
+		{Category: "source", SourceName: "../frontend/tests/playwright-files", Target: "/"},
+		{Category: "source", SourceName: ".", Target: "/"},
+		{Category: "source", SourceName: "/tests/playwright-files", Target: "/"},
 	}
 	if !reflect.DeepEqual(out, want) {
 		t.Fatalf("got %#v, want %#v", out, want)
@@ -95,8 +95,24 @@ func TestNormalizeSidebarLinks_nameFallbackRemapsStalePath(t *testing.T) {
 	if out[0].SourceName != "../frontend/tests/playwright-files" {
 		t.Fatalf("SourceName = %q", out[0].SourceName)
 	}
-	if out[0].Name != "playwright + files" {
-		t.Fatalf("Name = %q", out[0].Name)
+	if out[0].Name != "" {
+		t.Fatalf("Name = %q, want blanked default name", out[0].Name)
+	}
+}
+
+func TestNormalizeSidebarLinks_blanksDefaultSourceName(t *testing.T) {
+	testSourceConfig(t)
+
+	in := []users.SidebarLink{
+		{Name: "docker", Category: "source", SourceName: ".", Target: "/"},
+	}
+
+	out, changed := NormalizeSidebarLinks(in)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if out[0].Name != "" {
+		t.Fatalf("Name = %q, want blanked when matching source display name", out[0].Name)
 	}
 }
 
@@ -110,18 +126,20 @@ func TestNormalizeSidebarLinks_idempotentOnCanonicalLinks(t *testing.T) {
 	}
 
 	out, changed := NormalizeSidebarLinks(in)
-	if changed {
-		t.Fatal("expected changed=false for canonical links")
+	if !changed {
+		t.Fatal("expected changed=true when blanking default names")
 	}
-	if !reflect.DeepEqual(out, in) {
-		t.Fatalf("got %#v, want %#v", out, in)
+	for _, link := range out {
+		if link.Name != "" {
+			t.Fatalf("expected blank default name, got %#v", link)
+		}
 	}
 
 	out2, changed2 := NormalizeSidebarLinks(out)
 	if changed2 {
 		t.Fatal("expected second pass unchanged")
 	}
-	if !reflect.DeepEqual(out2, in) {
+	if !reflect.DeepEqual(out2, out) {
 		t.Fatalf("second pass got %#v", out2)
 	}
 }
@@ -141,8 +159,8 @@ func TestNormalizeSidebarLinks_dropsUnresolvableSourceLink(t *testing.T) {
 	if len(out) != 1 {
 		t.Fatalf("len(out) = %d, want 1", len(out))
 	}
-	if out[0].Name != "docker" {
-		t.Fatalf("remaining link = %#v", out[0])
+	if out[0].Name != "" {
+		t.Fatalf("remaining link should have blanked default name: %#v", out[0])
 	}
 }
 
@@ -175,11 +193,14 @@ func TestNormalizeSidebarLinks_preservesMultipleFolderShortcutsOnSameSource(t *t
 	}
 
 	out, changed := NormalizeSidebarLinks(in)
-	if changed {
-		t.Fatal("expected canonical folder shortcuts unchanged")
+	if !changed {
+		t.Fatal("expected changed=true when blanking default root source name")
 	}
 	if len(out) != 4 {
 		t.Fatalf("len(out) = %d, want 4", len(out))
+	}
+	if out[0].Name != "" {
+		t.Fatalf("root source link should have blank default name: %#v", out[0])
 	}
 	if out[1].Name != "Photos" || out[1].Icon != "photo" || out[1].Target != "/photos" {
 		t.Fatalf("photos link = %#v", out[1])
@@ -204,8 +225,8 @@ func TestNormalizeSidebarLinks_dedupesSameSourceAndTarget(t *testing.T) {
 	if len(out) != 1 {
 		t.Fatalf("len(out) = %d, want 1", len(out))
 	}
-	if out[0].Name != "docker" {
-		t.Fatalf("first link wins: %#v", out[0])
+	if out[0].Name != "" {
+		t.Fatalf("first link wins with blanked default name: %#v", out[0])
 	}
 }
 

--- a/backend/internal/usersidebar/persist.go
+++ b/backend/internal/usersidebar/persist.go
@@ -4,13 +4,18 @@ import (
 	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
 )
 
-// PrepareSidebarLinksForPersist normalizes sidebar links and adds missing scoped source entries.
-// Inaccessible sources are not pruned; callers rely on the UI to gray out stale links.
+// PrepareSidebarLinksForPersist normalizes sidebar links, prunes links for revoked scopes,
+// and adds missing scoped source entries. Sources absent from config are dropped by NormalizeSidebarLinks.
 func PrepareSidebarLinksForPersist(links []users.SidebarLink, scopes []users.BackendScope) ([]users.SidebarLink, bool) {
 	updated := false
 
 	if normalized, changed := NormalizeSidebarLinks(links); changed {
 		links = normalized
+		updated = true
+	}
+
+	if pruned, changed := PruneSidebarLinksForScopes(links, scopes); changed {
+		links = pruned
 		updated = true
 	}
 

--- a/backend/internal/usersidebar/persist_test.go
+++ b/backend/internal/usersidebar/persist_test.go
@@ -28,12 +28,12 @@ func TestPrepareSidebarLinksForPersist_addsScopedSourcesAndPreservesFolders(t *t
 	if out[1].Name != "Photos" || out[1].Icon != "photo" {
 		t.Fatalf("folder shortcut lost: %#v", out[1])
 	}
-	if out[2].Name != "playwright + files" {
-		t.Fatalf("added scope link = %#v", out[2])
+	if out[2].Name != "" {
+		t.Fatalf("added scope link should have empty default name, got %#v", out[2])
 	}
 }
 
-func TestPrepareSidebarLinksForPersist_keepsLinksWhenScopeRemoved(t *testing.T) {
+func TestPrepareSidebarLinksForPersist_prunesLinksWhenScopeRemoved(t *testing.T) {
 	testSourceConfig(t)
 
 	links := []users.SidebarLink{
@@ -46,10 +46,10 @@ func TestPrepareSidebarLinksForPersist_keepsLinksWhenScopeRemoved(t *testing.T) 
 	}
 
 	out, changed := PrepareSidebarLinksForPersist(links, scopes)
-	if changed {
-		t.Fatal("expected changed=false when only pruning is not performed")
+	if !changed {
+		t.Fatal("expected changed=true when revoked scope link is pruned")
 	}
-	if len(out) != 3 {
-		t.Fatalf("len(out) = %d, want 3 (stale scope link kept)", len(out))
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2 (revoked scope link removed)", len(out))
 	}
 }

--- a/backend/internal/usersidebar/prune.go
+++ b/backend/internal/usersidebar/prune.go
@@ -1,0 +1,37 @@
+package usersidebar
+
+import (
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+)
+
+// PruneSidebarLinksForScopes removes source-type links whose source is not in the user's scopes.
+// Non-source links (tool, custom, divider) are preserved.
+func PruneSidebarLinksForScopes(links []users.SidebarLink, scopes []users.BackendScope) ([]users.SidebarLink, bool) {
+	if !users.SourceConfigLoaded() || len(scopes) == 0 {
+		return links, false
+	}
+
+	allowed := make(map[string]struct{}, len(scopes))
+	for _, path := range uniqueScopedSourcePaths(scopes) {
+		allowed[path] = struct{}{}
+	}
+
+	out := make([]users.SidebarLink, 0, len(links))
+	changed := false
+	for _, link := range links {
+		if users.IsSourceSidebarCategory(link.Category) {
+			source, ok := resolveSourceLink(link)
+			if !ok {
+				changed = true
+				continue
+			}
+			if _, ok := allowed[source.Path]; !ok {
+				changed = true
+				continue
+			}
+		}
+		out = append(out, link)
+	}
+
+	return out, changed
+}

--- a/backend/internal/usersidebar/prune_test.go
+++ b/backend/internal/usersidebar/prune_test.go
@@ -1,0 +1,51 @@
+package usersidebar
+
+import (
+	"testing"
+
+	"github.com/gtsteffaniak/filebrowser/backend/internal/database/users"
+)
+
+func TestPruneSidebarLinksForScopes_removesRevokedSourceAndFolderShortcut(t *testing.T) {
+	testSourceConfig(t)
+
+	links := []users.SidebarLink{
+		{Name: "docker", Category: "source", SourceName: ".", Target: "/"},
+		{Name: "Photos", Category: string(users.SidebarLinkSourceMinimal), Icon: "photo", SourceName: ".", Target: "/photos"},
+		{Name: "playwright + files", Category: "source", SourceName: "../frontend/tests/playwright-files", Target: "/"},
+		{Name: "Docs", Category: string(users.SidebarLinkCustom), Target: "https://example.com", Icon: "link"},
+	}
+	scopes := []users.BackendScope{
+		{Path: "."},
+	}
+
+	out, changed := PruneSidebarLinksForScopes(links, scopes)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3 (playwright link removed, docker + folder + custom kept)", len(out))
+	}
+	if out[2].Category != string(users.SidebarLinkCustom) {
+		t.Fatalf("custom link lost: %#v", out[2])
+	}
+}
+
+func TestPruneSidebarLinksForScopes_noChangeWhenAllScoped(t *testing.T) {
+	testSourceConfig(t)
+
+	links := []users.SidebarLink{
+		{Name: "docker", Category: "source", SourceName: ".", Target: "/"},
+	}
+	scopes := []users.BackendScope{
+		{Path: "."},
+	}
+
+	out, changed := PruneSidebarLinksForScopes(links, scopes)
+	if changed {
+		t.Fatal("expected changed=false")
+	}
+	if len(out) != 1 {
+		t.Fatalf("len(out) = %d, want 1", len(out))
+	}
+}

--- a/backend/internal/usersidebar/scopes.go
+++ b/backend/internal/usersidebar/scopes.go
@@ -26,7 +26,6 @@ func EnsureSidebarLinksFromScopes(links []users.SidebarLink, scopes []users.Back
 			continue
 		}
 		out = append(out, users.SidebarLink{
-			Name:       source.Name,
 			Category:   string(users.SidebarLinkSource),
 			Target:     "/",
 			SourceName: source.Path,

--- a/backend/internal/usersidebar/scopes_test.go
+++ b/backend/internal/usersidebar/scopes_test.go
@@ -67,8 +67,8 @@ func TestEnsureSidebarLinksFromScopes_addsMissingScopedSources(t *testing.T) {
 	if len(out) != 3 {
 		t.Fatalf("len(out) = %d, want 3", len(out))
 	}
-	if out[2].Name != "playwright + files" {
-		t.Fatalf("added link = %#v", out[2])
+	if out[2].Name != "" {
+		t.Fatalf("added link should have empty default name, got %#v", out[2])
 	}
 	if out[1].Category != string(users.SidebarLinkCustom) {
 		t.Fatalf("custom link lost: %#v", out[1])

--- a/backend/pkg/settings/settings.go
+++ b/backend/pkg/settings/settings.go
@@ -140,12 +140,7 @@ func ApplyUserDefaultsFrom(u *users.User, d UserDefaults) {
 	u.BackendScopes = MergeDefaultEnabledBackendScopes(u.BackendScopes)
 	if len(u.SidebarLinks) == 0 && len(u.BackendScopes) > 0 {
 		scope := u.BackendScopes[0]
-		name := scope.Path
-		if src := Config.Server.SourceMap[scope.Path]; src != nil && src.Name != "" {
-			name = src.Name
-		}
 		u.SidebarLinks = append(u.SidebarLinks, users.SidebarLink{
-			Name:       name,
 			Category:   "source",
 			Target:     "/",
 			Icon:       "",


### PR DESCRIPTION
addresses 

 - renaming sources updates sidebar links (#2878)
 - disabling/deleting a user source removes that source from sidebar links (#2942)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sidebar source links now reflect renamed sources automatically while preserving custom labels.
  - Links to revoked or inaccessible sources are removed instead of remaining visible as stale or disabled entries.
  - Newly created source links use the current source name when displayed, avoiding outdated default labels.
- **Documentation**
  - Updated the v2.0.6 changelog with details about sidebar-link behavior when sources are renamed, disabled, or deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->