### PR TITLE
fix(upload): avoid false stalls during parallel transfers

### DIFF
--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -83,7 +83,8 @@ class UploadManager {
     this.pendingItems = null; // Store pending items during conflict resolution
     this.probedDirs = new Set(); // Track directories that were probed/created during conflict check
     this.progressTimeouts = new Map(); // Track progress timeouts per upload ID
-    this.PROGRESS_TIMEOUT_MS = 10000; // 10 seconds without progress = pause
+    this.lastUploadActivityTime = null;
+    this.PROGRESS_TIMEOUT_MS = 10000; // 10 seconds without upload activity = pause
   }
 
   setOnConflict(handler) {
@@ -389,6 +390,7 @@ class UploadManager {
         upload.xhr = promise.xhr;
         await promise;
 
+        this.recordUploadActivity(upload);
         // Clear timeout on successful completion
         this.clearProgressTimeout(upload.id);
         upload.status = "completed";
@@ -466,8 +468,8 @@ class UploadManager {
         // Only increment chunkOffset after successful chunk upload.
         // This ensures that if we pause/error mid-chunk, we'll retry that chunk on resume.
         upload.chunkOffset += chunk.size;
-        // Update last progress time after successful chunk upload
-        upload.lastProgressTime = Date.now();
+        // A completed chunk is activity even when no progress event was emitted.
+        this.recordUploadActivity(upload);
       } catch (err) {
         this.clearProgressTimeout(upload.id);
         await this.handleUploadError(upload, err);
@@ -559,27 +561,44 @@ class UploadManager {
     }
   }
 
-  startProgressTimeout(upload) {
+  recordUploadActivity(upload) {
+    upload.lastProgressTime = Date.now();
+    this.lastUploadActivityTime = upload.lastProgressTime;
+  }
+
+  startProgressTimeout(upload, delay = this.PROGRESS_TIMEOUT_MS) {
     // Clear any existing timeout
     this.clearProgressTimeout(upload.id);
 
-    // Set new timeout to pause if no progress for 10 seconds
+    // Requests can wait for bandwidth or a browser connection while siblings upload.
     const timeoutId = setTimeout(() => {
+      this.progressTimeouts.delete(upload.id);
       if (upload.status === "uploading") {
+        const lastActivity = Math.max(
+          upload.lastProgressTime ?? 0,
+          this.lastUploadActivityTime ?? 0
+        );
+        const idleTime = Date.now() - lastActivity;
+        if (idleTime < this.PROGRESS_TIMEOUT_MS) {
+          this.startProgressTimeout(upload, this.PROGRESS_TIMEOUT_MS - idleTime);
+          return;
+        }
         console.log(`Upload ${upload.id} stalled - no progress for ${this.PROGRESS_TIMEOUT_MS}ms, pausing`);
         upload.connectionIssue = true;
         void this.pause(upload.id);
         upload.errorDetails = "Connection stalled - upload paused. Click resume to retry.";
       }
-      this.progressTimeouts.delete(upload.id);
-    }, this.PROGRESS_TIMEOUT_MS);
+    }, delay);
 
     this.progressTimeouts.set(upload.id, timeoutId);
   }
 
   updateProgress(upload, progress) {
+    if (upload.status !== "uploading" || !this.findById(upload.id)) {
+      return;
+    }
     upload.progress = progress;
-    upload.lastProgressTime = Date.now();
+    this.recordUploadActivity(upload);
     upload.connectionIssue = false; // Clear connection issue on successful progress
     // Reset the timeout whenever we get progress
     this.startProgressTimeout(upload);

--- a/frontend/src/utils/upload.test.js
+++ b/frontend/src/utils/upload.test.js
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api", () => ({
+  resourcesApi: {
+    post: vi.fn(),
+    postPublic: vi.fn(),
+    signalUploadPause: vi.fn(),
+  },
+}));
+vi.mock("@/store", () => ({
+  state: {
+    user: { fileLoading: { maxConcurrentUpload: 10, uploadChunkSizeMb: 5 } },
+    shareInfo: { hash: "share" },
+  },
+  mutations: { setIsUploading: vi.fn(), setReload: vi.fn() },
+}));
+vi.mock("@/store/getters", () => ({ getters: { isShare: vi.fn(() => false) } }));
+vi.mock("@/utils/appNotifications", () => ({
+  notifyUploadComplete: vi.fn(),
+  notifyUploadError: vi.fn(),
+}));
+
+import { resourcesApi } from "@/api";
+import { getters } from "@/store/getters";
+import { uploadManager } from "./upload";
+
+function addUpload(status = "uploading", file = new Blob(["a"])) {
+  uploadManager.queue.push({
+    id: uploadManager.nextId++,
+    type: "file",
+    source: "test",
+    path: "/file",
+    file,
+    size: file.size,
+    status,
+    progress: 0,
+    chunkOffset: 0,
+    lastProgressTime: Date.now(),
+    connectionIssue: false,
+  });
+  return uploadManager.queue.at(-1);
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  vi.clearAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  getters.isShare.mockReturnValue(false);
+  uploadManager.queue.splice(0);
+  uploadManager.activeUploads = 0;
+  uploadManager.nextId = 0;
+  uploadManager.isOverallPaused = false;
+  uploadManager.hadActiveUploads = false;
+  uploadManager.lastUploadActivityTime = null;
+});
+
+afterEach(() => {
+  for (const id of uploadManager.progressTimeouts.keys()) {
+    uploadManager.clearProgressTimeout(id);
+  }
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("upload stall detection", () => {
+  it("allows an upload to wait while another progresses, then detects a batch stall", async () => {
+    const waiting = addUpload();
+    const progressing = addUpload();
+    uploadManager.startProgressTimeout(waiting);
+    uploadManager.startProgressTimeout(progressing);
+
+    for (let i = 0; i < 7; i++) {
+      await vi.advanceTimersByTimeAsync(5000);
+      // The API rounds progress, so successive events can have the same percent.
+      uploadManager.updateProgress(progressing, 1);
+      expect(waiting.status).toBe("uploading");
+    }
+    await vi.advanceTimersByTimeAsync(9999);
+    expect(waiting.status).toBe("uploading");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(waiting.status).toBe("paused");
+    expect(progressing.status).toBe("paused");
+    expect(waiting.connectionIssue).toBe(true);
+    expect(uploadManager.progressTimeouts.size).toBe(0);
+  });
+
+  it("still pauses a single upload after ten seconds without activity", async () => {
+    const upload = addUpload();
+    uploadManager.startProgressTimeout(upload);
+    await vi.advanceTimersByTimeAsync(9999);
+    expect(upload.status).toBe("uploading");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(upload.status).toBe("paused");
+  });
+
+  it.each([false, true])("keeps completion activity after a sibling finishes (share=%s)", async (share) => {
+    getters.isShare.mockReturnValue(share);
+    const request = deferred();
+    const post = share ? resourcesApi.postPublic : resourcesApi.post;
+    post.mockReturnValueOnce(request.promise);
+    const waiting = addUpload();
+    const finishing = addUpload("pending");
+    uploadManager.activeUploads = 1;
+    uploadManager.startProgressTimeout(waiting);
+    const done = uploadManager.startFileUpload(finishing);
+
+    await vi.advanceTimersByTimeAsync(9900);
+    request.resolve("");
+    await done;
+    expect(finishing.status).toBe("completed");
+    await vi.advanceTimersByTimeAsync(9999);
+    expect(waiting.status).toBe("uploading");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(waiting.status).toBe("paused");
+  });
+
+  it.each([false, true])("counts a successful chunk even without progress events (share=%s)", async (share) => {
+    getters.isShare.mockReturnValue(share);
+    const first = deferred();
+    const second = deferred();
+    const post = share ? resourcesApi.postPublic : resourcesApi.post;
+    post.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const waiting = addUpload();
+    const chunked = addUpload("pending", new Blob([new Uint8Array(5 * 1024 * 1024 + 1)]));
+    uploadManager.activeUploads = 1;
+    uploadManager.startProgressTimeout(waiting);
+    const done = uploadManager.startFileUpload(chunked);
+
+    await vi.advanceTimersByTimeAsync(9900);
+    first.resolve("");
+    await vi.advanceTimersByTimeAsync(100);
+    expect(chunked.chunkOffset).toBe(5 * 1024 * 1024);
+    expect(waiting.status).toBe("uploading");
+    second.resolve("");
+    await done;
+  });
+
+  it.each(["pause", "cancel"])("ignores late progress after %s", async (action) => {
+    const upload = addUpload();
+    uploadManager.startProgressTimeout(upload);
+    if (action === "pause") {
+      await uploadManager.pause(upload.id);
+    } else {
+      uploadManager.cancel(upload.id);
+    }
+    uploadManager.updateProgress(upload, 50);
+    expect(uploadManager.progressTimeouts.size).toBe(0);
+  });
+
+  it("gives a resumed upload a fresh inactivity window", async () => {
+    const upload = addUpload();
+    uploadManager.startProgressTimeout(upload);
+    await uploadManager.pause(upload.id);
+    await vi.advanceTimersByTimeAsync(20000);
+    const request = deferred();
+    resourcesApi.post.mockReturnValueOnce(request.promise);
+    uploadManager.resume(upload.id);
+    await vi.advanceTimersByTimeAsync(9999);
+    expect(upload.status).toBe("uploading");
+    request.resolve("");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(upload.status).toBe("completed");
+    expect(uploadManager.progressTimeouts.size).toBe(0);
+  });
+});


### PR DESCRIPTION
**Description**

Fixes #2948.

The per-file 10-second timer could pause an upload waiting for bandwidth or a browser connection while other files were still transferring. Track activity across uploads and recheck it when a timer expires, rescheduling only for the remaining inactivity period. Progress events, successful chunk responses and file completion all count as activity, including events whose rounded percentage has not changed.

Single uploads and batches with no activity still pause after 10 seconds. An individual stalled request now waits while sibling uploads continue making progress; explicit request failures retain their existing handling. Ignore late progress callbacks for paused or removed uploads so they cannot recreate timers.

- [x] A clear description of why it was opened.
- [x] A short title that best describes the change.
- [x] Unit and integration tests run locally; results below.
- [x] Additional behavior and limitations described above.

**Validation**

- Added 9 deterministic regression cases covering parallel progress, complete batch stalls, single uploads, chunk/file completion without progress events, public shares, late callbacks, and resume. Seven failed before the fix; all nine pass afterward.
- Frontend: 167 tests pass; lint, typecheck, production build, translation check and icon check pass. Lint reports existing warnings in unrelated files; changed files are clean.
- Backend: `go test -race -timeout=30s ./...` passes on the final run; `go tool golangci-lint run --path-prefix=backend` reports 0 issues. The initial run hit an outlier in the unchanged `TestJSONAuth_NoTimingAttack`; it passed both an isolated rerun and the final full-suite command.
- Docker/Firefox general Playwright suite: 27 tests pass using `_docker/Dockerfile.playwright-general`. Other Playwright matrices were not run locally.

**Additional Details**

Implemented with OpenAI Codex assistance and independently reviewed with GPT-6 Astra (medium reasoning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved upload stall detection to account for activity across simultaneous uploads.
  - Uploads now pause only after the configured period of inactivity, with active uploads receiving refreshed timeout windows.
  - Progress reporting is handled more reliably when uploads complete, pause, resume, or are canceled.
  - Improved timeout handling for both single-file and chunked uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->